### PR TITLE
Fix k8s version pinning

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -66,7 +66,7 @@ imports:
   - peer
   - transport
 - name: k8s.io/kubernetes
-  version: e72f26a3fff4f521d1da9f52b3ce82d4d0d5a401
+  version: v1.5.0-alpha.1
   repo: git://github.com/kubernetes/kubernetes.git
   vcs: git
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,7 +6,7 @@ import:
   - context
 - package: google.golang.org/grpc
 - package: k8s.io/kubernetes
-  version: e72f26a3fff4f521d1da9f52b3ce82d4d0d5a401
+  version: v1.5.0-alpha.1
   repo: git://github.com/kubernetes/kubernetes.git
   vcs: git
   subpackages:


### PR DESCRIPTION
Due to different versions in glide.yaml and glide.lock, version pinning
broke after I did `glide get ...`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/114)
<!-- Reviewable:end -->
