### PR TITLE
Fix virtlet shutdown in integration tests

### DIFF
--- a/tests/integration/manager.go
+++ b/tests/integration/manager.go
@@ -112,6 +112,8 @@ func (v *VirtletManager) Run() error {
 
 func (v *VirtletManager) Close() {
 	v.conn.Close()
-	syscall.Kill(v.pid, syscall.SIGKILL)
+	syscall.Kill(v.pid, syscall.SIGTERM)
 	os.Remove(virtletSocket)
+	var ws syscall.WaitStatus
+	syscall.Wait4(v.pid, &ws, 0, nil)
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/171)
<!-- Reviewable:end -->
