### PR TITLE
Remove ceph-common package from images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL Name="virtlet" Version="0.1"
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
-    apt-get install -y libvirt-bin libguestfs0 libguestfs-tools ceph-common \
+    apt-get install -y libvirt-bin libguestfs0 libguestfs-tools \
                        openssl qemu-kvm qemu-system-x86 python-libvirt \
                        netbase iproute2 iptables ebtables && \
     apt-get clean

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -25,7 +25,6 @@ RUN apt-get update && \
                 qemu-system-x86 \
                 libvirt-bin \
                 python-libvirt \
-                ceph-common \
                 netbase \
                 iputils-ping && \
     apt-get clean


### PR DESCRIPTION
It's not used as of now

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/155)
<!-- Reviewable:end -->
