### PR TITLE
Correct ContainerState

### DIFF
--- a/pkg/bolttools/sandbox.go
+++ b/pkg/bolttools/sandbox.go
@@ -83,7 +83,7 @@ func (b *BoltClient) SetPodSandbox(config *kubeapi.PodSandboxConfig, networkConf
 			return err
 		}
 
-		if err := sandboxBucket.Put([]byte("createdAt"), []byte(strconv.FormatInt(time.Now().Unix(), 10))); err != nil {
+		if err := sandboxBucket.Put([]byte("createdAt"), []byte(strconv.FormatInt(time.Now().UnixNano(), 10))); err != nil {
 			return err
 		}
 
@@ -165,7 +165,7 @@ func (b *BoltClient) SetPodSandbox(config *kubeapi.PodSandboxConfig, networkConf
 	return err
 }
 
-func (b *BoltClient) UpdatePodState(podId string, state kubeapi.PodSandBoxState) error {
+func (b *BoltClient) UpdatePodState(podId string, state byte) error {
 	err := b.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte("sandbox"))
 		if bucket == nil {
@@ -177,7 +177,7 @@ func (b *BoltClient) UpdatePodState(podId string, state kubeapi.PodSandBoxState)
 			return fmt.Errorf("bucket '%s' doesn't exist", podId)
 		}
 
-		if err := sandboxBucket.Put([]byte("state"), []byte{byte(state)}); err != nil {
+		if err := sandboxBucket.Put([]byte("state"), []byte{state}); err != nil {
 			return err
 		}
 

--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -28,12 +28,15 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
+	"time"
 	"unsafe"
 
 	kubeapi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 
 	"encoding/xml"
+
 	"github.com/Mirantis/virtlet/pkg/bolttools"
 	"github.com/Mirantis/virtlet/pkg/utils"
 	"github.com/golang/glog"
@@ -200,7 +203,7 @@ var volXML string = `
 </disk>`
 
 func (v *VirtualizationTool) createBootImageSnapshot(imageName, backingStorePath string) (string, error) {
-	vol, err := v.volumeStorage.CreateSnapshot(v.volumePool, imageName, defaultCapacity, defaultCapacityUnit, backingStorePath )
+	vol, err := v.volumeStorage.CreateSnapshot(v.volumePool, imageName, defaultCapacity, defaultCapacityUnit, backingStorePath)
 
 	if err != nil {
 		return "", err
@@ -329,7 +332,7 @@ func (v *VirtualizationTool) CreateContainer(boltClient *bolttools.BoltClient, i
 	cpuPeriod := config.GetLinux().GetResources().GetCpuPeriod()
 	cpuQuota := config.GetLinux().GetResources().GetCpuQuota()
 
-	snapshotImage, err := v.createBootImageSnapshot("snapshot_" + uuid, imageFilepath)
+	snapshotImage, err := v.createBootImageSnapshot("snapshot_"+uuid, imageFilepath)
 	if err != nil {
 		return "", err
 	}
@@ -433,7 +436,11 @@ func libvirtToKubeState(domainInfo C.virDomainInfo, lastState kubeapi.ContainerS
 	case C.VIR_DOMAIN_RUNNING:
 		containerState = kubeapi.ContainerState_RUNNING
 	case C.VIR_DOMAIN_PAUSED:
-		containerState = kubeapi.ContainerState_EXITED
+		if lastState == kubeapi.ContainerState_CREATED {
+			containerState = kubeapi.ContainerState_CREATED
+		} else {
+			containerState = kubeapi.ContainerState_EXITED
+		}
 	case C.VIR_DOMAIN_SHUTDOWN:
 		containerState = kubeapi.ContainerState_EXITED
 	case C.VIR_DOMAIN_SHUTOFF:
@@ -472,11 +479,11 @@ func filterContainer(container *kubeapi.Container, filter *kubeapi.ContainerFilt
 
 func (v *VirtualizationTool) getContainer(boltClient *bolttools.BoltClient, domain *C.struct__virDomain) (*kubeapi.Container, error) {
 	var domainInfo C.virDomainInfo
-	id, err := v.GetDomainUUID(domain)
+	containerId, err := v.GetDomainUUID(domain)
 	if err != nil {
 		return nil, err
 	}
-	containerInfo, err := boltClient.GetContainerInfo(id)
+	containerInfo, err := boltClient.GetContainerInfo(containerId)
 	if err != nil {
 		return nil, err
 	}
@@ -491,25 +498,34 @@ func (v *VirtualizationTool) getContainer(boltClient *bolttools.BoltClient, doma
 	}
 
 	metadata := &kubeapi.ContainerMetadata{
-		Name: &id,
+		Name: &containerId,
 	}
 
 	image := &kubeapi.ImageSpec{Image: &containerInfo.Image}
 
-	imageRef := containerInfo.Image
-
 	containerState := libvirtToKubeState(domainInfo, containerInfo.State)
-
-	createdAt := containerInfo.CreatedAt
+	if containerInfo.State != containerState {
+		if err := boltClient.UpdateState(containerId, byte(containerState)); err != nil {
+			return nil, err
+		}
+		startedAt := time.Now().UnixNano()
+		strStartedAt := strconv.FormatInt(startedAt, 10)
+		if containerState == kubeapi.ContainerState_RUNNING {
+			if err := boltClient.UpdateStartedAt(containerId, strStartedAt); err != nil {
+				return nil, err
+			}
+		}
+		containerInfo.StartedAt = startedAt
+	}
 
 	container := &kubeapi.Container{
-		Id:           &id,
+		Id:           &containerId,
 		PodSandboxId: &podSandboxId,
 		Metadata:     metadata,
 		Image:        image,
-		ImageRef:     &imageRef,
+		ImageRef:     &containerInfo.Image,
 		State:        &containerState,
-		CreatedAt:    &createdAt,
+		CreatedAt:    &containerInfo.CreatedAt,
 		Labels:       containerInfo.Labels,
 		Annotations:  containerInfo.Annotations,
 	}
@@ -621,14 +637,28 @@ func (v *VirtualizationTool) ContainerStatus(boltClient *bolttools.BoltClient, c
 
 	containerState := libvirtToKubeState(domainInfo, containerInfo.State)
 	if containerInfo.State != containerState {
-		if err := boltClient.UpdateState(containerId, containerState); err != nil {
+		if err := boltClient.UpdateState(containerId, byte(containerState)); err != nil {
 			return nil, err
 		}
+		startedAt := time.Now().UnixNano()
+		strStartedAt := strconv.FormatInt(startedAt, 10)
+		if containerState == kubeapi.ContainerState_RUNNING {
+			if err := boltClient.UpdateStartedAt(containerId, strStartedAt); err != nil {
+				return nil, err
+			}
+		}
+		containerInfo.StartedAt = startedAt
 	}
 
+	image := &kubeapi.ImageSpec{Image: &containerInfo.Image}
+
 	return &kubeapi.ContainerStatus{
-		Id:       &containerId,
-		Metadata: &kubeapi.ContainerMetadata{},
-		State:    &containerState,
+		Id:        &containerId,
+		Metadata:  &kubeapi.ContainerMetadata{},
+		Image:     image,
+		ImageRef:  &containerInfo.Image,
+		State:     &containerState,
+		CreatedAt: &containerInfo.CreatedAt,
+		StartedAt: &containerInfo.StartedAt,
 	}, nil
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -157,7 +157,7 @@ func (v *VirtletManager) StopPodSandbox(ctx context.Context, in *kubeapi.StopPod
 	podSandboxId := in.GetPodSandboxId()
 	glog.V(2).Infof("StopPodSandbox called for pod %s", in.GetPodSandboxId())
 	glog.V(3).Infof("StopPodSandbox: %s", spew.Sdump(in))
-	if err := v.boltClient.UpdatePodState(podSandboxId, kubeapi.PodSandBoxState_NOTREADY); err != nil {
+	if err := v.boltClient.UpdatePodState(podSandboxId, byte(kubeapi.PodSandBoxState_NOTREADY)); err != nil {
 		glog.Errorf("Error when stopping pod sandbox '%s': %v", podSandboxId, err)
 		return nil, err
 	}


### PR DESCRIPTION
Added saving and retrieval `startedAt` container state attribute.
Added returning `startedAt` in `ContainerStatus`.

Still `kubectl describe pods` shows `Thu, 01 Jan 1970 01:00:01 +0100` as start date, so trying to figure out logic behind cached container states in pod, in kubelet manager.

Related to #133

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/134)
<!-- Reviewable:end -->
