### PR TITLE
Fix error messages

### DIFF
--- a/cmd/fake-create-container/fake-create-container.go
+++ b/cmd/fake-create-container/fake-create-container.go
@@ -42,7 +42,7 @@ func main() {
 
 	conn, err := grpc.Dial(*virtletSocket, grpc.WithInsecure(), grpc.WithDialer(utils.Dial))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Cannot connect: %#v", err)
+		fmt.Fprintf(os.Stderr, "Cannot connect: %v", err)
 		os.Exit(1)
 	}
 	defer conn.Close()
@@ -83,7 +83,7 @@ func main() {
 
 	sandboxOut, err := c.RunPodSandbox(context.Background(), sandboxIn)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Cannot create pod sandbox: %#v", err)
+		fmt.Fprintf(os.Stderr, "Cannot create pod sandbox: %v", err)
 		os.Exit(1)
 	}
 
@@ -102,7 +102,7 @@ func main() {
 
 	containerOut, err := c.CreateContainer(context.Background(), containerIn)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Cannot create container: %#v", err)
+		fmt.Fprintf(os.Stderr, "Cannot create container: %v", err)
 		os.Exit(1)
 	}
 

--- a/cmd/fake-image-pull/fake-image-pull.go
+++ b/cmd/fake-image-pull/fake-image-pull.go
@@ -42,7 +42,7 @@ func main() {
 
 	conn, err := grpc.Dial(*virtletSocket, grpc.WithInsecure(), grpc.WithDialer(utils.Dial))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Cannot connect: %#v", err)
+		fmt.Fprintf(os.Stderr, "Cannot connect: %v", err)
 		os.Exit(1)
 	}
 	defer conn.Close()
@@ -57,7 +57,7 @@ func main() {
 
 	out, err := c.PullImage(context.Background(), in)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Cannot pull image: %#v", err)
+		fmt.Fprintf(os.Stderr, "Cannot pull image: %v", err)
 		os.Exit(1)
 	}
 

--- a/pkg/bolttools/image.go
+++ b/pkg/bolttools/image.go
@@ -50,7 +50,7 @@ func (b *BoltClient) SetImageFilepath(name, filepath string) error {
 	err := b.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte("images"))
 		if bucket == nil {
-			return fmt.Errorf("Bucket 'images' doesn't exist")
+			return fmt.Errorf("bucket 'images' doesn't exist")
 		}
 
 		if err := bucket.Put([]byte(key), []byte(filepath)); err != nil {
@@ -71,7 +71,7 @@ func (b *BoltClient) GetImageFilepath(name string) (string, error) {
 	err := b.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte("images"))
 		if bucket == nil {
-			return fmt.Errorf("Bucket 'images' doesn't exist")
+			return fmt.Errorf("bucket 'images' doesn't exist")
 		}
 
 		fp := bucket.Get([]byte(key))

--- a/pkg/bolttools/image_test.go
+++ b/pkg/bolttools/image_test.go
@@ -59,7 +59,7 @@ func TestSetImageFilepath(t *testing.T) {
 		if err := b.db.View(func(tx *bolt.Tx) error {
 			bucket := tx.Bucket([]byte("images"))
 			if bucket == nil {
-				return fmt.Errorf("Bucket 'images' doesn't exist")
+				return fmt.Errorf("bucket 'images' doesn't exist")
 			}
 
 			filepath, err := getString(bucket, tc.hash)

--- a/pkg/bolttools/sandbox.go
+++ b/pkg/bolttools/sandbox.go
@@ -53,23 +53,23 @@ func (b *BoltClient) SetPodSandbox(config *kubeapi.PodSandboxConfig) error {
 
 	metadata := config.GetMetadata()
 	if metadata == nil {
-		return fmt.Errorf("Sandbox config is missing Metadata attribute: %#v", config)
+		return fmt.Errorf("sandbox config is missing Metadata attribute: %#v", config)
 	}
 
 	linuxSandbox := config.GetLinux()
 	if linuxSandbox == nil {
-		return fmt.Errorf("Sandbox config is missing Linux attribute: %#v", config)
+		return fmt.Errorf("sandbox config is missing Linux attribute: %#v", config)
 	}
 
 	namespaceOptions := linuxSandbox.GetNamespaceOptions()
 	if namespaceOptions == nil {
-		return fmt.Errorf("Linux sandbox config is missint Namespaces attribute: %#v", linuxSandbox)
+		return fmt.Errorf("Linux sandbox config is missing Namespaces attribute: %#v", linuxSandbox)
 	}
 
 	err = b.db.Batch(func(tx *bolt.Tx) error {
 		parentBucket := tx.Bucket([]byte("sandbox"))
 		if parentBucket == nil {
-			return fmt.Errorf("Bucket 'sandbox' doesn't exist")
+			return fmt.Errorf("bucket 'sandbox' doesn't exist")
 		}
 
 		sandboxBucket, err := parentBucket.CreateBucketIfNotExists([]byte(podId))
@@ -154,7 +154,7 @@ func (b *BoltClient) RemovePodSandbox(podId string) error {
 	if err := b.db.Batch(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte("sandbox"))
 		if bucket == nil {
-			return fmt.Errorf("Bucket 'sandbox' doesn't exist")
+			return fmt.Errorf("bucket 'sandbox' doesn't exist")
 		}
 
 		if err := bucket.DeleteBucket([]byte(podId)); err != nil {
@@ -175,12 +175,12 @@ func (b *BoltClient) GetPodSandboxStatus(podId string) (*kubeapi.PodSandboxStatu
 	err := b.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte("sandbox"))
 		if bucket == nil {
-			return fmt.Errorf("Bucket 'sandbox' doesn't exist")
+			return fmt.Errorf("bucket 'sandbox' doesn't exist")
 		}
 
 		sandboxBucket := bucket.Bucket([]byte(podId))
 		if sandboxBucket == nil {
-			return fmt.Errorf("Bucket '%s' doesn't exist", podId)
+			return fmt.Errorf("bucket '%s' doesn't exist", podId)
 		}
 
 		byteCreatedAt, err := getString(sandboxBucket, "createdAt")
@@ -215,7 +215,7 @@ func (b *BoltClient) GetPodSandboxStatus(podId string) (*kubeapi.PodSandboxStatu
 
 		metadataBucket := sandboxBucket.Bucket([]byte("metadata"))
 		if metadataBucket == nil {
-			return fmt.Errorf("Bucket 'metadata' doesn't exist")
+			return fmt.Errorf("bucket 'metadata' doesn't exist")
 		}
 
 		metadataName, err := getString(metadataBucket, "name")
@@ -246,12 +246,12 @@ func (b *BoltClient) GetPodSandboxStatus(podId string) (*kubeapi.PodSandboxStatu
 
 		linuxSandboxBucket := sandboxBucket.Bucket([]byte("linuxSandbox"))
 		if linuxSandboxBucket == nil {
-			return fmt.Errorf("Bucket 'linuxSandbox' doesn't exist")
+			return fmt.Errorf("bucket 'linuxSandbox' doesn't exist")
 		}
 
 		namespaceOptionsBucket := linuxSandboxBucket.Bucket([]byte("namespaceOptions"))
 		if namespaceOptionsBucket == nil {
-			return fmt.Errorf("Bucket 'namespaceOptions' doesn't exist")
+			return fmt.Errorf("bucket 'namespaceOptions' doesn't exist")
 		}
 
 		strHostNetwork, err := getString(namespaceOptionsBucket, "hostNetwork")
@@ -359,12 +359,12 @@ func (b *BoltClient) getPodSandbox(sandboxId []byte, filter *kubeapi.PodSandboxF
 	err := b.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte("sandbox"))
 		if bucket == nil {
-			return fmt.Errorf("Bucket 'sandbox' doesn't exist")
+			return fmt.Errorf("bucket 'sandbox' doesn't exist")
 		}
 
 		sandboxBucket := bucket.Bucket(sandboxId)
 		if sandboxBucket == nil {
-			return fmt.Errorf("Bucket '%s' doesn't exist", sandboxId)
+			return fmt.Errorf("bucket '%s' doesn't exist", sandboxId)
 		}
 
 		strCreatedAt, err := getString(sandboxBucket, "createdAt")
@@ -389,7 +389,7 @@ func (b *BoltClient) getPodSandbox(sandboxId []byte, filter *kubeapi.PodSandboxF
 
 		metadataBucket := sandboxBucket.Bucket([]byte("metadata"))
 		if metadataBucket == nil {
-			return fmt.Errorf("Bucket 'metadata' doesn't exist")
+			return fmt.Errorf("bucket 'metadata' doesn't exist")
 		}
 
 		metadataName, err := getString(metadataBucket, "name")

--- a/pkg/bolttools/sandbox_test.go
+++ b/pkg/bolttools/sandbox_test.go
@@ -108,12 +108,12 @@ func TestSetPodSandbox(t *testing.T) {
 		if err := b.db.View(func(tx *bolt.Tx) error {
 			parentBucket := tx.Bucket([]byte("sandbox"))
 			if parentBucket == nil {
-				return fmt.Errorf("Bucket 'sandbox' doesn't exist")
+				return fmt.Errorf("bucket 'sandbox' doesn't exist")
 			}
 
 			bucket := parentBucket.Bucket([]byte(tc.config.GetMetadata().GetUid()))
 			if bucket == nil {
-				return fmt.Errorf("Bucket '%s' doesn't exist", tc.config.GetMetadata().GetUid())
+				return fmt.Errorf("bucket '%s' doesn't exist", tc.config.GetMetadata().GetUid())
 			}
 
 			hostname, err := getString(bucket, "hostname")
@@ -142,7 +142,7 @@ func TestSetPodSandbox(t *testing.T) {
 
 			metadataBucket := bucket.Bucket([]byte("metadata"))
 			if metadataBucket == nil {
-				return fmt.Errorf("Bucket 'metadata' doesn't exist")
+				return fmt.Errorf("bucket 'metadata' doesn't exist")
 			}
 
 			name, err := getString(metadataBucket, "name")
@@ -336,15 +336,15 @@ func TestGetPodSandboxStatus(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(status.GetLabels(), tc.config.GetLabels()) {
-			t.Errorf("Expected %#v, instead got %#v", tc.config.GetLabels(), status.GetLabels())
+			t.Errorf("Expected %v, instead got %v", tc.config.GetLabels(), status.GetLabels())
 		}
 
 		if !reflect.DeepEqual(status.GetAnnotations(), tc.config.GetAnnotations()) {
-			t.Errorf("Expected %#v, instead got %#v", tc.config.GetAnnotations(), status.GetAnnotations())
+			t.Errorf("Expected %v, instead got %v", tc.config.GetAnnotations(), status.GetAnnotations())
 		}
 
 		if status.GetMetadata().GetName() != tc.config.GetMetadata().GetName() {
-			t.Errorf("Expected %s, instead got %#v", tc.config.GetMetadata().GetName(), status.GetMetadata().GetName())
+			t.Errorf("Expected %s, instead got %s", tc.config.GetMetadata().GetName(), status.GetMetadata().GetName())
 		}
 	}
 }

--- a/pkg/bolttools/utils.go
+++ b/pkg/bolttools/utils.go
@@ -25,7 +25,7 @@ import (
 func get(bucket *bolt.Bucket, key []byte) ([]byte, error) {
 	value := bucket.Get(key)
 	if value == nil {
-		return nil, fmt.Errorf("Key '%s' doesn't exist in the bucket: %#v", key, bucket)
+		return nil, fmt.Errorf("key '%s' doesn't exist in the bucket", key)
 	}
 
 	return value, nil

--- a/pkg/bolttools/utils_test.go
+++ b/pkg/bolttools/utils_test.go
@@ -76,7 +76,7 @@ func TestGet(t *testing.T) {
 		if err := b.db.View(func(tx *bolt.Tx) error {
 			bucket := tx.Bucket(tc.bucketName)
 			if bucket == nil {
-				return fmt.Errorf("Bucket '%s' doesn't exist", tc.bucketName)
+				return fmt.Errorf("bucket '%s' doesn't exist", tc.bucketName)
 			}
 
 			for _, k := range tc.valuesToGet {

--- a/pkg/bolttools/virtualization.go
+++ b/pkg/bolttools/virtualization.go
@@ -59,7 +59,7 @@ func (b *BoltClient) SetContainer(containerId, sandboxId, image string, labels, 
 	err = b.db.Update(func(tx *bolt.Tx) error {
 		parentBucket := tx.Bucket([]byte("virtualization"))
 		if parentBucket == nil {
-			return fmt.Errorf("Bucket 'virtualization' doesn't exist")
+			return fmt.Errorf("bucket 'virtualization' doesn't exist")
 		}
 
 		bucket, err := parentBucket.CreateBucketIfNotExists([]byte(containerId))
@@ -99,7 +99,7 @@ func (b *BoltClient) GetContainerInfo(containerId string) (*ContainerInfo, error
 	if err := b.db.View(func(tx *bolt.Tx) error {
 		parentBucket := tx.Bucket([]byte("virtualization"))
 		if parentBucket == nil {
-			return fmt.Errorf("Bucket 'virtualization' doesn't exist")
+			return fmt.Errorf("bucket 'virtualization' doesn't exist")
 		}
 
 		bucket := parentBucket.Bucket([]byte(containerId))
@@ -168,7 +168,7 @@ func (b *BoltClient) RemoveContainer(containerId string) error {
 	return b.db.Batch(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte("virtualization"))
 		if bucket == nil {
-			return fmt.Errorf("Bucket 'virtualization' doesn't exist")
+			return fmt.Errorf("bucket 'virtualization' doesn't exist")
 		}
 
 		if err := bucket.DeleteBucket([]byte(containerId)); err != nil {

--- a/pkg/bolttools/virtualization_test.go
+++ b/pkg/bolttools/virtualization_test.go
@@ -83,12 +83,12 @@ func TestSetContainer(t *testing.T) {
 		if err := b.db.View(func(tx *bolt.Tx) error {
 			parentBucket := tx.Bucket([]byte("virtualization"))
 			if parentBucket == nil {
-				return fmt.Errorf("Bucket 'virtualization' doesn't exist")
+				return fmt.Errorf("bucket 'virtualization' doesn't exist")
 			}
 
 			bucket := parentBucket.Bucket([]byte(tc.containerId))
 			if bucket == nil {
-				return fmt.Errorf("Bucket '%s' doesn't exist", tc.containerId)
+				return fmt.Errorf("bucket '%s' doesn't exist", tc.containerId)
 			}
 
 			sandboxId, err := getString(bucket, "sandboxId")
@@ -198,11 +198,11 @@ func TestGetContainerInfo(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(containerInfo.Labels, tc.labels) {
-			t.Errorf("Expected %#v, instead got %#v", tc.labels, containerInfo.Labels)
+			t.Errorf("Expected %v, instead got %v", tc.labels, containerInfo.Labels)
 		}
 
 		if !reflect.DeepEqual(containerInfo.Annotations, tc.annotations) {
-			t.Errorf("Expected %#v, instead got %#v", tc.annotations, containerInfo.Annotations)
+			t.Errorf("Expected %v, instead got %v", tc.annotations, containerInfo.Annotations)
 		}
 	}
 }

--- a/pkg/libvirttools/storage_volume.go
+++ b/pkg/libvirttools/storage_volume.go
@@ -46,7 +46,7 @@ func GetStorageBackend(name string) (StorageBackend, error) {
 	case poolTypeRBD:
 		return &RBDBackend{}, nil
 	}
-	return nil, fmt.Errorf("There is no such a storage backend: %s", name)
+	return nil, fmt.Errorf("there is no such a storage backend: %s", name)
 }
 
 type LocalFilesystemBackend struct{}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -109,10 +109,10 @@ func (v *VirtletManager) RunPodSandbox(ctx context.Context, in *kubeapi.RunPodSa
 	podId := config.GetMetadata().GetUid()
 	name := config.GetMetadata().GetName()
 	glog.Infof("RunPodSandbox called for pod %s (%s)", name, podId)
-	glog.Infof("Sandbox config labels: %#v", config.GetLabels())
-	glog.Infof("Sandbox config annotations: %#v", config.GetAnnotations())
+	glog.Infof("Sandbox config labels: %v", config.GetLabels())
+	glog.Infof("Sandbox config annotations: %v", config.GetAnnotations())
 	if err := v.boltClient.SetPodSandbox(config); err != nil {
-		glog.Errorf("Error when creating pod sandbox for pod %s (%s): %#v", name, podId, err)
+		glog.Errorf("Error when creating pod sandbox for pod %s (%s): %v", name, podId, err)
 		return nil, err
 	}
 	response := &kubeapi.RunPodSandboxResponse{
@@ -143,7 +143,7 @@ func (v *VirtletManager) PodSandboxStatus(ctx context.Context, in *kubeapi.PodSa
 	podSandboxId := in.GetPodSandboxId()
 	status, err := v.boltClient.GetPodSandboxStatus(podSandboxId)
 	if err != nil {
-		glog.Errorf("Error when getting pod sandbox '%s' status: %#v", podSandboxId, err)
+		glog.Errorf("Error when getting pod sandbox '%s' status: %v", podSandboxId, err)
 		return nil, err
 	}
 	response := &kubeapi.PodSandboxStatusResponse{Status: status}
@@ -154,7 +154,7 @@ func (v *VirtletManager) ListPodSandbox(ctx context.Context, in *kubeapi.ListPod
 	filter := in.GetFilter()
 	podSandboxList, err := v.boltClient.ListPodSandbox(filter)
 	if err != nil {
-		glog.Errorf("Error when listing (with filter: %#v) pod sandboxes: %#v", filter, err)
+		glog.Errorf("Error when listing (with filter: %#v) pod sandboxes: %v", filter, err)
 		return nil, err
 	}
 	response := &kubeapi.ListPodSandboxResponse{Items: podSandboxList}
@@ -177,7 +177,7 @@ func (v *VirtletManager) CreateContainer(ctx context.Context, in *kubeapi.Create
 	// without whole data container
 	uuid, err := v.libvirtVirtualizationTool.CreateContainer(v.boltClient, in, imageFilepath)
 	if err != nil {
-		glog.Errorf("Error when creating container %s: %#v", name, err)
+		glog.Errorf("Error when creating container %s: %v", name, err)
 		return nil, err
 	}
 
@@ -190,7 +190,7 @@ func (v *VirtletManager) StartContainer(ctx context.Context, in *kubeapi.StartCo
 	glog.Infof("StartContainer called for containerID: %s", containerId)
 
 	if err := v.libvirtVirtualizationTool.StartContainer(containerId); err != nil {
-		glog.Errorf("Error when starting container %s: %#v", containerId, err)
+		glog.Errorf("Error when starting container %s: %v", containerId, err)
 		return nil, err
 	}
 	response := &kubeapi.StartContainerResponse{}
@@ -202,7 +202,7 @@ func (v *VirtletManager) StopContainer(ctx context.Context, in *kubeapi.StopCont
 	glog.Infof("StopContainer called for containerID: %s", containerId)
 
 	if err := v.libvirtVirtualizationTool.StopContainer(containerId); err != nil {
-		glog.Errorf("Error when stopping container %s: %#v", containerId, err)
+		glog.Errorf("Error when stopping container %s: %v", containerId, err)
 		return nil, err
 	}
 	response := &kubeapi.StopContainerResponse{}
@@ -214,7 +214,7 @@ func (v *VirtletManager) RemoveContainer(ctx context.Context, in *kubeapi.Remove
 	glog.Infof("RemoveContainer called for containerID: %s", containerId)
 
 	if err := v.libvirtVirtualizationTool.RemoveContainer(*in.ContainerId); err != nil {
-		glog.Errorf("Error when removing container '%s': %#v", containerId, err)
+		glog.Errorf("Error when removing container '%s': %v", containerId, err)
 		return nil, err
 	}
 
@@ -230,7 +230,7 @@ func (v *VirtletManager) ListContainers(ctx context.Context, in *kubeapi.ListCon
 	filter := in.GetFilter()
 	containers, err := v.libvirtVirtualizationTool.ListContainers(v.boltClient, filter)
 	if err != nil {
-		glog.Errorf("Error when listing containers with filter %#v: %#v", filter, err)
+		glog.Errorf("Error when listing containers with filter %#v: %v", filter, err)
 		return nil, err
 	}
 	response := &kubeapi.ListContainersResponse{Containers: containers}
@@ -241,7 +241,7 @@ func (v *VirtletManager) ContainerStatus(ctx context.Context, in *kubeapi.Contai
 	containerId := in.GetContainerId()
 	status, err := v.libvirtVirtualizationTool.ContainerStatus(containerId)
 	if err != nil {
-		glog.Errorf("Error when getting container '%s' status: %#v", containerId, err)
+		glog.Errorf("Error when getting container '%s' status: %v", containerId, err)
 		return nil, err
 	}
 
@@ -250,13 +250,13 @@ func (v *VirtletManager) ContainerStatus(ctx context.Context, in *kubeapi.Contai
 }
 
 func (v *VirtletManager) Exec(kubeapi.RuntimeService_ExecServer) error {
-	return fmt.Errorf("Not implemented")
+	return errors.New("not implemented")
 }
 
 func (v *VirtletManager) ListImages(ctx context.Context, in *kubeapi.ListImagesRequest) (*kubeapi.ListImagesResponse, error) {
 	images, err := v.libvirtImageTool.ListImages()
 	if err != nil {
-		glog.Errorf("Error when listing images: %#v", err)
+		glog.Errorf("Error when listing images: %v", err)
 	}
 	response := &kubeapi.ListImagesResponse{Images: images}
 	return response, err
@@ -267,7 +267,7 @@ func (v *VirtletManager) ImageStatus(ctx context.Context, in *kubeapi.ImageStatu
 
 	filepath, err := v.boltClient.GetImageFilepath(name)
 	if err != nil {
-		glog.Errorf("Error when getting image '%s' filepath: %#v", name, err)
+		glog.Errorf("Error when getting image '%s' filepath: %v", name, err)
 		return nil, err
 	}
 	if filepath == "" {
@@ -275,7 +275,7 @@ func (v *VirtletManager) ImageStatus(ctx context.Context, in *kubeapi.ImageStatu
 	}
 	image, err := v.libvirtImageTool.ImageStatus(filepath)
 	if err != nil {
-		glog.Errorf("Error when getting image '%s' in path '%s' status: %#v", name, filepath, err)
+		glog.Errorf("Error when getting image '%s' in path '%s' status: %v", name, filepath, err)
 		return nil, err
 	}
 
@@ -295,12 +295,12 @@ func (v *VirtletManager) PullImage(ctx context.Context, in *kubeapi.PullImageReq
 
 	filepath, err := v.libvirtImageTool.PullImage(name)
 	if err != nil {
-		glog.Errorf("Error when pulling image '%s': %#v", name, err)
+		glog.Errorf("Error when pulling image '%s': %v", name, err)
 		return nil, err
 	}
 	err = v.boltClient.SetImageFilepath(name, filepath)
 	if err != nil {
-		glog.Errorf("Error when setting filepath '%s' to image '%s': %#v", filepath, name, err)
+		glog.Errorf("Error when setting filepath '%s' to image '%s': %v", filepath, name, err)
 		return nil, err
 	}
 
@@ -314,17 +314,17 @@ func (v *VirtletManager) RemoveImage(ctx context.Context, in *kubeapi.RemoveImag
 
 	filepath, err := v.boltClient.GetImageFilepath(name)
 	if err != nil {
-		glog.Errorf("Error when getting filepath for image '%s': %#v", name, err)
+		glog.Errorf("Error when getting filepath for image '%s': %v", name, err)
 		return nil, err
 	}
 	if filepath == "" {
-		err = fmt.Errorf("Error when getting filepath for image '%s': image not found in database", name)
-		glog.Errorf(err.Error())
+		err = errors.New("image not found in database")
+		glog.Errorf("Error when getting filepath for image '%s': %v", err)
 		return nil, err
 	}
 	err = v.libvirtImageTool.RemoveImage(filepath)
 	if err != nil {
-		glog.Errorf("Error when removing image '%s' with path '%s': %#v", name, filepath, err)
+		glog.Errorf("Error when removing image '%s' with path '%s': %v", name, filepath, err)
 		return nil, err
 	}
 


### PR DESCRIPTION
Some `%#v` occurrences were left as is as they're used to dump some complex structures which may contain info that's necessary for debugging.
 
https://github.com/Mirantis/virtlet/blob/66127920ecaaed810e484ba4f263f45784f522d9/cmd/fake-create-container/fake-create-container.go#L109
```go
fmt.Printf("Got response: %#v\n", containerOut)
```

https://github.com/Mirantis/virtlet/blob/66127920ecaaed810e484ba4f263f45784f522d9/cmd/fake-image-pull/fake-image-pull.go#L64
```go
fmt.Printf("Got response: %#v\n", out)
```

https://github.com/Mirantis/virtlet/blob/66127920ecaaed810e484ba4f263f45784f522d9/pkg/bolttools/sandbox.go#L56
```go
return fmt.Errorf("Sandbox config is missing Metadata attribute: %#v", config)
```

https://github.com/Mirantis/virtlet/blob/66127920ecaaed810e484ba4f263f45784f522d9/pkg/bolttools/sandbox.go#L61
```go
return fmt.Errorf("Sandbox config is missing Linux attribute: %#v", config)
```

https://github.com/Mirantis/virtlet/blob/66127920ecaaed810e484ba4f263f45784f522d9/pkg/bolttools/sandbox.go#L66
```go
return fmt.Errorf("Linux sandbox config is missing Namespaces attribute: %#v", linuxSandbox)
```

https://github.com/Mirantis/virtlet/blob/66127920ecaaed810e484ba4f263f45784f522d9/pkg/manager/manager.go#L157
```go
glog.Errorf("Error when listing (with filter: %#v) pod sandboxes: %v", filter, err)
```

https://github.com/Mirantis/virtlet/blob/66127920ecaaed810e484ba4f263f45784f522d9/pkg/manager/manager.go#L233
```go
glog.Errorf("Error when listing containers with filter %#v: %v", filter, err)
```

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/109)
<!-- Reviewable:end -->
