### PR TITLE
Move networking tests to separate directory

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,7 @@ export GO15VENDOREXPERIMENT=1
 export CGO_CFLAGS=$(CFLAGS)
 export CGO_LDFLAGS=$(LDFLAGS) $(LIBS)
 
-SUBDIRS = pkg/bolttools pkg/download pkg/libvirttools pkg/manager pkg/nettools tests/integration
+SUBDIRS = pkg/bolttools pkg/download pkg/libvirttools pkg/manager pkg/nettools tests/integration tests/network
 
 # FIXME: add back dockerfilelint.test
 # (as of now, it requires Docker)

--- a/configure.ac
+++ b/configure.ac
@@ -12,6 +12,6 @@ CFLAGS="$CFLAGS $glib_CFLAGS $libvirt_CFLAGS"
 LDFLAGS="$LDFLAGS"
 LIBS="$LIBS $glib_LIBS $libvirt_LIBS"
 
-AC_CONFIG_FILES([Makefile pkg/bolttools/Makefile pkg/download/Makefile pkg/libvirttools/Makefile pkg/manager/Makefile pkg/nettools/Makefile tests/integration/Makefile])
+AC_CONFIG_FILES([Makefile pkg/bolttools/Makefile pkg/download/Makefile pkg/libvirttools/Makefile pkg/manager/Makefile pkg/nettools/Makefile tests/integration/Makefile tests/network/Makefile])
 
 AC_OUTPUT

--- a/tests/network/Makefile.am
+++ b/tests/network/Makefile.am
@@ -1,0 +1,16 @@
+# Copyright 2016 Mirantis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+check_SCRIPTS = go.test
+TESTS = $(check_SCRIPTS)

--- a/tests/network/README.md
+++ b/tests/network/README.md
@@ -1,0 +1,6 @@
+This directory contains network tests that make use of network
+namespaces and should not be mixed with non-network-namespace-aware
+tests.
+
+For more info, see containernetworking/cni#262, vishvananda/netns#17
+etc.

--- a/tests/network/dhcp_test.go
+++ b/tests/network/dhcp_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package integration
+package network
 
 import (
 	"fmt"

--- a/tests/network/go.test
+++ b/tests/network/go.test
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+go test -v .

--- a/tests/network/utils_test.go
+++ b/tests/network/utils_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package integration
+package network
 
 import (
 	"bytes"

--- a/tests/network/vm_network_test.go
+++ b/tests/network/vm_network_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package integration
+package network
 
 import (
 	"bytes"


### PR DESCRIPTION
The new tests/network directory contains network tests that make use of network
namespaces and should not be mixed with non-network-namespace-aware
tests.

For more info, see containernetworking/cni#262, vishvananda/netns#17 etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/173)
<!-- Reviewable:end -->
