### PR TITLE
Partial fix for pod/container statuses

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -123,8 +123,14 @@ func (v *VirtletManager) RunPodSandbox(ctx context.Context, in *kubeapi.RunPodSa
 }
 
 func (v *VirtletManager) StopPodSandbox(ctx context.Context, in *kubeapi.StopPodSandboxRequest) (*kubeapi.StopPodSandboxResponse, error) {
+	podSandboxId := in.GetPodSandboxId()
 	glog.V(2).Infof("StopPodSandbox called for pod %s", in.GetPodSandboxId())
 	glog.V(3).Infof("StopPodSandbox: %s", spew.Sdump(in))
+	if err := v.boltClient.UpdatePodState(podSandboxId, kubeapi.PodSandBoxState_NOTREADY); err != nil {
+		glog.Errorf("Error when stopping pod sandbox '%s': %v", podSandboxId, err)
+		return nil, err
+	}
+
 	response := &kubeapi.StopPodSandboxResponse{}
 	return response, nil
 }
@@ -135,7 +141,7 @@ func (v *VirtletManager) RemovePodSandbox(ctx context.Context, in *kubeapi.Remov
 	glog.V(3).Infof("RemovePodSandbox: %s", spew.Sdump(in))
 
 	if err := v.boltClient.RemovePodSandbox(podSandboxId); err != nil {
-		glog.Errorf("Error when removing pod sandbox '%s' status: %v", podSandboxId, err)
+		glog.Errorf("Error when removing pod sandbox '%s': %v", podSandboxId, err)
 		return nil, err
 	}
 
@@ -149,7 +155,7 @@ func (v *VirtletManager) PodSandboxStatus(ctx context.Context, in *kubeapi.PodSa
 	podSandboxId := in.GetPodSandboxId()
 	status, err := v.boltClient.GetPodSandboxStatus(podSandboxId)
 	if err != nil {
-		glog.Errorf("Error when getting pod sandbox '%s' status: %v", podSandboxId, err)
+		glog.Errorf("Error when getting pod sandbox '%s': %v", podSandboxId, err)
 		return nil, err
 	}
 	response := &kubeapi.PodSandboxStatusResponse{Status: status}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -261,7 +261,7 @@ func (v *VirtletManager) ListContainers(ctx context.Context, in *kubeapi.ListCon
 func (v *VirtletManager) ContainerStatus(ctx context.Context, in *kubeapi.ContainerStatusRequest) (*kubeapi.ContainerStatusResponse, error) {
 	containerId := in.GetContainerId()
 	glog.V(3).Infof("ContainerStatus: %s", spew.Sdump(in))
-	status, err := v.libvirtVirtualizationTool.ContainerStatus(containerId)
+	status, err := v.libvirtVirtualizationTool.ContainerStatus(v.boltClient, containerId)
 	if err != nil {
 		glog.Errorf("Error when getting container '%s' status: %v", containerId, err)
 		return nil, err


### PR DESCRIPTION
Solves a bit issue described in #120 

For containers - provides differentiation between vm not running because it was newly created/defined from vm not running because it was stopped.

In similar manner for sandboxes - if there was call to stop pod sandbox - now we are changing it's status in podstatus responses to not ready (being compatible with dockershim).

Still there is no check if stop pod sandbox was called before container/vm had really chance to clean stop - this should be added.

Still there is some issue with statuses, because after create/delete example fedora pod - `virsh list` shows that domain was not undefined. Next call to create same pod starts new vm (what seems to be dangerous, could overwrite some data which was not cleanly stopped) what we can see in `virsh list`, but whole pod is stick in:
```
    State:              Waiting
      Reason:           ContainerCreating
```

So this need further investigation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/122)
<!-- Reviewable:end -->
