### PR TITLE
cmd: Fix logging

### DIFF
--- a/cmd/virtlet/virtlet.go
+++ b/cmd/virtlet/virtlet.go
@@ -42,11 +42,11 @@ func main() {
 
 	server, err := manager.NewVirtletManager(*libvirtUri, *pool, *storageBackend, *etcdEndpoint)
 	if err != nil {
-		glog.Errorf("Initializing server failed: %#v", err)
+		glog.Errorf("Initializing server failed: %v", err)
 		os.Exit(1)
 	}
 	glog.Infof("Starting server on socket %s", *listen)
 	if err = server.Serve(*listen); err != nil {
-		glog.Errorf("Serving failed: %#v", err)
+		glog.Errorf("Serving failed: %v", err)
 	}
 }


### PR DESCRIPTION
`%#v` gives in output:
```
   Initializing server failed: &errors.errorString{s:"unable to connect to server at 'libvirt:16509': Connection refused"}
```
`%v` gives:
```
   Initializing server failed: unable to connect to server at 'libvirt:16509': Connection refused
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/94)
<!-- Reviewable:end -->
