### PR TITLE
contrib: Fix cleanup of libvirt data

### DIFF
--- a/contrib/docker-compose/docker-compose.yml
+++ b/contrib/docker-compose/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     # network_mode: host
     restart: always
     environment:
-      - LIBVIRT_CLEANUP=""
+      - LIBVIRT_CLEANUP
     volumes:
       - /lib/modules:/lib/modules:ro
       - /run:/run


### PR DESCRIPTION
Following instructions from:
https://docs.docker.com/compose/environment-variables/#/passing-environment-variables-through-to-containers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/83)
<!-- Reviewable:end -->
