### PR TITLE
build system: Remove glide deprecated options.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,7 +29,7 @@ all:
 	go build -o $(builddir)/virtlet-fake-image-pull ./cmd/fake-image-pull
 
 vendor:
-	glide update --strip-vcs --strip-vendor --update-vendored --delete
+	glide update --strip-vendor
 	glide-vc --only-code --no-tests --keep="**/*.json.in"
 
 clean-local:


### PR DESCRIPTION
This also removes warnings:
```
[WARN]  The --delete flag is deprecated. This now works by default.
[WARN]  The --update-vendored flag is deprecated. This now works by default.
[WARN]  The --strip-vcs flag is deprecated. This now works by default.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/55)
<!-- Reviewable:end -->
