### PR TITLE
virtualization: Name domain using containerId

### DIFF
--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -170,7 +170,7 @@ func generateDomXML(useKvm bool, name string, memory int64, memoryUnit string, u
 	cniConfigEscaped := buf.String()
 	domXML := `
 <domain type='%s'>
-    <name>%s</name>
+    <name>%s-%s</name>
     <uuid>%s</uuid>
     <memory unit='%s'>%d</memory>
     <vcpu>%d</vcpu>
@@ -215,7 +215,7 @@ func generateDomXML(useKvm bool, name string, memory int64, memoryUnit string, u
       <env name='VIRTLET_CNI_CONFIG' value='%s'/>
     </commandline>
 </domain>`
-	return fmt.Sprintf(domXML, domainType, name, uuid, memoryUnit, memory, cpuNum, cpuShare, cpuPeriod, cpuQuota, imageFilepath, emulator, netNSPath, cniConfigEscaped)
+	return fmt.Sprintf(domXML, domainType, uuid, name, uuid, memoryUnit, memory, cpuNum, cpuShare, cpuPeriod, cpuQuota, imageFilepath, emulator, netNSPath, cniConfigEscaped)
 }
 
 var volXML string = `


### PR DESCRIPTION
Closes #149

Instead of using `podId` - there is used `containerId-imageName` as name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/150)
<!-- Reviewable:end -->
