### PR TITLE
autotools: Introduce autotools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,22 @@
+# Prerequisites
+*.d
+
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a
 *.so
+*.ko
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
 
 # Folders
 _obj
@@ -20,11 +35,43 @@ _cgo_export.*
 _testmain.go
 
 *.exe
-*.test
 *.prof
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# virtlet bindir
-out/
+# virtlet binaries
+/virtlet
+/virtlet-fake-image-pull
+
+# Autotools
+Makefile
+Makefile.in
+/autom4te.cache
+/autoscan.log
+/autoscan-*.log
+/aclocal.m4
+/compile
+/config.h.in
+/config.log
+/config.status
+/configure
+/configure.scan
+/depcomp
+/install-sh
+/missing
+/stamp-h1
+
+# Temporary files
+*~
+*.swp
+*.sw?
+
+# Tests
+*.log
+*.test
+!go.test
+*.trs
+.deps
+.dirstamp
+test-driver

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ MAINTAINER Michal Rostecki <mrostecki@mirantis.com>
 
 RUN apk --no-cache add \
 	alpine-sdk \
+	autoconf \
+	automake \
+	glib-dev \
 	libvirt-dev
 
 RUN mkdir -p /go/src/github.com/Mirantis/virtlet
@@ -10,7 +13,9 @@ COPY . /go/src/github.com/Mirantis/virtlet
 
 WORKDIR /go/src/github.com/Mirantis/virtlet
 
-RUN make \
+RUN ./autogen.sh \
+	&& ./configure \
+	&& make \
 	&& make install \
 	&& make clean
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,36 @@
+# Copyright 2016 Mirantis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+export GO15VENDOREXPERIMENT=1
+export CGO_CFLAGS=$(CFLAGS)
+export CGO_LDFLAGS=$(LDFLAGS)
+
+SUBDIRS = pkg/download pkg/etcdtools pkg/libvirttools pkg/manager pkg/sandbox
+
+.PHONY: all vendor
+
+all:
+	go build -o $(builddir)/virtlet ./cmd/virtlet
+	go build -o $(builddir)/virtlet-fake-image-pull ./cmd/fake-image-pull
+
+vendor:
+	glide update --strip-vcs --strip-vendor --update-vendored --delete
+	glide-vc --only-code --no-tests --keep="**/*.json.in"
+
+clean-local:
+	rm -f $(builddir)/virtlet $(builddir)/virtlet-fake-image-pull
+
+install-exec-local:
+	install $(builddir)/virtlet $(bindir)/virtlet
+	install $(builddir)/virtlet-fake-image-pull $(bindir)/virtlet-fake-image-pull

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# aclocal
+# autoconf
+autoreconf --install --warnings=all --force

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,14 @@
+AC_INIT([virtlet], [0.1])
+AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
+
+AC_PROG_CC
+
+PKG_CHECK_MODULES([glib], [glib-2.0])
+PKG_CHECK_MODULES([libvirt], [libvirt])
+
+CFLAGS="$CFLAGS $glib_CFLAGS $libvirt_CFLAGS"
+LDFLAGS="$LDFLAGS $glib_LIBS $libvirt_LIBS"
+
+AC_CONFIG_FILES([Makefile pkg/download/Makefile pkg/etcdtools/Makefile pkg/libvirttools/Makefile pkg/manager/Makefile pkg/sandbox/Makefile])
+
+AC_OUTPUT

--- a/pkg/download/Makefile.am
+++ b/pkg/download/Makefile.am
@@ -1,0 +1,16 @@
+# Copyright 2016 Mirantis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+check_SCRIPTS = go.test
+TESTS = $(check_SCRIPTS)

--- a/pkg/download/go.test
+++ b/pkg/download/go.test
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+go test .

--- a/pkg/etcdtools/Makefile.am
+++ b/pkg/etcdtools/Makefile.am
@@ -1,0 +1,16 @@
+# Copyright 2016 Mirantis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+check_SCRIPTS = go.test
+TESTS = $(check_SCRIPTS)

--- a/pkg/etcdtools/go.test
+++ b/pkg/etcdtools/go.test
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+go test .

--- a/pkg/libvirttools/Makefile.am
+++ b/pkg/libvirttools/Makefile.am
@@ -12,25 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export GO15VENDOREXPERIMENT=1
+check_PROGRAMS = image.test
+check_SCRIPTS = go.test
+TESTS = $(check_PROGRAMS) $(check_SCRIPTS)
 
-BUILD_DIR ?= ./out
-PREFIX ?= /usr/local
-bindir = $(PREFIX)/bin
-
-.PHONY: all install vendor clean
-
-all:
-	go build -o $(BUILD_DIR)/virtlet ./cmd/virtlet
-	go build -o $(BUILD_DIR)/virtlet-fake-image-pull ./cmd/fake-image-pull
-
-install:
-	install $(BUILD_DIR)/virtlet $(bindir)/virtlet
-	install $(BUILD_DIR)/virtlet-fake-image-pull $(bindir)/virtlet-fake-image-pull
-
-vendor:
-	glide update --strip-vcs --strip-vendor --update-vendored --delete
-	glide-vc --only-code --no-tests --keep="**/*.json.in"
-
-clean:
-	rm -rf $(BUILD_DIR)
+image_test_CFLAGS = $(CFLAGS) -I.
+image_test_SOURCES = tests/test_image.c image.h image.c

--- a/pkg/libvirttools/connection.go
+++ b/pkg/libvirttools/connection.go
@@ -17,7 +17,6 @@ limitations under the License.
 package libvirttools
 
 /*
-#cgo LDFLAGS: -lvirt
 #include <libvirt/libvirt.h>
 #include <libvirt/virterror.h>
 #include <stdlib.h>

--- a/pkg/libvirttools/connection_test.go
+++ b/pkg/libvirttools/connection_test.go
@@ -1,0 +1,8 @@
+package libvirttools_test
+
+import (
+	"testing"
+)
+
+func TestFoo(t *testing.T) {
+}

--- a/pkg/libvirttools/error.go
+++ b/pkg/libvirttools/error.go
@@ -17,7 +17,6 @@ limitations under the License.
 package libvirttools
 
 /*
-#cgo LDFLAGS: -lvirt
 #include <libvirt/libvirt.h>
 #include <libvirt/virterror.h>
 #include <stdlib.h>

--- a/pkg/libvirttools/go.test
+++ b/pkg/libvirttools/go.test
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+go test .

--- a/pkg/libvirttools/image.go
+++ b/pkg/libvirttools/image.go
@@ -17,7 +17,6 @@ limitations under the License.
 package libvirttools
 
 /*
-#cgo LDFLAGS: -lvirt
 #include <fcntl.h>
 #include <libvirt/libvirt.h>
 #include <libvirt/virterror.h>

--- a/pkg/libvirttools/tests/test_image.c
+++ b/pkg/libvirttools/tests/test_image.c
@@ -1,0 +1,53 @@
+/*
+Copyright 2016 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <fcntl.h>
+#include <glib.h>
+#include <libvirt/libvirt.h>
+#include "image.h"
+
+void testVirtletVolUploadSourceNullOpaque()
+{
+	virConnectPtr conn;
+	virStreamPtr stream;
+	int result;
+
+	if (!(conn = virConnectOpen("test:///default")) ||
+	    !(stream = virStreamNew(conn, 0))) {
+		g_test_fail();
+		goto cleanup;
+	}
+
+	result = virtletVolUploadSource(stream, "", 0, NULL);
+	g_assert_cmpint(result, ==, -1);
+
+ cleanup:
+	if (stream) {
+		virStreamFree(stream);
+	}
+	if (conn) {
+		virConnectClose(conn);
+	}
+}
+
+int
+main(int argc, char **argv)
+{
+	g_test_init(&argc, &argv, NULL);
+	g_test_add_func("/virtletVolUploadSourceNullOpaque", &testVirtletVolUploadSourceNullOpaque);
+
+	return g_test_run();
+}

--- a/pkg/manager/Makefile.am
+++ b/pkg/manager/Makefile.am
@@ -1,0 +1,16 @@
+# Copyright 2016 Mirantis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+check_SCRIPTS = go.test
+TESTS = $(check_SCRIPTS)

--- a/pkg/manager/go.test
+++ b/pkg/manager/go.test
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+go test .

--- a/pkg/sandbox/Makefile.am
+++ b/pkg/sandbox/Makefile.am
@@ -1,0 +1,16 @@
+# Copyright 2016 Mirantis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+check_SCRIPTS = go.test
+TESTS = $(check_SCRIPTS)

--- a/pkg/sandbox/go.test
+++ b/pkg/sandbox/go.test
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+go test .


### PR DESCRIPTION
Introduce autotools in order to:
* handle both Go and C unit tests
* check C library headers

This commit also contains small example of C unit test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/8)
<!-- Reviewable:end -->
