### PR TITLE
libvirt: Fix cleanup

### DIFF
--- a/contrib/docker/libvirt/start.sh
+++ b/contrib/docker/libvirt/start.sh
@@ -14,7 +14,7 @@ chown root:root /etc/libvirt/qemu.conf
 chmod 644 /etc/libvirt/libvirtd.conf
 chmod 644 /etc/libvirt/qemu.conf
 
-if [[ -z "$LIBVIRT_CLEANUP" ]]; then
+if [[ -n "$LIBVIRT_CLEANUP" ]]; then
 	/usr/sbin/libvirtd -d
 	/cleanup.py
 	kill -9 $(cat /var/run/libvirtd.pid)


### PR DESCRIPTION
Finally fix cleanup procedure. Start docker compose without any passed
env - cleanup will be skipped. Add LIBVIRT_CLEANUP=something before
docker-compose up - cleanup will run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/102)
<!-- Reviewable:end -->
