### PR TITLE
docker: Remove qemu-system-x86 from libvirt Dockerfile

### DIFF
--- a/contrib/docker/libvirt/Dockerfile
+++ b/contrib/docker/libvirt/Dockerfile
@@ -5,7 +5,6 @@ RUN yum -y install \
 		openssl \
 		libvirt-daemon \
 		libguestfs \
-		qemu-system-x86 \
 		libvirt-daemon-driver-nwfilter \
 		libvirt-daemon-config-nwfilter \
 		ceph-common \


### PR DESCRIPTION
This package doesn't exist in Centos 7 repos and isn't even
necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/4)
<!-- Reviewable:end -->
