### PR TITLE
CRI proxy

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,7 @@ export GO15VENDOREXPERIMENT=1
 export CGO_CFLAGS=$(CFLAGS)
 export CGO_LDFLAGS=$(LDFLAGS) $(LIBS)
 
-SUBDIRS = pkg/bolttools pkg/download pkg/libvirttools pkg/manager pkg/nettools tests/integration tests/network
+SUBDIRS = pkg/bolttools pkg/download pkg/libvirttools pkg/manager pkg/nettools pkg/criproxy tests/integration tests/network
 
 # FIXME: add back dockerfilelint.test
 # (as of now, it requires Docker)

--- a/Makefile.am
+++ b/Makefile.am
@@ -30,6 +30,7 @@ all:
 	mkdir -p $(builddir)/_output $(builddir)/contrib/images/libvirt/_output
 	go build -o $(builddir)/_output/virtlet ./cmd/virtlet
 	go build -o $(builddir)/_output/vmwrapper ./cmd/vmwrapper
+	go build -o $(builddir)/_output/criproxy ./cmd/criproxy
 
 verify-glide-installation:
 	@which glide || go get github.com/Masterminds/glide

--- a/cmd/criproxy/criproxy.go
+++ b/cmd/criproxy/criproxy.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2016 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"os"
+	"time"
+
+	"github.com/Mirantis/virtlet/pkg/criproxy"
+
+	"github.com/golang/glog"
+)
+
+const (
+	// XXX: fix this
+	connectionTimeout = 30 * time.Second
+)
+
+var (
+	listen = flag.String("listen", "/run/criproxy.sock",
+		"The unix socket to listen on, e.g. /run/virtlet.sock")
+	connect = flag.String("connect", "/var/run/dockershim.sock",
+		"CRI unix socket to connect to, e.g. /var/run/dockershim.sock")
+)
+
+func main() {
+	flag.Parse()
+
+	proxy, err := criproxy.NewRuntimeProxy(*connect, connectionTimeout)
+	if err != nil {
+		glog.Errorf("Initializing server failed: %v", err)
+		os.Exit(1)
+	}
+	glog.V(1).Infof("Starting CRI proxy on socket %s", *listen)
+	if err = proxy.Serve(*listen); err != nil {
+		glog.Errorf("Serving failed: %v", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/criproxy/criproxy.go
+++ b/cmd/criproxy/criproxy.go
@@ -42,9 +42,9 @@ var (
 func main() {
 	flag.Parse()
 
-	proxy := criproxy.NewRuntimeProxy(strings.Split(*connect, ","), connectionTimeout)
-	if err := proxy.Connect(); err != nil {
-		glog.Errorf("Error connecting to CRI endpoints: %v", err)
+	proxy, err := criproxy.NewRuntimeProxy(strings.Split(*connect, ","), connectionTimeout)
+	if err != nil {
+		glog.Errorf("Error starting CRI proxy: %v", err)
 		os.Exit(1)
 	}
 	glog.V(1).Infof("Starting CRI proxy on socket %s", *listen)

--- a/configure.ac
+++ b/configure.ac
@@ -12,6 +12,6 @@ CFLAGS="$CFLAGS $glib_CFLAGS $libvirt_CFLAGS"
 LDFLAGS="$LDFLAGS"
 LIBS="$LIBS $glib_LIBS $libvirt_LIBS"
 
-AC_CONFIG_FILES([Makefile pkg/bolttools/Makefile pkg/download/Makefile pkg/libvirttools/Makefile pkg/manager/Makefile pkg/nettools/Makefile tests/integration/Makefile tests/network/Makefile])
+AC_CONFIG_FILES([Makefile pkg/bolttools/Makefile pkg/download/Makefile pkg/libvirttools/Makefile pkg/manager/Makefile pkg/nettools/Makefile pkg/criproxy/Makefile tests/integration/Makefile tests/network/Makefile])
 
 AC_OUTPUT

--- a/contrib/deploy/README.md
+++ b/contrib/deploy/README.md
@@ -1,0 +1,33 @@
+# Deploying virtlet as a DaemonSet
+
+1. Start [kubeadm-dind-cluster](https://github.com/Mirants/kubeadm-dind-cluster) on [this k8s fork](https://github.com/ivan4th/kubernetes/tree/mixed-container-runtime-mode)
+2. 'Virtletify' `kube-node-1`:
+```
+./virtletify-dind-node.sh
+```
+3. Create image server Deployment and Service:
+```
+kubectl create -f image-server.yaml
+kubectl create -f image-service.yaml
+```
+4. Wait for image-server pod to become Running (this is important for virtlet initialization due to host network + cluster DNS [issue](https://github.com/kubernetes/kubernetes/issues/17406)):
+```
+kubectl get pods -w
+```
+5. Create Virtlet DaemonSet:
+```
+kubectl create -f virtlet-ds.yaml
+```
+6. Wait for Virtlet to start:
+```
+kubectl get pods -w
+```
+
+Notes:
+
+1. Currently CRI proxy doesn't survive node restart (need to add proper systemd unit to fix this).
+2. Trying to do `kubectl exec` in virtlet container may currently fail with unhelpful error message ("Error from server"). To inspect VM using virsh, you may use `docker exec -it kube-node-1 /bin/bash`, then locate virtlet container and then use `docker exec`:
+```
+docker exec -it k8s_virtlet_virtlet-qtchf_default_bc500518-d0cf-11e6-b02c-0242ac1e0002_0 virsh list
+docker exec -it k8s_virtlet_virtlet-qtchf_default_bc500518-d0cf-11e6-b02c-0242ac1e0002_0 virsh console 46348787-0880-487f-6bf0-5228513b78e5-cirros-vm
+```

--- a/contrib/deploy/cirros-vm.yaml
+++ b/contrib/deploy/cirros-vm.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cirros-vm
+  annotations:
+    kubernetes.io/target-runtime: virtlet
+    scheduler.alpha.kubernetes.io/affinity: >
+      {
+        "nodeAffinity": {
+          "requiredDuringSchedulingIgnoredDuringExecution": {
+            "nodeSelectorTerms": [
+              {
+                "matchExpressions": [
+                  {
+                    "key": "extraRuntime",
+                    "operator": "In",
+                    "values": ["virtlet"]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+spec:
+  containers:
+    - name: cirros-vm
+      image: virtlet/image-service/cirros

--- a/contrib/deploy/image-server.yaml
+++ b/contrib/deploy/image-server.yaml
@@ -1,0 +1,39 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: image-server
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        role: image-server
+      annotations:
+        pod.beta.kubernetes.io/init-containers: >
+          [
+            {
+              "name": "dl-image",
+              "image": "busybox",
+              "imagePullPolicy": "IfNotPresent",
+              "command": ["wget", "http://download.cirros-cloud.net/0.3.4/cirros-0.3.4-x86_64-disk.img", "-O", "/images/cirros"],
+              "volumeMounts": [
+                {
+                  "name": "images",
+                  "mountPath": "/images"
+                }
+              ]
+            }
+          ]
+    spec:
+      containers:
+      - name: web
+        image: nginx
+        ports:
+        - name: web
+          containerPort: 80
+        volumeMounts:
+        - mountPath: /usr/share/nginx/html
+          name: images
+      volumes:
+      - name: images
+        emptyDir: {}

--- a/contrib/deploy/image-service.yaml
+++ b/contrib/deploy/image-service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: image-service
+spec:
+  selector:
+    role: image-server
+  ports:
+  - name: web
+    port: 80

--- a/contrib/deploy/virtlet-ds.yaml
+++ b/contrib/deploy/virtlet-ds.yaml
@@ -1,0 +1,82 @@
+apiVersion: extensions/v1beta1 
+kind: DaemonSet
+metadata:
+  name: virtlet
+spec:
+  template:
+    metadata:
+      name: virtlet
+      labels:
+        runtime: virtlet
+      annotations:
+        scheduler.alpha.kubernetes.io/affinity: >
+          {
+            "nodeAffinity": {
+              "requiredDuringSchedulingIgnoredDuringExecution": {
+                "nodeSelectorTerms": [
+                  {
+                    "matchExpressions": [
+                      {
+                        "key": "extraRuntime",
+                        "operator": "In",
+                        "values": ["virtlet"]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+    spec:
+      # TODO: hostPID: true for VMs to survive libvirt restart
+      hostNetwork: true
+      containers:
+      - name: virtlet
+        image: mirantis/virtlet
+        # Workaround for https://github.com/kubernetes/kubernetes/issues/17406
+        command:
+          - "/bin/bash"
+          - "-c"
+          - "echo ${IMAGE_SERVICE_SERVICE_HOST} image-service >>/etc/hosts && /start.sh"
+        volumeMounts:
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /boot
+          name: boot
+          readOnly: true
+        - mountPath: /run
+          name: run
+        - mountPath: /var/lib/virtlet
+          name: virtlet
+        # FIXME: E0102 08:26:02.959687      32 virtlet.go:50] Initializing server failed: cannot open path '/var/lib/libvirt/images': No such file or directory
+        # - mountPath: /var/lib/libvirt
+        #   name: libvirt
+        securityContext:
+          privileged: true
+        env:
+        - name: VIRTLET_LOGLEVEL
+          value: "3"
+        - name: VIRTLET_DISABLE_KVM
+          value: "1"
+      volumes:
+      - hostPath:
+          path: /sys/fs/cgroup
+        name: cgroup
+      - hostPath:
+          path: /lib/modules
+        name: modules
+      - hostPath:
+          path: /boot
+        name: boot
+      - hostPath:
+          path: /run
+        name: run
+      - hostPath:
+          path: /var/lib/virtlet
+        name: virtlet
+      - hostPath:
+          path: /var/lib/libvirt
+        name: libvirt

--- a/contrib/deploy/virtletify-dind-node.sh
+++ b/contrib/deploy/virtletify-dind-node.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+if [ $(uname) = Darwin ]; then
+  readlinkf(){ perl -MCwd -e 'print Cwd::abs_path shift' "$1";}
+else
+  readlinkf(){ readlink -f "$1"; }
+fi
+
+cd "$(dirname "$(readlinkf "${BASH_SOURCE}")")/../.."
+
+container="${1:-kube-node-1}"
+
+build/cmd.sh build
+build/cmd.sh copy
+
+docker cp _output/criproxy kube-node-1:/usr/local/bin/
+
+# kubeadm-dind-cluster specific node naming
+node_name="$(docker exec "${container}" hostname --ip-address)"
+
+docker exec -d "${container}" bash -c '/usr/local/bin/criproxy -v 3 -alsologtostderr -connect /var/run/dockershim.sock,virtlet:/run/virtlet.sock >& /tmp/criproxy.log'
+
+# FIXME: --node-labels doesn't work here because of this issue:
+# https://github.com/kubernetes/kubernetes/issues/28051
+docker exec "${container}" sed -i \
+       "s@'\$@ --node-labels=extraRuntime=virtlet --experimental-cri --container-runtime=mixed --container-runtime-endpoint=/run/criproxy.sock --image-service-endpoint=/run/criproxy.sock'@" \
+       /etc/systemd/system/kubelet.service.d/20-hostname-override.conf
+docker exec -i "${container}" systemctl stop kubelet
+docker exec -i "${container}" bash -c 'docker ps -qa|xargs docker rm -fv'
+docker exec -i "${container}" systemctl daemon-reload
+docker exec -i "${container}" systemctl start kubelet
+
+# Set node label because --node-labels doesn't update node labels after
+# restarting kubelet (see above)
+kubectl label node "${node_name}" extraRuntime=virtlet
+
+# kubectl create -f contrib/deploy/virtlet-ds.yaml

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: fa3d1e706971c5363fe2c8804ade9bddd498856f61a72b7b63ac4aab3a26f3ca
-updated: 2016-12-15T15:09:09.243431338+03:00
+hash: 2e99359afe089edfde09dae29a2ba5d6e8a7d5bc0b5d464bda13b33ddc98e795
+updated: 2016-12-27T17:30:04.84118858+03:00
 imports:
 - name: github.com/boltdb/bolt
   version: dfb21201d9270c1082d5fb0f07f500311ff72f18
@@ -56,6 +56,10 @@ imports:
   - proto
 - name: github.com/nu7hatch/gouuid
   version: 179d4d0c4d8d407a32af483c2354df1d2c91e6c3
+- name: github.com/pmezard/go-difflib
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  subpackages:
+  - difflib
 - name: github.com/vishvananda/netlink
   version: a4f22d8ad2327663017dbb309b5e3f8b6f348020
   subpackages:
@@ -102,5 +106,8 @@ imports:
   - pkg/fields
   - pkg/kubelet/api/v1alpha1/runtime
   - pkg/selection
-  - pkg/util/exec
-testImports: []
+testImports:
+- name: github.com/sergi/go-diff
+  version: 83532ca1c1caa393179c677b6facf48e61f4ca5d
+  subpackages:
+  - diffmatchpatch

--- a/glide.yaml
+++ b/glide.yaml
@@ -21,3 +21,7 @@ import:
   version: ~0.3.0
 - package: github.com/vishvananda/netlink
   version: a4f22d8ad2327663017dbb309b5e3f8b6f348020
+- package: github.com/pmezard/go-difflib
+  version: ~1.0.0
+  subpackages:
+  - difflib

--- a/pkg/criproxy/Makefile.am
+++ b/pkg/criproxy/Makefile.am
@@ -1,0 +1,16 @@
+# Copyright 2016 Mirantis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+check_SCRIPTS = go.test
+TESTS = $(check_SCRIPTS)

--- a/pkg/criproxy/go.test
+++ b/pkg/criproxy/go.test
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+go test -v .

--- a/pkg/criproxy/proxy.go
+++ b/pkg/criproxy/proxy.go
@@ -1,0 +1,392 @@
+/*
+Copyright 2016 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// TODO: credits
+// (based on remote_runtime.go and remote_image.go from k8s)
+package criproxy
+
+import (
+	"net"
+	"os"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/golang/glog"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	runtimeapi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
+)
+
+// dial creates a net.Conn by unix socket addr.
+func dial(addr string, timeout time.Duration) (net.Conn, error) {
+	return net.DialTimeout("unix", addr, timeout)
+}
+
+// getContextWithTimeout returns a context with timeout.
+func getContextWithTimeout(timeout time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), timeout)
+}
+
+// RuntimeProxy is a gRPC implementation of internalapi.RuntimeService.
+type RuntimeProxy struct {
+	timeout       time.Duration
+	server        *grpc.Server
+	runtimeClient runtimeapi.RuntimeServiceClient
+	imageClient   runtimeapi.ImageServiceClient
+}
+
+// NewRuntimeProxy creates a new internalapi.RuntimeService.
+func NewRuntimeProxy(addr string, connectionTimout time.Duration) (*RuntimeProxy, error) {
+	glog.Infof("Connecting to runtime service %s", addr)
+	conn, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithTimeout(connectionTimout), grpc.WithDialer(dial))
+	if err != nil {
+		glog.Errorf("Connect remote runtime %s failed: %v", addr, err)
+		return nil, err
+	}
+
+	proxy := &RuntimeProxy{
+		server:        grpc.NewServer(),
+		runtimeClient: runtimeapi.NewRuntimeServiceClient(conn),
+		imageClient:   runtimeapi.NewImageServiceClient(conn),
+	}
+	runtimeapi.RegisterRuntimeServiceServer(proxy.server, proxy)
+	runtimeapi.RegisterImageServiceServer(proxy.server, proxy)
+
+	return proxy, nil
+}
+
+func (r *RuntimeProxy) Serve(addr string) error {
+	if err := syscall.Unlink(addr); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	ln, err := net.Listen("unix", addr)
+	if err != nil {
+		return err
+	}
+	defer ln.Close()
+	return r.server.Serve(ln)
+}
+
+// RuntimeServiceServer methods follow
+
+// Version returns the runtime name, runtime version and runtime API version.
+func (r *RuntimeProxy) Version(ctx context.Context, in *runtimeapi.VersionRequest) (*runtimeapi.VersionResponse, error) {
+	glog.Infof("ENTER: Version(): %s", spew.Sdump(in))
+	resp, err := r.runtimeClient.Version(ctx, in)
+	if err != nil {
+		glog.Errorf("FAIL: Version(): Version from runtime service failed: %v", err)
+		return nil, err
+	}
+
+	glog.Infof("LEAVE: Version(): %s", spew.Sdump(resp))
+	return resp, err
+}
+
+// RunPodSandbox creates and starts a pod-level sandbox. Runtimes should ensure
+// the sandbox is in ready state.
+func (r *RuntimeProxy) RunPodSandbox(ctx context.Context, in *runtimeapi.RunPodSandboxRequest) (*runtimeapi.RunPodSandboxResponse, error) {
+	glog.Infof("ENTER: RunPodSandbox(): %s", spew.Sdump(in))
+	resp, err := r.runtimeClient.RunPodSandbox(ctx, in)
+	if err != nil {
+		glog.Errorf("FAIL: RunPodSandbox(): RunPodSandbox from runtime service failed: %v", err)
+		return nil, err
+	}
+
+	glog.Infof("LEAVE: RunPodSandbox(): %s", spew.Sdump(resp))
+	return resp, nil
+}
+
+// StopPodSandbox stops the sandbox. If there are any running containers in the
+// sandbox, they should be forced to termination.
+func (r *RuntimeProxy) StopPodSandbox(ctx context.Context, in *runtimeapi.StopPodSandboxRequest) (*runtimeapi.StopPodSandboxResponse, error) {
+	glog.Infof("ENTER: StopPodSandbox(): %s", spew.Sdump(in))
+	resp, err := r.runtimeClient.StopPodSandbox(ctx, in)
+	if err != nil {
+		glog.Errorf("FAIL: StopPodSandbox(): StopPodSandbox %q from runtime service failed: %v", in.GetPodSandboxId(), err)
+		return nil, err
+	}
+
+	glog.Infof("LEAVE: StopPodSandbox(): %s", spew.Sdump(resp))
+	return resp, nil
+}
+
+// RemovePodSandbox removes the sandbox. If there are any containers in the
+// sandbox, they should be forcibly removed.
+func (r *RuntimeProxy) RemovePodSandbox(ctx context.Context, in *runtimeapi.RemovePodSandboxRequest) (*runtimeapi.RemovePodSandboxResponse, error) {
+	glog.Infof("ENTER: RemovePodSandbox(): %s", spew.Sdump(in))
+	resp, err := r.runtimeClient.RemovePodSandbox(ctx, in)
+	if err != nil {
+		glog.Errorf("FAIL: RemovePodSandbox(): RemovePodSandbox %q from runtime service failed: %v", in.GetPodSandboxId(), err)
+		return nil, err
+	}
+
+	glog.Infof("LEAVE: RemovePodSandbox(): %s", spew.Sdump(resp))
+	return resp, nil
+}
+
+// PodSandboxStatus returns ruRemoteRuntimeServicentiSandbox.
+func (r *RuntimeProxy) PodSandboxStatus(ctx context.Context, in *runtimeapi.PodSandboxStatusRequest) (*runtimeapi.PodSandboxStatusResponse, error) {
+	glog.Infof("ENTER: PodSandboxStatus(): %s", spew.Sdump(in))
+	resp, err := r.runtimeClient.PodSandboxStatus(ctx, in)
+	if err != nil {
+		glog.Errorf("FAIL: PodSandboxStatus(): PodSandboxStatus %q from runtime service failed: %v", in.GetPodSandboxId(), err)
+		return nil, err
+	}
+
+	glog.Infof("LEAVE: PodSandboxStatus(): %s", spew.Sdump(resp))
+	return resp, nil
+}
+
+// ListPodSandbox returns a list of PodSandboxes.
+func (r *RuntimeProxy) ListPodSandbox(ctx context.Context, in *runtimeapi.ListPodSandboxRequest) (*runtimeapi.ListPodSandboxResponse, error) {
+	glog.Infof("ENTER: ListPodSandbox(): %s", spew.Sdump(in))
+	resp, err := r.runtimeClient.ListPodSandbox(ctx, in)
+	if err != nil {
+		glog.Errorf("FAIL: ListPodSandbox(): ListPodSandbox with filter %q from runtime service failed: %v", in.GetFilter(), err)
+		return nil, err
+	}
+
+	glog.Infof("LEAVE: ListPodSandbox(): %s", spew.Sdump(resp))
+	return resp, nil
+}
+
+// CreateContainer creates a new container in the specified PodSandbox.
+func (r *RuntimeProxy) CreateContainer(ctx context.Context, in *runtimeapi.CreateContainerRequest) (*runtimeapi.CreateContainerResponse, error) {
+	glog.Infof("ENTER: CreateContainer(): %s", spew.Sdump(in))
+	resp, err := r.runtimeClient.CreateContainer(ctx, in)
+	if err != nil {
+		glog.Errorf("FAIL: CreateContainer(): CreateContainer in sandbox %q from runtime service failed: %v", in.GetPodSandboxId(), err)
+		return nil, err
+	}
+
+	glog.Infof("LEAVE: CreateContainer(): %s", spew.Sdump(resp))
+	return resp, nil
+}
+
+// StartContainer starts the container.
+func (r *RuntimeProxy) StartContainer(ctx context.Context, in *runtimeapi.StartContainerRequest) (*runtimeapi.StartContainerResponse, error) {
+	glog.Infof("ENTER: StartContainer(): %s", spew.Sdump(in))
+	resp, err := r.runtimeClient.StartContainer(ctx, in)
+	if err != nil {
+		glog.Errorf("FAIL: StartContainer(): StartContainer %q from runtime service failed: %v", in.GetContainerId(), err)
+		return nil, err
+	}
+
+	glog.Infof("LEAVE: StartContainer(): %s", spew.Sdump(resp))
+	return resp, nil
+}
+
+// StopContainer stops a running container with a grace period (i.e., timeout).
+func (r *RuntimeProxy) StopContainer(ctx context.Context, in *runtimeapi.StopContainerRequest) (*runtimeapi.StopContainerResponse, error) {
+	glog.Infof("ENTER: StopContainer(): %s", spew.Sdump(in))
+	resp, err := r.runtimeClient.StopContainer(ctx, in)
+	if err != nil {
+		glog.Errorf("FAIL: StopContainer(): StopContainer %q from runtime service failed: %v", in.GetContainerId(), err)
+		return nil, err
+	}
+
+	glog.Infof("LEAVE: StopContainer(): %s", spew.Sdump(resp))
+	return resp, nil
+}
+
+// RemoveContainer removes the container. If the container is running, the container
+// should be forced to removal.
+func (r *RuntimeProxy) RemoveContainer(ctx context.Context, in *runtimeapi.RemoveContainerRequest) (*runtimeapi.RemoveContainerResponse, error) {
+	glog.Infof("ENTER: RemoveContainer(): %s", spew.Sdump(in))
+	resp, err := r.runtimeClient.RemoveContainer(ctx, in)
+	if err != nil {
+		glog.Errorf("FAIL: RemoveContainer(): RemoveContainer %q from runtime service failed: %v", in.GetContainerId(), err)
+		return nil, err
+	}
+
+	glog.Infof("LEAVE: RemoveContainer(): %s", spew.Sdump(resp))
+	return resp, nil
+}
+
+// ListContainers lists containers by filters.
+func (r *RuntimeProxy) ListContainers(ctx context.Context, in *runtimeapi.ListContainersRequest) (*runtimeapi.ListContainersResponse, error) {
+	glog.Infof("ENTER: ListContainers(): %s", spew.Sdump(in))
+	resp, err := r.runtimeClient.ListContainers(ctx, in)
+	if err != nil {
+		glog.Errorf("FAIL: ListContainers(): ListContainers with filter %q from runtime service failed: %v", in.GetFilter(), err)
+		return nil, err
+	}
+
+	glog.Infof("LEAVE: ListContainers(): %s", spew.Sdump(resp))
+	return resp, nil
+}
+
+// ContainerStatus returns the container status.
+func (r *RuntimeProxy) ContainerStatus(ctx context.Context, in *runtimeapi.ContainerStatusRequest) (*runtimeapi.ContainerStatusResponse, error) {
+	glog.Infof("ENTER: ContainerStatus(): %s", spew.Sdump(in))
+	resp, err := r.runtimeClient.ContainerStatus(ctx, in)
+	if err != nil {
+		glog.Errorf("FAIL: ContainerStatus(): ContainerStatus %q from runtime service failed: %v", in.GetContainerId(), err)
+		return nil, err
+	}
+
+	glog.Infof("LEAVE: ContainerStatus(): %s", spew.Sdump(resp))
+	return resp, nil
+}
+
+// ExecSync executes a command in the container, and returns the stdout output.
+// If command exits with a non-zero exit code, an error is returned.
+func (r *RuntimeProxy) ExecSync(ctx context.Context, in *runtimeapi.ExecSyncRequest) (*runtimeapi.ExecSyncResponse, error) {
+	glog.Infof("ENTER: ExecSync(): %s", spew.Sdump(in))
+	resp, err := r.runtimeClient.ExecSync(ctx, in)
+	if err != nil {
+		glog.Errorf("FAIL: ExecSync(): ExecSync %s '%s' from runtime service failed: %v", in.GetContainerId(), strings.Join(in.GetCmd(), " "), err)
+		return nil, err
+	}
+
+	glog.Infof("LEAVE: ExecSync(): %s", spew.Sdump(resp))
+	return resp, nil
+}
+
+// Exec prepares a streaming endpoint to execute a command in the container, and returns the address.
+func (r *RuntimeProxy) Exec(ctx context.Context, in *runtimeapi.ExecRequest) (*runtimeapi.ExecResponse, error) {
+	glog.Infof("ENTER: Exec(): %s", spew.Sdump(in))
+	resp, err := r.runtimeClient.Exec(ctx, in)
+	if err != nil {
+		glog.Errorf("FAIL: Exec(): Exec %s '%s' from runtime service failed: %v", in.GetContainerId(), strings.Join(in.GetCmd(), " "), err)
+		return nil, err
+	}
+
+	glog.Infof("LEAVE: Exec(): %s", spew.Sdump(resp))
+	return resp, nil
+}
+
+// Attach prepares a streaming endpoint to attach to a running container, and returns the address.
+func (r *RuntimeProxy) Attach(ctx context.Context, in *runtimeapi.AttachRequest) (*runtimeapi.AttachResponse, error) {
+	glog.Infof("ENTER: Attach(): %s", spew.Sdump(in))
+	resp, err := r.runtimeClient.Attach(ctx, in)
+	if err != nil {
+		glog.Errorf("FAIL: Attach(): Attach %s from runtime service failed: %v", in.GetContainerId(), err)
+		return nil, err
+	}
+
+	glog.Infof("LEAVE: Attach(): %s", spew.Sdump(resp))
+	return resp, nil
+}
+
+// PortForward prepares a streaming endpoint to forward ports from a PodSandbox, and returns the address.
+func (r *RuntimeProxy) PortForward(ctx context.Context, in *runtimeapi.PortForwardRequest) (*runtimeapi.PortForwardResponse, error) {
+	glog.Infof("ENTER: PortForward(): %s", spew.Sdump(in))
+	resp, err := r.runtimeClient.PortForward(ctx, in)
+	if err != nil {
+		glog.Errorf("FAIL: PortForward(): PortForward %s from runtime service failed: %v", in.GetPodSandboxId(), err)
+		return nil, err
+	}
+
+	glog.Infof("LEAVE: PortForward(): %s", spew.Sdump(resp))
+	return resp, nil
+}
+
+// UpdateRuntimeConfig updates the config of a runtime service. The only
+// update payload currently supported is the pod CIDR assigned to a node,
+// and the runtime service just proxies it down to the network plugin.
+func (r *RuntimeProxy) UpdateRuntimeConfig(ctx context.Context, in *runtimeapi.UpdateRuntimeConfigRequest) (*runtimeapi.UpdateRuntimeConfigResponse, error) {
+	glog.Infof("ENTER: UpdateRuntimeConfig(): %s", spew.Sdump(in))
+	resp, err := r.runtimeClient.UpdateRuntimeConfig(ctx, in)
+
+	if err != nil {
+		glog.Errorf("FAIL: UpdateRuntimeConfig(): UpdateRuntimeConfig from runtime service failed: %v", err)
+		return nil, err
+	}
+
+	glog.Infof("LEAVE: UpdateRuntimeConfig(): %s", spew.Sdump(resp))
+	return resp, nil
+}
+
+// Status returns the status of the runtime.
+func (r *RuntimeProxy) Status(ctx context.Context, in *runtimeapi.StatusRequest) (*runtimeapi.StatusResponse, error) {
+	glog.Infof("ENTER: Status(): %s", spew.Sdump(in))
+	resp, err := r.runtimeClient.Status(ctx, in)
+	if err != nil {
+		glog.Errorf("FAIL: Status(): Status from runtime service failed: %v", err)
+		return nil, err
+	}
+
+	glog.Infof("LEAVE: Status(): %s", spew.Sdump(resp))
+	return resp, nil
+}
+
+// ImageServiceServer methods follow
+
+// ListImages lists available images.
+func (r *RuntimeProxy) ListImages(ctx context.Context, in *runtimeapi.ListImagesRequest) (*runtimeapi.ListImagesResponse, error) {
+	glog.Infof("ENTER: ListImages(): %s", spew.Sdump(in))
+	resp, err := r.imageClient.ListImages(ctx, in)
+	if err != nil {
+		glog.Errorf("FAIL: ListImages(): ListImages with filter %q from image service failed: %v", in.GetFilter(), err)
+		return nil, err
+	}
+
+	glog.Infof("LEAVE: ListImages(): %s", spew.Sdump(resp))
+	return resp, nil
+}
+
+// ImageStatus returns the status of the image.
+func (r *RuntimeProxy) ImageStatus(ctx context.Context, in *runtimeapi.ImageStatusRequest) (*runtimeapi.ImageStatusResponse, error) {
+	glog.Infof("ENTER: ImageStatus(): %s", spew.Sdump(in))
+	resp, err := r.imageClient.ImageStatus(ctx, in)
+	if err != nil {
+		glog.Errorf("FAIL: ImageStatus(): ImageStatus %q from image service failed: %v", in.GetImage().GetImage(), err)
+		return nil, err
+	}
+
+	glog.Infof("LEAVE: ImageStatus(): %s", spew.Sdump(resp))
+	return resp, nil
+}
+
+// PullImage pulls an image with authentication config.
+func (r *RuntimeProxy) PullImage(ctx context.Context, in *runtimeapi.PullImageRequest) (*runtimeapi.PullImageResponse, error) {
+	glog.Infof("ENTER: PullImage(): %s", spew.Sdump(in))
+	resp, err := r.imageClient.PullImage(ctx, in)
+	if err != nil {
+		glog.Errorf("FAIL: PullImage(): PullImage %q from image service failed: %v", in.GetImage().GetImage(), err)
+		return nil, err
+	}
+
+	glog.Infof("LEAVE: PullImage(): %s", spew.Sdump(resp))
+	return resp, nil
+}
+
+// RemoveImage removes the image.
+func (r *RuntimeProxy) RemoveImage(ctx context.Context, in *runtimeapi.RemoveImageRequest) (*runtimeapi.RemoveImageResponse, error) {
+	glog.Infof("ENTER: RemoveImage(): %s", spew.Sdump(in))
+	resp, err := r.imageClient.RemoveImage(ctx, in)
+	if err != nil {
+		glog.Errorf("FAIL: RemoveImage(): RemoveImage %q from image service failed: %v", in.GetImage().GetImage(), err)
+		return nil, err
+	}
+
+	glog.Infof("LEAVE: RemoveImage(): %s", spew.Sdump(resp))
+	return resp, nil
+}
+
+// TODO: remove all of the following
+
+// var removeThis1 runtimeapi.RuntimeServiceServer = &RuntimeProxy{}
+// var removeThis2 runtimeapi.ImageServiceServer = &RuntimeProxy{}
+
+func init() {
+	// Make spew output more readable for k8s runtime API objects
+	spew.Config.DisableMethods = true
+	spew.Config.DisablePointerMethods = true
+}

--- a/pkg/criproxy/proxy.go
+++ b/pkg/criproxy/proxy.go
@@ -12,10 +12,26 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+Based on pkg/kubelet/remote/remote_runtime.go and pkg/kubelet/remote/remote_image.go
+from Kubernetes project.
+Original copyright notice follows:
+
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
-// TODO: credits
-// (based on remote_runtime.go and remote_image.go from k8s)
 package criproxy
 
 import (

--- a/pkg/criproxy/proxy.go
+++ b/pkg/criproxy/proxy.go
@@ -40,8 +40,7 @@ type clientState int
 const (
 	targetRuntimeAnnotationKey = "kubernetes.io/target-runtime"
 	// FIXME: make the following configurable
-	numConnectAttempts     = 300
-	connectAttemptInterval = 200 * time.Millisecond
+	connectAttemptInterval = 500 * time.Millisecond
 	clientStateOffline     = clientState(iota)
 	clientStateConnecting
 	clientStateConnected
@@ -84,15 +83,13 @@ func (c *apiClient) isPrimary() bool {
 
 func (c *apiClient) waitForSocket() error {
 	var err error
-	for i := 0; i < numConnectAttempts; i++ {
-		if i > 0 {
-			time.Sleep(connectAttemptInterval)
-		}
+	for {
 		if _, err = os.Stat(c.addr); err != nil {
 			glog.V(1).Infof("%q is not here yet: %s", c.addr, err)
 		} else {
 			break
 		}
+		time.Sleep(connectAttemptInterval)
 	}
 	return err
 }

--- a/pkg/criproxy/proxy_test.go
+++ b/pkg/criproxy/proxy_test.go
@@ -63,6 +63,10 @@ func pstr(s string) *string {
 	return &s
 }
 
+func pbool(b bool) *bool {
+	return &b
+}
+
 func puint64(v uint64) *uint64 {
 	return &v
 }
@@ -104,6 +108,40 @@ func TestCriProxy(t *testing.T) {
 		in, resp     interface{}
 		journal      []string
 	}{
+		{
+			name:   "version",
+			method: "/runtime.RuntimeService/Version",
+			in:     &runtimeapi.VersionRequest{},
+			resp: &runtimeapi.VersionResponse{
+				Version:           pstr("0.1.0"),
+				RuntimeName:       pstr("fakeRuntime"),
+				RuntimeVersion:    pstr("0.1.0"),
+				RuntimeApiVersion: pstr("0.1.0"),
+			},
+			journal: []string{"1/runtime/Version"},
+		},
+		{
+			name:   "status",
+			method: "/runtime.RuntimeService/Status",
+			in:     &runtimeapi.StatusRequest{},
+			resp: &runtimeapi.StatusResponse{
+				Status: &runtimeapi.RuntimeStatus{
+					Conditions: []*runtimeapi.RuntimeCondition{
+						{
+							Type:   pstr("RuntimeReady"),
+							Status: pbool(true),
+						},
+						{
+							Type:   pstr("NetworkReady"),
+							Status: pbool(true),
+						},
+					},
+				},
+			},
+			// FIXME: actually, both runtimes need to be contacted and
+			// the result needs to be combined
+			journal: []string{"1/runtime/Status"},
+		},
 		{
 			name:   "list images",
 			method: "/runtime.ImageService/ListImages",
@@ -305,3 +343,5 @@ func TestCriProxy(t *testing.T) {
 		})
 	}
 }
+
+// TODO: proper status handling (contact both runtimes, etc.)

--- a/pkg/criproxy/proxy_test.go
+++ b/pkg/criproxy/proxy_test.go
@@ -1217,5 +1217,6 @@ func init() {
 	flag.Set("v", "5")
 }
 
+// TODO: never wait for the client to connect, just err
 // TODO: proper status handling (contact both runtimes, etc.)
 // TODO: make sure patching requests/responses is ok & if it is, don't use copying for them

--- a/pkg/criproxy/proxy_test.go
+++ b/pkg/criproxy/proxy_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2016 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package criproxy
+
+import (
+	"testing"
+	"time"
+
+	// "github.com/davecgh/go-spew/spew"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	runtimeapi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
+	"reflect"
+
+	proxytest "github.com/Mirantis/virtlet/pkg/criproxy/testing"
+)
+
+const (
+	fakeCriSocketPath         = "/tmp/fake-cri.socket"
+	criProxySocketForTests    = "/tmp/cri-proxy.socket"
+	connectionTimeoutForTests = 20 * time.Second
+	fakeImageSize             = uint64(424242)
+)
+
+type ServerWithReadinessFeedback interface {
+	Serve(addr string, readyCh chan struct{}) error
+}
+
+func startServer(t *testing.T, s ServerWithReadinessFeedback, addr string) {
+	readyCh := make(chan struct{})
+	errCh := make(chan error)
+	go func() {
+		if err := s.Serve(addr, readyCh); err != nil {
+			errCh <- err
+		}
+	}()
+	select {
+	case err := <-errCh:
+		t.Fatalf("Failed to start fake CRI server: %v", err)
+	case <-readyCh:
+	}
+}
+
+func TestCriProxy(t *testing.T) {
+	criServer := proxytest.NewFakeCriServer()
+	defer criServer.Stop()
+	// TODO: don't wait for the server to start, the proxy should do it
+	startServer(t, criServer, fakeCriSocketPath)
+
+	proxy, err := NewRuntimeProxy(fakeCriSocketPath, connectionTimeoutForTests)
+	if err != nil {
+		// TODO: NewRuntimeProxy() shouldn't do any real work
+		t.Fatalf("Failed to set up CRI proxy: %v", err)
+	}
+	defer proxy.Stop()
+	startServer(t, proxy, criProxySocketForTests)
+
+	conn, err := grpc.Dial(criProxySocketForTests, grpc.WithInsecure(), grpc.WithTimeout(connectionTimeoutForTests), grpc.WithDialer(dial))
+	if err != nil {
+		t.Fatalf("Connect remote runtime %s failed: %v", fakeCriSocketPath, err)
+	}
+	defer conn.Close()
+	imageClient := runtimeapi.NewImageServiceClient(conn)
+
+	fakeImageNames := []string{"image1", "image2"}
+	criServer.SetFakeImages(fakeImageNames)
+	criServer.SetFakeImageSize(fakeImageSize)
+
+	resp, err := imageClient.ListImages(context.Background(), &runtimeapi.ListImagesRequest{})
+	if err != nil {
+		t.Fatalf("ListImages() failed: %v", err)
+	}
+
+	var repoTags []string
+	for _, image := range resp.GetImages() {
+		imageRepoTags := image.GetRepoTags()
+		if len(imageRepoTags) != 1 {
+			t.Errorf("bad repo tags for image: %#v", imageRepoTags)
+			continue
+		}
+		if image.GetSize_() != fakeImageSize {
+			t.Errorf("bad image size for image %q: %v instead of %v", imageRepoTags[0], image.GetSize_(), fakeImageSize)
+		}
+		repoTags = append(repoTags, imageRepoTags[0])
+	}
+	if !reflect.DeepEqual(fakeImageNames, repoTags) {
+		t.Errorf("bad image tags returned: %#v instead of %#v", repoTags, fakeImageNames)
+	}
+}

--- a/pkg/criproxy/testing/fake_cri_server.go
+++ b/pkg/criproxy/testing/fake_cri_server.go
@@ -31,10 +31,10 @@ type FakeCriServer struct {
 	server *grpc.Server
 }
 
-func NewFakeCriServer() *FakeCriServer {
+func NewFakeCriServer(journal Journal) *FakeCriServer {
 	s := &FakeCriServer{
-		FakeRuntimeServer: NewFakeRuntimeServer(),
-		FakeImageServer:   NewFakeImageServer(),
+		FakeRuntimeServer: NewFakeRuntimeServer(NewPrefixJournal(journal, "runtime/")),
+		FakeImageServer:   NewFakeImageServer(NewPrefixJournal(journal, "image/")),
 		server:            grpc.NewServer(),
 	}
 	runtimeapi.RegisterRuntimeServiceServer(s.server, s)

--- a/pkg/criproxy/testing/fake_cri_server.go
+++ b/pkg/criproxy/testing/fake_cri_server.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2016 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"net"
+	"os"
+	"syscall"
+
+	"google.golang.org/grpc"
+	runtimeapi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
+)
+
+type FakeCriServer struct {
+	*FakeRuntimeServer
+	*FakeImageServer
+	server *grpc.Server
+}
+
+func NewFakeCriServer() *FakeCriServer {
+	s := &FakeCriServer{
+		FakeRuntimeServer: NewFakeRuntimeServer(),
+		FakeImageServer:   NewFakeImageServer(),
+		server:            grpc.NewServer(),
+	}
+	runtimeapi.RegisterRuntimeServiceServer(s.server, s)
+	runtimeapi.RegisterImageServiceServer(s.server, s)
+	return s
+}
+
+func (s *FakeCriServer) Serve(addr string, readyCh chan struct{}) error {
+	if err := syscall.Unlink(addr); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	ln, err := net.Listen("unix", addr)
+	if err != nil {
+		return err
+	}
+	defer ln.Close()
+	if readyCh != nil {
+		close(readyCh)
+	}
+	return s.server.Serve(ln)
+}
+
+func (s *FakeCriServer) Stop() {
+	s.server.Stop()
+}

--- a/pkg/criproxy/testing/fake_image_server.go
+++ b/pkg/criproxy/testing/fake_image_server.go
@@ -19,6 +19,7 @@ limitations under the License.
 package testing
 
 import (
+	"sort"
 	"sync"
 
 	"golang.org/x/net/context"
@@ -71,9 +72,16 @@ func (r *FakeImageServer) ListImages(ctx context.Context, in *runtimeapi.ListIma
 
 	r.Called = append(r.Called, "ListImages")
 
+	var imageNames []string
+	for imageName, _ := range r.Images {
+		imageNames = append(imageNames, imageName)
+	}
+	sort.Strings(imageNames)
+
 	filter := in.GetFilter()
 	images := make([]*runtimeapi.Image, 0)
-	for _, img := range r.Images {
+	for _, name := range imageNames {
+		img := r.Images[name]
 		if filter != nil && filter.Image != nil {
 			imageName := filter.Image.GetImage()
 			found := false

--- a/pkg/criproxy/testing/fake_image_server.go
+++ b/pkg/criproxy/testing/fake_image_server.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2016 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// TODO: credits
+// (based on fake_image_service.go from k8s)
+package testing
+
+import (
+	"sync"
+
+	"golang.org/x/net/context"
+	runtimeapi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
+)
+
+type FakeImageServer struct {
+	sync.Mutex
+
+	FakeImageSize uint64
+	Called        []string
+	Images        map[string]*runtimeapi.Image
+}
+
+func (r *FakeImageServer) SetFakeImages(images []string) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Images = make(map[string]*runtimeapi.Image)
+	for _, image := range images {
+		r.Images[image] = r.makeFakeImage(image)
+	}
+}
+
+func (r *FakeImageServer) SetFakeImageSize(size uint64) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.FakeImageSize = size
+}
+
+func NewFakeImageServer() *FakeImageServer {
+	return &FakeImageServer{
+		Called: make([]string, 0),
+		Images: make(map[string]*runtimeapi.Image),
+	}
+}
+
+func (r *FakeImageServer) makeFakeImage(image string) *runtimeapi.Image {
+	return &runtimeapi.Image{
+		Id:       &image,
+		Size_:    &r.FakeImageSize,
+		RepoTags: []string{image},
+	}
+}
+
+func (r *FakeImageServer) ListImages(ctx context.Context, in *runtimeapi.ListImagesRequest) (*runtimeapi.ListImagesResponse, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "ListImages")
+
+	filter := in.GetFilter()
+	images := make([]*runtimeapi.Image, 0)
+	for _, img := range r.Images {
+		if filter != nil && filter.Image != nil {
+			imageName := filter.Image.GetImage()
+			found := false
+			for _, tag := range img.RepoTags {
+				if imageName == tag {
+					found = true
+					break
+				}
+			}
+			if !found {
+				continue
+			}
+		}
+
+		images = append(images, img)
+	}
+	return &runtimeapi.ListImagesResponse{Images: images}, nil
+}
+
+func (r *FakeImageServer) ImageStatus(ctx context.Context, in *runtimeapi.ImageStatusRequest) (*runtimeapi.ImageStatusResponse, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "ImageStatus")
+
+	image := in.GetImage()
+	return &runtimeapi.ImageStatusResponse{Image: r.Images[image.GetImage()]}, nil
+}
+
+func (r *FakeImageServer) PullImage(ctx context.Context, in *runtimeapi.PullImageRequest) (*runtimeapi.PullImageResponse, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "PullImage")
+
+	// ImageID should be randomized for real container runtime, but here just use
+	// image's name for easily making fake images.
+	image := in.GetImage()
+	imageID := image.GetImage()
+	if _, ok := r.Images[imageID]; !ok {
+		r.Images[imageID] = r.makeFakeImage(image.GetImage())
+	}
+
+	return &runtimeapi.PullImageResponse{}, nil
+}
+
+func (r *FakeImageServer) RemoveImage(ctx context.Context, in *runtimeapi.RemoveImageRequest) (*runtimeapi.RemoveImageResponse, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "RemoveImage")
+
+	// Remove the image
+	image := in.GetImage()
+	delete(r.Images, image.GetImage())
+
+	return &runtimeapi.RemoveImageResponse{}, nil
+}

--- a/pkg/criproxy/testing/fake_image_server.go
+++ b/pkg/criproxy/testing/fake_image_server.go
@@ -29,8 +29,8 @@ import (
 type FakeImageServer struct {
 	sync.Mutex
 
+	journal       Journal
 	FakeImageSize uint64
-	Called        []string
 	Images        map[string]*runtimeapi.Image
 }
 
@@ -51,10 +51,10 @@ func (r *FakeImageServer) SetFakeImageSize(size uint64) {
 	r.FakeImageSize = size
 }
 
-func NewFakeImageServer() *FakeImageServer {
+func NewFakeImageServer(journal Journal) *FakeImageServer {
 	return &FakeImageServer{
-		Called: make([]string, 0),
-		Images: make(map[string]*runtimeapi.Image),
+		journal: journal,
+		Images:  make(map[string]*runtimeapi.Image),
 	}
 }
 
@@ -70,7 +70,7 @@ func (r *FakeImageServer) ListImages(ctx context.Context, in *runtimeapi.ListIma
 	r.Lock()
 	defer r.Unlock()
 
-	r.Called = append(r.Called, "ListImages")
+	r.journal.Record("ListImages")
 
 	var imageNames []string
 	for imageName, _ := range r.Images {
@@ -105,7 +105,7 @@ func (r *FakeImageServer) ImageStatus(ctx context.Context, in *runtimeapi.ImageS
 	r.Lock()
 	defer r.Unlock()
 
-	r.Called = append(r.Called, "ImageStatus")
+	r.journal.Record("ImageStatus")
 
 	image := in.GetImage()
 	return &runtimeapi.ImageStatusResponse{Image: r.Images[image.GetImage()]}, nil
@@ -115,7 +115,7 @@ func (r *FakeImageServer) PullImage(ctx context.Context, in *runtimeapi.PullImag
 	r.Lock()
 	defer r.Unlock()
 
-	r.Called = append(r.Called, "PullImage")
+	r.journal.Record("PullImage")
 
 	// ImageID should be randomized for real container runtime, but here just use
 	// image's name for easily making fake images.
@@ -132,7 +132,7 @@ func (r *FakeImageServer) RemoveImage(ctx context.Context, in *runtimeapi.Remove
 	r.Lock()
 	defer r.Unlock()
 
-	r.Called = append(r.Called, "RemoveImage")
+	r.journal.Record("RemoveImage")
 
 	// Remove the image
 	image := in.GetImage()

--- a/pkg/criproxy/testing/fake_runtime_server.go
+++ b/pkg/criproxy/testing/fake_runtime_server.go
@@ -82,8 +82,23 @@ func (r *FakeRuntimeServer) SetFakeContainers(containers []*FakeContainer) {
 }
 
 func NewFakeRuntimeServer(journal Journal) *FakeRuntimeServer {
+	ready := true
+	runtimeReadyStr := runtimeapi.RuntimeReady
+	networkReadyStr := runtimeapi.NetworkReady
 	return &FakeRuntimeServer{
-		journal:    journal,
+		journal: journal,
+		FakeStatus: &runtimeapi.RuntimeStatus{
+			Conditions: []*runtimeapi.RuntimeCondition{
+				{
+					Type:   &runtimeReadyStr,
+					Status: &ready,
+				},
+				{
+					Type:   &networkReadyStr,
+					Status: &ready,
+				},
+			},
+		},
 		Containers: make(map[string]*FakeContainer),
 		Sandboxes:  make(map[string]*FakePodSandbox),
 	}

--- a/pkg/criproxy/testing/fake_runtime_server.go
+++ b/pkg/criproxy/testing/fake_runtime_server.go
@@ -12,10 +12,25 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+Based on fake_runtime_service.go from Kubernetes project.
+Original copyright notice follows:
+
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
-// TODO: credits
-// (based on fake_runtime_service.go from k8s)
 package testing
 
 import (

--- a/pkg/criproxy/testing/fake_runtime_server.go
+++ b/pkg/criproxy/testing/fake_runtime_server.go
@@ -108,9 +108,6 @@ func NewFakeRuntimeServer(journal Journal) *FakeRuntimeServer {
 }
 
 func (r *FakeRuntimeServer) Version(ctx context.Context, in *runtimeapi.VersionRequest) (*runtimeapi.VersionResponse, error) {
-	r.Lock()
-	defer r.Unlock()
-
 	r.journal.Record("Version")
 
 	return &runtimeapi.VersionResponse{
@@ -122,11 +119,7 @@ func (r *FakeRuntimeServer) Version(ctx context.Context, in *runtimeapi.VersionR
 }
 
 func (r *FakeRuntimeServer) Status(ctx context.Context, in *runtimeapi.StatusRequest) (*runtimeapi.StatusResponse, error) {
-	r.Lock()
-	defer r.Unlock()
-
 	r.journal.Record("Status")
-
 	return &runtimeapi.StatusResponse{Status: r.FakeStatus}, nil
 }
 
@@ -388,38 +381,27 @@ func (r *FakeRuntimeServer) ContainerStatus(ctx context.Context, in *runtimeapi.
 }
 
 func (r *FakeRuntimeServer) ExecSync(ctx context.Context, in *runtimeapi.ExecSyncRequest) (*runtimeapi.ExecSyncResponse, error) {
-	r.Lock()
-	defer r.Unlock()
-
 	r.journal.Record("ExecSync")
 	exitCode := int32(0)
 	return &runtimeapi.ExecSyncResponse{Stdout: nil, Stderr: nil, ExitCode: &exitCode}, nil
 }
 
 func (r *FakeRuntimeServer) Exec(ctx context.Context, in *runtimeapi.ExecRequest) (*runtimeapi.ExecResponse, error) {
-	r.Lock()
-	defer r.Unlock()
-
 	r.journal.Record("Exec")
 	return &runtimeapi.ExecResponse{}, nil
 }
 
 func (r *FakeRuntimeServer) Attach(ctx context.Context, in *runtimeapi.AttachRequest) (*runtimeapi.AttachResponse, error) {
-	r.Lock()
-	defer r.Unlock()
-
 	r.journal.Record("Attach")
 	return &runtimeapi.AttachResponse{}, nil
 }
 
 func (r *FakeRuntimeServer) PortForward(ctx context.Context, in *runtimeapi.PortForwardRequest) (*runtimeapi.PortForwardResponse, error) {
-	r.Lock()
-	defer r.Unlock()
-
 	r.journal.Record("PortForward")
 	return &runtimeapi.PortForwardResponse{}, nil
 }
 
 func (r *FakeRuntimeServer) UpdateRuntimeConfig(ctx context.Context, in *runtimeapi.UpdateRuntimeConfigRequest) (*runtimeapi.UpdateRuntimeConfigResponse, error) {
+	r.journal.Record("UpdateRuntimeConfig")
 	return &runtimeapi.UpdateRuntimeConfigResponse{}, nil
 }

--- a/pkg/criproxy/testing/fake_runtime_server.go
+++ b/pkg/criproxy/testing/fake_runtime_server.go
@@ -21,6 +21,7 @@ package testing
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"sync"
 	"time"
 
@@ -224,9 +225,16 @@ func (r *FakeRuntimeServer) ListPodSandbox(ctx context.Context, in *runtimeapi.L
 
 	r.Called = append(r.Called, "ListPodSandbox")
 
+	var ids []string
+	for id, _ := range r.Sandboxes {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
 	filter := in.GetFilter()
 	result := make([]*runtimeapi.PodSandbox, 0)
-	for id, s := range r.Sandboxes {
+	for _, id := range ids {
+		s := r.Sandboxes[id]
 		if filter != nil {
 			if filter.Id != nil && filter.GetId() != id {
 				continue
@@ -343,9 +351,16 @@ func (r *FakeRuntimeServer) ListContainers(ctx context.Context, in *runtimeapi.L
 
 	r.Called = append(r.Called, "ListContainers")
 
+	var ids []string
+	for id, _ := range r.Containers {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
 	filter := in.GetFilter()
 	result := make([]*runtimeapi.Container, 0)
-	for _, s := range r.Containers {
+	for _, id := range ids {
+		s := r.Containers[id]
 		if filter != nil {
 			if filter.Id != nil && filter.GetId() != s.GetId() {
 				continue

--- a/pkg/criproxy/testing/fake_runtime_server.go
+++ b/pkg/criproxy/testing/fake_runtime_server.go
@@ -1,0 +1,430 @@
+/*
+Copyright 2016 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// TODO: credits
+// (based on fake_runtime_service.go and utils.go [from the same dir] from k8s)
+package testing
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+	"time"
+
+	"golang.org/x/net/context"
+	runtimeapi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
+)
+
+var (
+	version = "0.1.0"
+
+	FakeRuntimeName  = "fakeRuntime"
+	FakePodSandboxIP = "192.168.192.168"
+)
+
+func BuildContainerName(metadata *runtimeapi.ContainerMetadata, sandboxID string) string {
+	// include the sandbox ID to make the container ID unique.
+	return fmt.Sprintf("%s_%s_%d", sandboxID, metadata.GetName(), metadata.GetAttempt())
+}
+
+func BuildSandboxName(metadata *runtimeapi.PodSandboxMetadata) string {
+	return fmt.Sprintf("%s_%s_%s_%d", metadata.GetName(), metadata.GetNamespace(), metadata.GetUid(), metadata.GetAttempt())
+}
+
+func filterInLabels(filter, labels map[string]string) bool {
+	for k, v := range filter {
+		if value, ok := labels[k]; ok {
+			if value != v {
+				return false
+			}
+		} else {
+			return false
+		}
+	}
+
+	return true
+}
+
+type FakePodSandbox struct {
+	// PodSandboxStatus contains the runtime information for a sandbox.
+	runtimeapi.PodSandboxStatus
+}
+
+type FakeContainer struct {
+	// ContainerStatus contains the runtime information for a container.
+	runtimeapi.ContainerStatus
+
+	// the sandbox id of this container
+	SandboxID string
+}
+
+type FakeRuntimeServer struct {
+	sync.Mutex
+
+	Called []string
+
+	FakeStatus *runtimeapi.RuntimeStatus
+	Containers map[string]*FakeContainer
+	Sandboxes  map[string]*FakePodSandbox
+}
+
+func (r *FakeRuntimeServer) SetFakeSandboxes(sandboxes []*FakePodSandbox) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Sandboxes = make(map[string]*FakePodSandbox)
+	for _, sandbox := range sandboxes {
+		sandboxID := sandbox.GetId()
+		r.Sandboxes[sandboxID] = sandbox
+	}
+}
+
+func (r *FakeRuntimeServer) SetFakeContainers(containers []*FakeContainer) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Containers = make(map[string]*FakeContainer)
+	for _, c := range containers {
+		containerID := c.GetId()
+		r.Containers[containerID] = c
+	}
+
+}
+
+func (r *FakeRuntimeServer) AssertCalls(calls []string) error {
+	r.Lock()
+	defer r.Unlock()
+
+	if !reflect.DeepEqual(calls, r.Called) {
+		return fmt.Errorf("expected %#v, got %#v", calls, r.Called)
+	}
+	return nil
+}
+
+func NewFakeRuntimeServer() *FakeRuntimeServer {
+	return &FakeRuntimeServer{
+		Called:     make([]string, 0),
+		Containers: make(map[string]*FakeContainer),
+		Sandboxes:  make(map[string]*FakePodSandbox),
+	}
+}
+
+func (r *FakeRuntimeServer) Version(ctx context.Context, in *runtimeapi.VersionRequest) (*runtimeapi.VersionResponse, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "Version")
+
+	return &runtimeapi.VersionResponse{
+		Version:           &version,
+		RuntimeName:       &FakeRuntimeName,
+		RuntimeVersion:    &version,
+		RuntimeApiVersion: &version,
+	}, nil
+}
+
+func (r *FakeRuntimeServer) Status(ctx context.Context, in *runtimeapi.StatusRequest) (*runtimeapi.StatusResponse, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "Status")
+
+	return &runtimeapi.StatusResponse{Status: r.FakeStatus}, nil
+}
+
+func (r *FakeRuntimeServer) RunPodSandbox(ctx context.Context, in *runtimeapi.RunPodSandboxRequest) (*runtimeapi.RunPodSandboxResponse, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "RunPodSandbox")
+
+	// PodSandboxID should be randomized for real container runtime, but here just use
+	// fixed name from BuildSandboxName() for easily making fake sandboxes.
+	config := in.GetConfig()
+	podSandboxID := BuildSandboxName(config.Metadata)
+	createdAt := time.Now().Unix()
+	readyState := runtimeapi.PodSandboxState_SANDBOX_READY
+	r.Sandboxes[podSandboxID] = &FakePodSandbox{
+		PodSandboxStatus: runtimeapi.PodSandboxStatus{
+			Id:        &podSandboxID,
+			Metadata:  config.Metadata,
+			State:     &readyState,
+			CreatedAt: &createdAt,
+			Network: &runtimeapi.PodSandboxNetworkStatus{
+				Ip: &FakePodSandboxIP,
+			},
+			Labels:      config.Labels,
+			Annotations: config.Annotations,
+		},
+	}
+
+	return &runtimeapi.RunPodSandboxResponse{PodSandboxId: &podSandboxID}, nil
+}
+
+func (r *FakeRuntimeServer) StopPodSandbox(ctx context.Context, in *runtimeapi.StopPodSandboxRequest) (*runtimeapi.StopPodSandboxResponse, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "StopPodSandbox")
+
+	podSandboxID := in.GetPodSandboxId()
+	notReadyState := runtimeapi.PodSandboxState_SANDBOX_NOTREADY
+	if s, ok := r.Sandboxes[podSandboxID]; ok {
+		s.State = &notReadyState
+	} else {
+		return nil, fmt.Errorf("pod sandbox %s not found", podSandboxID)
+	}
+
+	return &runtimeapi.StopPodSandboxResponse{}, nil
+}
+
+func (r *FakeRuntimeServer) RemovePodSandbox(ctx context.Context, in *runtimeapi.RemovePodSandboxRequest) (*runtimeapi.RemovePodSandboxResponse, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "RemovePodSandbox")
+
+	// Remove the pod sandbox
+	delete(r.Sandboxes, in.GetPodSandboxId())
+
+	return &runtimeapi.RemovePodSandboxResponse{}, nil
+}
+
+func (r *FakeRuntimeServer) PodSandboxStatus(ctx context.Context, in *runtimeapi.PodSandboxStatusRequest) (*runtimeapi.PodSandboxStatusResponse, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "PodSandboxStatus")
+
+	podSandboxID := in.GetPodSandboxId()
+	s, ok := r.Sandboxes[podSandboxID]
+	if !ok {
+		return nil, fmt.Errorf("pod sandbox %q not found", podSandboxID)
+	}
+
+	return &runtimeapi.PodSandboxStatusResponse{Status: &s.PodSandboxStatus}, nil
+}
+
+func (r *FakeRuntimeServer) ListPodSandbox(ctx context.Context, in *runtimeapi.ListPodSandboxRequest) (*runtimeapi.ListPodSandboxResponse, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "ListPodSandbox")
+
+	filter := in.GetFilter()
+	result := make([]*runtimeapi.PodSandbox, 0)
+	for id, s := range r.Sandboxes {
+		if filter != nil {
+			if filter.Id != nil && filter.GetId() != id {
+				continue
+			}
+			if filter.State != nil && filter.GetState() != s.GetState() {
+				continue
+			}
+			if filter.LabelSelector != nil && !filterInLabels(filter.LabelSelector, s.GetLabels()) {
+				continue
+			}
+		}
+
+		result = append(result, &runtimeapi.PodSandbox{
+			Id:          s.Id,
+			Metadata:    s.Metadata,
+			State:       s.State,
+			CreatedAt:   s.CreatedAt,
+			Labels:      s.Labels,
+			Annotations: s.Annotations,
+		})
+	}
+
+	return &runtimeapi.ListPodSandboxResponse{Items: result}, nil
+}
+
+func (r *FakeRuntimeServer) CreateContainer(ctx context.Context, in *runtimeapi.CreateContainerRequest) (*runtimeapi.CreateContainerResponse, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "CreateContainer")
+
+	// ContainerID should be randomized for real container runtime, but here just use
+	// fixed BuildContainerName() for easily making fake containers.
+	podSandboxID := in.GetPodSandboxId()
+	config := in.GetConfig()
+	containerID := BuildContainerName(config.Metadata, podSandboxID)
+	createdAt := time.Now().Unix()
+	createdState := runtimeapi.ContainerState_CONTAINER_CREATED
+	imageRef := config.Image.GetImage()
+	r.Containers[containerID] = &FakeContainer{
+		ContainerStatus: runtimeapi.ContainerStatus{
+			Id:          &containerID,
+			Metadata:    config.Metadata,
+			Image:       config.Image,
+			ImageRef:    &imageRef,
+			CreatedAt:   &createdAt,
+			State:       &createdState,
+			Labels:      config.Labels,
+			Annotations: config.Annotations,
+		},
+		SandboxID: podSandboxID,
+	}
+
+	return &runtimeapi.CreateContainerResponse{ContainerId: &containerID}, nil
+}
+
+func (r *FakeRuntimeServer) StartContainer(ctx context.Context, in *runtimeapi.StartContainerRequest) (*runtimeapi.StartContainerResponse, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "StartContainer")
+
+	containerID := in.GetContainerId()
+	c, ok := r.Containers[containerID]
+	if !ok {
+		return nil, fmt.Errorf("container %s not found", containerID)
+	}
+
+	// Set container to running.
+	startedAt := time.Now().Unix()
+	runningState := runtimeapi.ContainerState_CONTAINER_RUNNING
+	c.State = &runningState
+	c.StartedAt = &startedAt
+
+	return &runtimeapi.StartContainerResponse{}, nil
+}
+
+func (r *FakeRuntimeServer) StopContainer(ctx context.Context, in *runtimeapi.StopContainerRequest) (*runtimeapi.StopContainerResponse, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "StopContainer")
+
+	containerID := in.GetContainerId()
+	c, ok := r.Containers[containerID]
+	if !ok {
+		return nil, fmt.Errorf("container %q not found", containerID)
+	}
+
+	// Set container to exited state.
+	finishedAt := time.Now().Unix()
+	exitedState := runtimeapi.ContainerState_CONTAINER_EXITED
+	c.State = &exitedState
+	c.FinishedAt = &finishedAt
+
+	return &runtimeapi.StopContainerResponse{}, nil
+}
+
+func (r *FakeRuntimeServer) RemoveContainer(ctx context.Context, in *runtimeapi.RemoveContainerRequest) (*runtimeapi.RemoveContainerResponse, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "RemoveContainer")
+
+	// Remove the container
+	delete(r.Containers, in.GetContainerId())
+
+	return &runtimeapi.RemoveContainerResponse{}, nil
+}
+
+func (r *FakeRuntimeServer) ListContainers(ctx context.Context, in *runtimeapi.ListContainersRequest) (*runtimeapi.ListContainersResponse, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "ListContainers")
+
+	filter := in.GetFilter()
+	result := make([]*runtimeapi.Container, 0)
+	for _, s := range r.Containers {
+		if filter != nil {
+			if filter.Id != nil && filter.GetId() != s.GetId() {
+				continue
+			}
+			if filter.PodSandboxId != nil && filter.GetPodSandboxId() != s.SandboxID {
+				continue
+			}
+			if filter.State != nil && filter.GetState() != s.GetState() {
+				continue
+			}
+			if filter.LabelSelector != nil && !filterInLabels(filter.LabelSelector, s.GetLabels()) {
+				continue
+			}
+		}
+
+		result = append(result, &runtimeapi.Container{
+			Id:           s.Id,
+			CreatedAt:    s.CreatedAt,
+			PodSandboxId: &s.SandboxID,
+			Metadata:     s.Metadata,
+			State:        s.State,
+			Image:        s.Image,
+			ImageRef:     s.ImageRef,
+			Labels:       s.Labels,
+			Annotations:  s.Annotations,
+		})
+	}
+
+	return &runtimeapi.ListContainersResponse{Containers: result}, nil
+}
+
+func (r *FakeRuntimeServer) ContainerStatus(ctx context.Context, in *runtimeapi.ContainerStatusRequest) (*runtimeapi.ContainerStatusResponse, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "ContainerStatus")
+
+	containerID := in.GetContainerId()
+	c, ok := r.Containers[containerID]
+	if !ok {
+		return nil, fmt.Errorf("container %q not found", containerID)
+	}
+
+	return &runtimeapi.ContainerStatusResponse{Status: &c.ContainerStatus}, nil
+}
+
+func (r *FakeRuntimeServer) ExecSync(ctx context.Context, in *runtimeapi.ExecSyncRequest) (*runtimeapi.ExecSyncResponse, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "ExecSync")
+	exitCode := int32(0)
+	return &runtimeapi.ExecSyncResponse{Stdout: nil, Stderr: nil, ExitCode: &exitCode}, nil
+}
+
+func (r *FakeRuntimeServer) Exec(ctx context.Context, in *runtimeapi.ExecRequest) (*runtimeapi.ExecResponse, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "Exec")
+	return &runtimeapi.ExecResponse{}, nil
+}
+
+func (r *FakeRuntimeServer) Attach(ctx context.Context, in *runtimeapi.AttachRequest) (*runtimeapi.AttachResponse, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "Attach")
+	return &runtimeapi.AttachResponse{}, nil
+}
+
+func (r *FakeRuntimeServer) PortForward(ctx context.Context, in *runtimeapi.PortForwardRequest) (*runtimeapi.PortForwardResponse, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "PortForward")
+	return &runtimeapi.PortForwardResponse{}, nil
+}
+
+func (r *FakeRuntimeServer) UpdateRuntimeConfig(ctx context.Context, in *runtimeapi.UpdateRuntimeConfigRequest) (*runtimeapi.UpdateRuntimeConfigResponse, error) {
+	return &runtimeapi.UpdateRuntimeConfigResponse{}, nil
+}

--- a/pkg/criproxy/testing/fake_runtime_server.go
+++ b/pkg/criproxy/testing/fake_runtime_server.go
@@ -122,7 +122,7 @@ func (r *FakeRuntimeServer) RunPodSandbox(ctx context.Context, in *runtimeapi.Ru
 	// fixed name from BuildSandboxName() for easily making fake sandboxes.
 	config := in.GetConfig()
 	podSandboxID := BuildSandboxName(config.Metadata)
-	createdAt := time.Now().Unix()
+	createdAt := time.Now().UnixNano()
 	readyState := runtimeapi.PodSandboxState_SANDBOX_READY
 	r.Sandboxes[podSandboxID] = &FakePodSandbox{
 		PodSandboxStatus: runtimeapi.PodSandboxStatus{
@@ -237,7 +237,7 @@ func (r *FakeRuntimeServer) CreateContainer(ctx context.Context, in *runtimeapi.
 	podSandboxID := in.GetPodSandboxId()
 	config := in.GetConfig()
 	containerID := BuildContainerName(config.Metadata, podSandboxID)
-	createdAt := time.Now().Unix()
+	createdAt := time.Now().UnixNano()
 	createdState := runtimeapi.ContainerState_CONTAINER_CREATED
 	imageRef := config.Image.GetImage()
 	r.Containers[containerID] = &FakeContainer{
@@ -270,7 +270,7 @@ func (r *FakeRuntimeServer) StartContainer(ctx context.Context, in *runtimeapi.S
 	}
 
 	// Set container to running.
-	startedAt := time.Now().Unix()
+	startedAt := time.Now().UnixNano()
 	runningState := runtimeapi.ContainerState_CONTAINER_RUNNING
 	c.State = &runningState
 	c.StartedAt = &startedAt
@@ -291,7 +291,7 @@ func (r *FakeRuntimeServer) StopContainer(ctx context.Context, in *runtimeapi.St
 	}
 
 	// Set container to exited state.
-	finishedAt := time.Now().Unix()
+	finishedAt := time.Now().UnixNano()
 	exitedState := runtimeapi.ContainerState_CONTAINER_EXITED
 	c.State = &exitedState
 	c.FinishedAt = &finishedAt

--- a/pkg/criproxy/testing/utils.go
+++ b/pkg/criproxy/testing/utils.go
@@ -12,10 +12,25 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+Based on pkg/kubelet/api/testing/utils.go from Kubernetes project.
+Original copyright notice follows:
+
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
-// TODO: credits
-// (based on pkg/kubelet/api/testing/utils.go from k8s)
 package testing
 
 import (

--- a/pkg/criproxy/testing/utils.go
+++ b/pkg/criproxy/testing/utils.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2016 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// TODO: credits
+// (based on pkg/kubelet/api/testing/utils.go from k8s)
+package testing
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+
+	runtimeapi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
+)
+
+func BuildContainerName(metadata *runtimeapi.ContainerMetadata, sandboxID string) string {
+	// include the sandbox ID to make the container ID unique.
+	return fmt.Sprintf("%s_%s_%d", sandboxID, metadata.GetName(), metadata.GetAttempt())
+}
+
+func BuildSandboxName(metadata *runtimeapi.PodSandboxMetadata) string {
+	return fmt.Sprintf("%s_%s_%s_%d", metadata.GetName(), metadata.GetNamespace(), metadata.GetUid(), metadata.GetAttempt())
+}
+
+func filterInLabels(filter, labels map[string]string) bool {
+	for k, v := range filter {
+		if value, ok := labels[k]; ok {
+			if value != v {
+				return false
+			}
+		} else {
+			return false
+		}
+	}
+
+	return true
+}
+
+type Journal interface {
+	Record(item string)
+}
+
+type SimpleJournal struct {
+	sync.Mutex
+	Items []string
+}
+
+func NewSimpleJournal() *SimpleJournal { return &SimpleJournal{} }
+
+func (j *SimpleJournal) Record(item string) {
+	j.Lock()
+	defer j.Unlock()
+
+	j.Items = append(j.Items, item)
+}
+
+func (j *SimpleJournal) Verify(expectedItems []string) error {
+	j.Lock()
+	defer j.Unlock()
+
+	actualItems := j.Items
+	j.Items = nil
+	if !reflect.DeepEqual(actualItems, expectedItems) {
+		return fmt.Errorf("bad journal items. Expected %v, got %v", expectedItems, actualItems)
+	}
+	return nil
+}
+
+type PrefixJournal struct {
+	journal Journal
+	prefix  string
+}
+
+func NewPrefixJournal(journal Journal, prefix string) *PrefixJournal {
+	return &PrefixJournal{journal, prefix}
+}
+
+func (j *PrefixJournal) Record(item string) {
+	j.journal.Record(j.prefix + item)
+}


### PR DESCRIPTION
- [x] Patch k8s to support 'mixed' runtime mode
- [x] Basic docker-shim interception on kubeadm clusters
- [x] ImageService proxying
- [x] RuntimeService proxying with multiple runtime support based on annotations (test with cri-o)
- [x] Fix proxy startup race (in 'mixed' mode, wait for the runtime to be able to handle `Version()` call successfully)
- [x] Support virtlet
- [x] Add proper credits pointing at the places in k8s source from where some  of the code was copied

After merging this PR and showcasing virtlet, we need to refactor ['mixed' mode](https://github.com/ivan4th/kubernetes/tree/mixed-container-runtime-mode) and submit PR to upstream.

`mixed` container runtime k8s fork: https://github.com/ivan4th/kubernetes/tree/mixed-container-runtime-mode

[Sample dump](https://gist.githubusercontent.com/ivan4th/0d53b4900dca746ed6e22f141a8f6021/raw/e204ac12d2ca486c6734287dcfde4c4452f92442/cridump.txt
) from CRI proxy (captures startup of kube-proxy pod on the node)

How to use with [kubeadm-dind-cluster](https://github.com/Mirantis/kubeadm-dind-cluster):
1. Build `criproxy`
1. Start the cluster with `dind/dind-cluster.sh update && dind/dind-cluster.sh up`
1. Prepare to change the runtime on a node by copying criproxy, killing kubelet and currently active docker containers and updating kubelet config:
```
docker cp criproxy kube-node-1:/usr/local/bin/
docker exec kube-node-1 systemctl stop kubelet
docker exec kube-node-1 bash -c 'docker ps -qa|xargs docker rm -fv'
echo -e "[Service]\nEnvironment='KUBELET_EXTRA_ARGS=--hostname-override=172.30.0.5 --v=4 --experimental-cri --container-runtime=mixed --container-runtime-endpoint=/run/criproxy.sock --image-service-endpoint=/run/criproxy.sock'" | docker exec -i kube-node-1 /bin/bash -c 'cat >/etc/systemd/system/kubelet.service.d/20-hostname-override.conf'
docker exec kube-node-1 systemctl daemon-reload
```
1. Start criproxy:
```
docker exec -it kube-node-1 /usr/local/bin/criproxy -v 3 -alsologtostderr
```
1. In another terminal window start kubelet (this currently should be done quickly after starting criproxy as it probably may time out - need to check/fix):
```
docker exec kube-node-1 systemctl start kubelet
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/156)
<!-- Reviewable:end -->
