### PR TITLE
sandbox: Fix missing sandbox bucket.

### DIFF
--- a/pkg/bolttools/sandbox.go
+++ b/pkg/bolttools/sandbox.go
@@ -443,7 +443,8 @@ func (b *BoltClient) ListPodSandbox(filter *kubeapi.PodSandboxFilter) ([]*kubeap
 	err := b.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte("sandbox"))
 		if bucket == nil {
-			return fmt.Errorf("Bucket 'sandbox' doesn't exist")
+			// there is no sanbox bucket, so there are no pods
+			return nil
 		}
 
 		bucket.ForEach(func(k, v []byte) error {


### PR DESCRIPTION
Missing `sandbox` bucket in this situation is not an error - simply there was not any pod stored in bolt up to this moment.

Closes #53

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/57)
<!-- Reviewable:end -->
