### PR TITLE
images: Keep knowledge about k8s only in manager

### DIFF
--- a/pkg/libvirttools/storage_volume.go
+++ b/pkg/libvirttools/storage_volume.go
@@ -127,7 +127,7 @@ func VolGetPath(vol C.virStorageVolPtr) (string, error) {
 
 }
 
-func LookupVol(name string, pool C.virStoragePoolPtr) (C.virStorageVolPtr, error) {
+func LookupVolumeByName(name string, pool C.virStoragePoolPtr) (C.virStorageVolPtr, error) {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
 	vol := C.virStorageVolLookupByName(pool, cName)
@@ -137,8 +137,8 @@ func LookupVol(name string, pool C.virStoragePoolPtr) (C.virStorageVolPtr, error
 	return vol, nil
 }
 
-func RemoveVol(name string, pool C.virStoragePoolPtr) error {
-	vol, err := LookupVol(name, pool)
+func RemoveVolumeByName(name string, pool C.virStoragePoolPtr) error {
+	vol, err := LookupVolumeByName(name, pool)
 	if err != nil {
 		return err
 	}

--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -245,7 +245,7 @@ func (v *VirtualizationTool) createVolumes(containerName string, mounts []*kubea
 	if len(mounts) == 0 {
 		return domXML, nil
 	}
-	glog.V(2).Infof("INPUT domain:\n%s\n\n", domXML)
+	glog.V(3).Infof("INPUT domain:\n%s\n\n", domXML)
 	domainXML := &Domain{}
 	err := xml.Unmarshal([]byte(domXML), domainXML)
 	if err != nil {
@@ -255,7 +255,7 @@ func (v *VirtualizationTool) createVolumes(containerName string, mounts []*kubea
 	for _, mount := range mounts {
 		volumeName := containerName + "_" + strings.Replace(mount.GetContainerPath(), "/", "_", -1)
 		if mount.GetHostPath() != "" {
-			vol, err := LookupVol(volumeName, v.volumePool)
+			vol, err := LookupVolumeByName(volumeName, v.volumePool)
 			if vol == nil {
 				vol, err = v.volumeStorage.CreateVol(v.volumePool, volumeName, defaultCapacity, defaultCapacityUnit)
 			}


### PR DESCRIPTION
Also added more verbose names (`LookupVolumeByName` instead `LookupVol`) because they were misleading and used incorrectly - there was call to `LookupVol` with path instead of volume name.

https://github.com/Mirantis/virtlet/compare/jell/refactor_images?expand=1#diff-7d903b129bc883285ffc5068c39c00b0L397

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/164)
<!-- Reviewable:end -->
