### PR TITLE
Add setting CONTAINER_RUNTIME env var to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Assuming standard configuration for Kubernetes sources location, use following c
 ```sh
 cd $GOPATH/k8s.io/kubernetes
 export KUBERNETES_PROVIDER=local
+export CONTAINER_RUNTIME=remote
 export CONTAINER_RUNTIME_ENDPOINT=/run/virtlet.sock
 ./hack/local-up-cluster.sh
 ```


### PR DESCRIPTION
As of k8s commit `7f74d48586ca09c9f690698d7b19fe0c3d8a9f44` (Nov 7 2016), `CONTAINER_RUNTIME_ENDPOINT` (`--container-runtime-endopoint` kubelet option) gets ignored unless `CONTAINER_RUNTIME=remote` (`--container-runtime=remote`) is set, too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/105)
<!-- Reviewable:end -->
