### PR TITLE
libvirt: Fix starting cleanup.

### DIFF
--- a/contrib/docker/libvirt/start.sh
+++ b/contrib/docker/libvirt/start.sh
@@ -14,7 +14,7 @@ chown root:root /etc/libvirt/qemu.conf
 chmod 644 /etc/libvirt/libvirtd.conf
 chmod 644 /etc/libvirt/qemu.conf
 
-if [[ "${!LIBVIRT_CLEANUP[@]}" ]]; then
+if [[ -z "$LIBVIRT_CLEANUP" ]]; then
 	/usr/sbin/libvirtd -d
 	/cleanup.py
 	kill -9 $(cat /var/run/libvirtd.pid)


### PR DESCRIPTION
`cleanup.py` should be started only when $LIBVIRT_CLEANUP env variable is set to any value.

Closes #51

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/59)
<!-- Reviewable:end -->
