### PR TITLE
Use __cleanup__ attribute instead of manual cleanups

### DIFF
--- a/pkg/libvirttools/Makefile.am
+++ b/pkg/libvirttools/Makefile.am
@@ -17,7 +17,7 @@ check_SCRIPTS = go.test
 TESTS = $(check_PROGRAMS) $(check_SCRIPTS)
 
 image_test_CFLAGS = $(CFLAGS) -I.
-image_test_SOURCES = tests/test_image.c image.h image.c
+image_test_SOURCES = tests/test_image.c alloc-util.h image.h image.c
 
 virtualization_test_CFLAGS = $(CFLAGS) -I.
-virtualization_test_SOURCES = tests/test_virtualization.c virtualization.h virtualization.c
+virtualization_test_SOURCES = tests/test_virtualization.c alloc-util.h virtualization.h virtualization.c

--- a/pkg/libvirttools/alloc-util.h
+++ b/pkg/libvirttools/alloc-util.h
@@ -1,0 +1,52 @@
+/*
+Copyright 2016 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef PKG_LIBVIRTTOOLS_ALLOC_UTIL_H_
+#define PKG_LIBVIRTTOOLS_ALLOC_UTIL_H_
+
+#include <libvirt/libvirt.h>
+#include <unistd.h>
+
+#define _cleanup_(x) __attribute__((cleanup(x)))
+
+#define DEFINE_CLEANUP_FUNC(name, type, func) \
+	static inline void name(type *p) {    \
+		if (*p) {                     \
+			func(*p);             \
+		}                             \
+	}
+
+DEFINE_CLEANUP_FUNC(cleanupFd, int, close);
+DEFINE_CLEANUP_FUNC(cleanupVirConnect, virConnectPtr, virConnectClose);
+DEFINE_CLEANUP_FUNC(cleanupVirDomain, virDomainPtr, virDomainFree);
+DEFINE_CLEANUP_FUNC(cleanupVirStorageVol, virStorageVolPtr, virStorageVolFree);
+DEFINE_CLEANUP_FUNC(cleanupVirStream, virStreamPtr, virStreamFree);
+
+#define DEFINE_VARIABLE_WITH_AUTOCLEANUP(type, func, name, value) \
+	type name _cleanup_(func) = value
+#define DEFINE_FD(name) \
+	DEFINE_VARIABLE_WITH_AUTOCLEANUP(int, cleanupFd, name, -1)
+#define DEFINE_VIR_CONNECT(name) \
+	DEFINE_VARIABLE_WITH_AUTOCLEANUP(virConnectPtr, cleanupVirConnect, name, NULL)
+#define DEFINE_VIR_DOMAIN(name) \
+	DEFINE_VARIABLE_WITH_AUTOCLEANUP(virDomainPtr, cleanupVirDomain, name, NULL)
+#define DEFINE_VIR_STORAGE_VOL(name) \
+	DEFINE_VARIABLE_WITH_AUTOCLEANUP\
+	(virStorageVolPtr, cleanupVirStorageVol, name, NULL)
+#define DEFINE_VIR_STREAM(name) \
+	DEFINE_VARIABLE_WITH_AUTOCLEANUP(virStreamPtr, cleanupVirStream, name, NULL)
+
+#endif  // PKG_LIBVIRTTOOLS_ALLOC_UTIL_H_

--- a/pkg/libvirttools/tests/test_image.c
+++ b/pkg/libvirttools/tests/test_image.c
@@ -17,29 +17,21 @@ limitations under the License.
 #include <fcntl.h>
 #include <glib.h>
 #include <libvirt/libvirt.h>
+#include "alloc-util.h"
 #include "image.h"
 
 void testVirtletVolUploadSourceNullOpaque() {
-	virConnectPtr conn;
-	virStreamPtr stream;
 	int result;
+	DEFINE_VIR_CONNECT(conn);
+	DEFINE_VIR_STREAM(stream);
 
 	if (!(conn = virConnectOpen("test:///default")) ||
 	    !(stream = virStreamNew(conn, 0))) {
 		g_test_fail();
-		goto cleanup;
 	}
 
 	result = virtletVolUploadSource(stream, "", 0, NULL);
 	g_assert_cmpint(result, ==, -1);
-
- cleanup:
-	if (stream) {
-		virStreamFree(stream);
-	}
-	if (conn) {
-		virConnectClose(conn);
-	}
 }
 
 int main(int argc, char **argv) {

--- a/pkg/libvirttools/tests/test_virtualization.c
+++ b/pkg/libvirttools/tests/test_virtualization.c
@@ -16,6 +16,7 @@ limitations under the License.
 
 #include <glib.h>
 #include <libvirt/libvirt.h>
+#include "alloc-util.h"
 #include "virtualization.h"
 
 void testDefineDomain(gconstpointer gConn) {
@@ -74,13 +75,12 @@ void testDestroyAndUndefineDomain(gconstpointer gConn) {
 }
 
 int main(int argc, char **argv) {
-	virConnectPtr conn;
 	gconstpointer gConn;
 	int result;
+	DEFINE_VIR_CONNECT(conn);
 
 	if (!(conn = virConnectOpen("test:///default"))) {
-		result = -1;
-		goto cleanup;
+		return -1;
 	}
 
 	gConn = (gconstpointer) conn;
@@ -92,12 +92,5 @@ int main(int argc, char **argv) {
 	g_test_add_data_func("/destroyAndUndefineDomain", gConn,
 			     &testDestroyAndUndefineDomain);
 
-	result = g_test_run();
-
- cleanup:
-	if (conn) {
-		virConnectClose(conn);
-	}
-
-	return result;
+	return g_test_run();
 }

--- a/pkg/libvirttools/virtualization.c
+++ b/pkg/libvirttools/virtualization.c
@@ -17,66 +17,49 @@ limitations under the License.
 #include <libvirt/libvirt.h>
 #include <libvirt/virterror.h>
 #include <stdlib.h>
+#include "alloc-util.h"
 #include "virtualization.h"
 
 int defineDomain(virConnectPtr conn, char *domXML) {
-	int result = 0;
-	virDomainPtr domain = NULL;
+	DEFINE_VIR_DOMAIN(domain);
 
 	if (!(domain = virDomainDefineXML(conn, (const char*) domXML))) {
-		result = -1;
+		return -1;
 	}
 
-	if (domain) {
-		virDomainFree(domain);
-	}
-
-	return result;
+	return 0;
 }
 
 int createDomain(virConnectPtr conn, char *uuid) {
-	int result = 0;
-	virDomainPtr domain = NULL;
+	DEFINE_VIR_DOMAIN(domain);
 
 	if (!(domain = virDomainLookupByUUIDString(conn, (const char*) uuid)) ||
 	    virDomainCreate(domain) < 0) {
-		result = -1;
+		return -1;
 	}
 
-	if (domain) {
-		virDomainFree(domain);
-	}
-
-	return result;
+	return 0;
 }
 
 int stopDomain(virConnectPtr conn, char *uuid) {
-	int result = 0;
-	virDomainPtr domain = NULL;
+	DEFINE_VIR_DOMAIN(domain);
 
 	if (!(domain = virDomainLookupByUUIDString(conn, (const char*) uuid)) ||
 	    virDomainShutdown(domain) < 0) {
-		result = -1;
+		return -1;
 	}
 
-	if (domain) {
-		virDomainFree(domain);
-	}
-
-	return result;
+	return 0;
 }
 
 int destroyAndUndefineDomain(virConnectPtr conn, char *uuid) {
-	int result = 0;
-	virDomainPtr domain = NULL;
+	DEFINE_VIR_DOMAIN(domain);
 
 	if (!(domain = virDomainLookupByUUIDString(conn, (const char*) uuid)) ||
 	    virDomainDestroy(domain) < 0 ||
 	    virDomainUndefine(domain) < 0) {
-		result = -1;
+		return -1;
 	}
 
-	if (domain) {
-		virDomainFree(domain);
-	}
+	return 0;
 }


### PR DESCRIPTION
GCC __attribute__ variables allow to specify custom attributes of variables. One of them  __cleanup__ which allows you to specify a function which will be automatically called when a variable goes out of scope.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/86)
<!-- Reviewable:end -->
