### PR TITLE
Fix domain name handling in e2e runner

### DIFF
--- a/contrib/images/e2e-test/Dockerfile
+++ b/contrib/images/e2e-test/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
     mkdir /images && \
     wget http://download.cirros-cloud.net/0.3.4/cirros-0.3.4-x86_64-disk.img -O /images/cirros
 
-COPY run.sh /
-RUN chmod +x /run.sh
+COPY run.sh vmchat.exp /
+RUN chmod +x /run.sh /vmchat.exp
 
 CMD ["/run.sh"]

--- a/contrib/images/e2e-test/run.sh
+++ b/contrib/images/e2e-test/run.sh
@@ -94,55 +94,12 @@ function e2e::wait-for-libvirt-domain {
   virsh -c qemu+tcp://virtlet/system list
 }
 
-function e2e::chat-with-vm {
-  expect -c '
-    set timeout 600
-    spawn virsh -c qemu+tcp://virtlet/system console cirros
-    expect {
-      timeout { puts "initial message timeout"; exit 1 }
-      "Escape character"
-    }
-    send "\r"
-
-    expect {
-      timeout { puts "login prompt timeout"; exit 1 }
-      "login:"
-    }
-    send "cirros\r"
-
-    set timeout 20
-    expect {
-      timeout { puts "password prompt timeout"; exit 1 }
-      "Password: "
-    }
-    sleep 3
-    send "cubswin:)\r"
-
-    expect {
-      timeout { puts "shell prompt timeout"; exit 1 }
-      -re "\n\\$"
-    }
-    send "/sbin/ifconfig\r"
-
-    expect {
-      timeout { puts "shell prompt timeout"; exit 1 }
-      -re "\n\\$"
-    }
-    send "exit\r"
-
-    expect {
-      timeout { puts "login prompt timeout"; exit 1 }
-      "login:"
-    }
-'
-}
-
 e2e::setup-kubectl
 e2e::serve-image
 e2e::wait-for-apiserver
 e2e::create-vm
 e2e::wait-for-pod
 e2e::wait-for-libvirt-domain
-e2e::chat-with-vm
+/vmchat.exp $(virsh -c qemu+tcp://virtlet/system list --name)
 
 e2e::step "Done"

--- a/contrib/images/e2e-test/vmchat.exp
+++ b/contrib/images/e2e-test/vmchat.exp
@@ -1,0 +1,42 @@
+#!/usr/bin/expect -f
+set timeout 600
+set domain [lindex $argv 0]
+
+spawn virsh -c qemu+tcp://virtlet/system console $domain
+
+expect {
+    timeout { puts "initial message timeout"; exit 1 }
+    "Escape character"
+}
+send "\r"
+
+expect {
+    timeout { puts "login prompt timeout"; exit 1 }
+    "login:"
+}
+send "cirros\r"
+
+set timeout 20
+expect {
+    timeout { puts "password prompt timeout"; exit 1 }
+    "Password: "
+}
+sleep 3
+send "cubswin:)\r"
+
+expect {
+    timeout { puts "shell prompt timeout"; exit 1 }
+    -re "\n\\$"
+}
+send "/sbin/ifconfig\r"
+
+expect {
+    timeout { puts "shell prompt timeout"; exit 1 }
+    -re "\n\\$"
+}
+send "exit\r"
+
+expect {
+    timeout { puts "login prompt timeout"; exit 1 }
+    "login:"
+}


### PR DESCRIPTION
e2e runner was always "succeeding" due to a problem with libvirt domain name and strange tcl error handling

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/169)
<!-- Reviewable:end -->
