### PR TITLE
Run docker-shim from criproxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,3 +24,4 @@ CMD ["/start.sh"]
 # in build/test image and production one
 COPY _output/virtlet /usr/local/bin
 COPY _output/vmwrapper /
+COPY _output/criproxy /

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -25,7 +25,8 @@ RUN apt-get update && \
                 libvirt-bin \
                 python-libvirt \
                 netbase \
-                iputils-ping && \
+                iputils-ping \
+                mercurial && \
     apt-get clean
 
 # The following is based on official Go container:

--- a/build/cmd.sh
+++ b/build/cmd.sh
@@ -27,6 +27,8 @@ function ensure_build_image {
 function vcmd {
     ensure_build_image
     cd "${project_dir}"
+    # need to mount docker socket into the container because of
+    # CRI proxy deployment tests
     tar -C "${project_dir}" "${exclude[@]}" -cz . |
         docker run --rm --privileged -i \
                -l virtlet_build \
@@ -35,7 +37,9 @@ function vcmd {
                -v /sys/fs/cgroup:/sys/fs/cgroup \
                -v /lib/modules:/lib/modules:ro \
                -v /boot:/boot:ro \
+               -v /var/run/docker.sock:/var/run/docker.sock \
                -e TRAVIS="${TRAVIS:-}" \
+               -e CRIPROXY_TEST_REMOTE_DOCKER_ENDPOINT="${CRIPROXY_TEST_REMOTE_DOCKER_ENDPOINT:-}" \
                --name ${container_name} \
                "${build_image}" bash -c "tar -C '${remote_project_dir}' -xz && $*"
 }

--- a/cmd/criproxy/criproxy.go
+++ b/cmd/criproxy/criproxy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 Mirantis
+Copyright 2017 Mirantis
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/criproxy/criproxy.go
+++ b/cmd/criproxy/criproxy.go
@@ -129,6 +129,5 @@ func main() {
 	}
 }
 
-// TODO: fix waiting for proxy socket
 // Testing:
 // /criproxy -alsologtostderr -v 2 -install -apiserver=http://172.30.0.2:8080

--- a/cmd/criproxy/criproxy.go
+++ b/cmd/criproxy/criproxy.go
@@ -17,29 +17,19 @@ limitations under the License.
 package main
 
 import (
-	"errors"
 	"flag"
-	"net"
-	"net/http"
+	"fmt"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/Mirantis/virtlet/pkg/criproxy"
-	"k8s.io/kubernetes/pkg/apis/componentconfig"
-	cfg "k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1"
-	"k8s.io/kubernetes/pkg/kubelet/dockershim"
-	dockerremote "k8s.io/kubernetes/pkg/kubelet/dockershim/remote"
-	"k8s.io/kubernetes/pkg/kubelet/dockertools"
-	"k8s.io/kubernetes/pkg/kubelet/server/streaming"
-
 	"github.com/golang/glog"
 )
 
 const (
-	// XXX: fix this
+	// XXX: don't hardcode
 	connectionTimeout = 30 * time.Second
-	dockerShimSocket  = "/var/run/proxy-dockershim.sock"
 )
 
 var (
@@ -47,102 +37,97 @@ var (
 		"The unix socket to listen on, e.g. /run/virtlet.sock")
 	connect = flag.String("connect", "/var/run/dockershim.sock",
 		"CRI runtime ids and unix socket(s) to connect to, e.g. /var/run/dockershim.sock,alt:/var/run/another.sock")
+	kubeletConfigPath = flag.String("kletcfg", "/etc/criproxy/kubelet.conf", "path to saved kubelet config file")
+	apiServerHost     = flag.String("apiserver", "", "apiserver URL")
 )
 
-func getAddressForStreaming() (string, error) {
-	// FIXME: see kubelet.setNodeAddress
-	hostname, err := os.Hostname()
-	if err != nil {
-		return "", err
-	}
-	addrs, err := net.LookupIP(hostname)
-	for _, addr := range addrs {
-		if !addr.IsLoopback() && addr.To4() != nil {
-			return addr.String(), nil
-		}
-	}
-	return "", errors.New("unable to get IP address")
-}
-
-func startDockerShim() (string, error) {
-	streamingAddr, err := getAddressForStreaming()
-	if err != nil {
-		return "", err
-	}
-	var kubeCfg cfg.KubeletConfiguration
-	cfg.SetDefaults_KubeletConfiguration(&kubeCfg)
-	pluginSettings := dockershim.NetworkPluginSettings{
-		HairpinMode:       componentconfig.HairpinNone, // kubeCfg.HairpinMode, --- XXX
-		NonMasqueradeCIDR: kubeCfg.NonMasqueradeCIDR,   // XXX: was being taken from kubelet object
-		PluginName:        "cni",
-		PluginConfDir:     "/etc/kubernetes/cni/net.d",
-		PluginBinDir:      "/usr/lib/kubernetes/cni/bin", // XXX: cniBinDir
-		MTU:               int(kubeCfg.NetworkPluginMTU),
-	}
-	dockerClient := dockertools.ConnectToDockerOrDie(kubeCfg.DockerEndpoint, kubeCfg.RuntimeRequestTimeout.Duration)
-
-	streamingConfig := &streaming.Config{
-		Addr:                  streamingAddr + ":12345", // FIXME
-		StreamIdleTimeout:     kubeCfg.StreamingConnectionIdleTimeout.Duration,
-		StreamCreationTimeout: streaming.DefaultConfig.StreamCreationTimeout,
-		SupportedProtocols:    streaming.DefaultConfig.SupportedProtocols,
-	}
-
-	ds, err := dockershim.NewDockerService(dockerClient, kubeCfg.SeccompProfileRoot, kubeCfg.PodInfraContainerImage, streamingConfig, &pluginSettings, kubeCfg.RuntimeCgroups)
-	if err != nil {
-		return "", err
-	}
-
-	httpServer := &http.Server{
-		Addr:    streamingConfig.Addr,
-		Handler: ds,
-		// TODO: TLSConfig?
-	}
-	go func() {
-		if err := httpServer.ListenAndServe(); err != nil {
-			glog.Errorf("Failed to start http server: %v", err)
-		}
-	}()
-
-	server := dockerremote.NewDockerServer(dockerShimSocket, ds)
-	glog.V(2).Infof("Starting the GRPC server for the docker CRI shim.")
-	if err := server.Start(); err != nil {
-		return "", err
-	}
-
-	return dockerShimSocket, nil
-}
-
-func main() {
-	flag.Parse()
-
-	addrs := strings.Split(*connect, ",")
+func runCriProxy(connect, listen, savedConfigPath string) error {
+	addrs := strings.Split(connect, ",")
 	dockerStarted := false
+
+	kubeCfg, err := criproxy.LoadKubeletConfig(savedConfigPath)
+	if err != nil {
+		return err
+	}
+
 	for n, addr := range addrs {
 		if addr != "docker" {
 			continue
 		}
 		if dockerStarted {
-			glog.Errorf("More than one 'docker' endpoint is specified")
-			os.Exit(1)
+			return fmt.Errorf("More than one 'docker' endpoint is specified")
 		}
-		dockerEndpoint, err := startDockerShim()
+
+		dockerEndpoint, err := criproxy.StartDockerShim(kubeCfg)
 		if err != nil {
-			glog.Errorf("Failed to start docker-shim: %v", err)
-			os.Exit(1)
+			return fmt.Errorf("Failed to start docker-shim: %v", err)
 		}
 		addrs[n] = dockerEndpoint
 		dockerStarted = true
 	}
 
-	proxy, err := criproxy.NewRuntimeProxy(addrs, connectionTimeout)
+	cleanupDone := false
+	proxy, err := criproxy.NewRuntimeProxy(addrs, connectionTimeout, func() {
+		if cleanupDone {
+			return
+		}
+		// Perform the cleanup only when we're completely sure that kubelet
+		// with proper runtime is active. Otherwise the old containers may
+		// get recreated.
+		if err := criproxy.RemoveContainersFromDefaultDockerRuntime(kubeCfg); err != nil {
+			glog.Errorf("Container cleanup error: %v", err)
+		}
+		cleanupDone = true
+	})
 	if err != nil {
-		glog.Errorf("Error starting CRI proxy: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("Error starting CRI proxy: %v", err)
 	}
-	glog.V(1).Infof("Starting CRI proxy on socket %s", *listen)
-	if err := proxy.Serve(*listen, nil); err != nil {
-		glog.Errorf("Serving failed: %v", err)
+	glog.V(1).Infof("Starting CRI proxy on socket %s", listen)
+	if err := proxy.Serve(listen, nil); err != nil {
+		return fmt.Errorf("Serving failed: %v", err)
+	}
+	return nil
+}
+
+func installCriProxy(execPath, savedConfigPath string) error {
+	changed, err := criproxy.EnsureCRIProxy(&criproxy.BootstrapConfig{
+		ApiServerHost:   *apiServerHost,
+		ConfigzBaseUrl:  "https://127.0.0.1:10250",
+		StatsBaseUrl:    "http://127.0.0.1:10255",
+		SavedConfigPath: savedConfigPath,
+		ProxyPath:       execPath,
+		ProxyArgs: []string{
+			// TODO: don't hardcode
+			"-v",
+			"3",
+			"-alsologtostderr",
+			"-connect",
+			"docker,virtlet:/run/virtlet.sock",
+		},
+		ProxySocketPath: "/run/criproxy.sock",
+	})
+	if !changed {
+		glog.V(1).Infof("Node configuration unchanged")
+	}
+	return err
+}
+
+func main() {
+	install := flag.Bool("install", false, "install criproxy container")
+	flag.Parse()
+
+	var err error
+	if *install {
+		err = installCriProxy(os.Args[0], *kubeletConfigPath)
+	} else {
+		err = runCriProxy(*connect, *listen, *kubeletConfigPath)
+	}
+	if err != nil {
+		glog.Error(err)
 		os.Exit(1)
 	}
 }
+
+// TODO: fix waiting for proxy socket
+// Testing:
+// /criproxy -alsologtostderr -v 2 -install -apiserver=http://172.30.0.2:8080

--- a/cmd/criproxy/criproxy.go
+++ b/cmd/criproxy/criproxy.go
@@ -37,7 +37,7 @@ var (
 		"The unix socket to listen on, e.g. /run/virtlet.sock")
 	connect = flag.String("connect", "/var/run/dockershim.sock",
 		"CRI runtime ids and unix socket(s) to connect to, e.g. /var/run/dockershim.sock,alt:/var/run/another.sock")
-	kubeletConfigPath = flag.String("kletcfg", "/etc/criproxy/kubelet.conf", "path to saved kubelet config file")
+	kubeletConfigPath = flag.String("kubeletcfg", "/etc/criproxy/kubelet.conf", "path to saved kubelet config file")
 	apiServerHost     = flag.String("apiserver", "", "apiserver URL")
 )
 

--- a/cmd/criproxy/criproxy.go
+++ b/cmd/criproxy/criproxy.go
@@ -74,9 +74,9 @@ func startDockerShim() (string, error) {
 	pluginSettings := dockershim.NetworkPluginSettings{
 		HairpinMode:       componentconfig.HairpinNone, // kubeCfg.HairpinMode, --- XXX
 		NonMasqueradeCIDR: kubeCfg.NonMasqueradeCIDR,   // XXX: was being taken from kubelet object
-		PluginName:        kubeCfg.NetworkPluginName,
-		PluginConfDir:     kubeCfg.CNIConfDir,
-		PluginBinDir:      kubeCfg.NetworkPluginDir, // XXX: cniBinDir
+		PluginName:        "cni",
+		PluginConfDir:     "/etc/kubernetes/cni/net.d",
+		PluginBinDir:      "/usr/lib/kubernetes/cni/bin", // XXX: cniBinDir
 		MTU:               int(kubeCfg.NetworkPluginMTU),
 	}
 	dockerClient := dockertools.ConnectToDockerOrDie(kubeCfg.DockerEndpoint, kubeCfg.RuntimeRequestTimeout.Duration)

--- a/cmd/criproxy/criproxy.go
+++ b/cmd/criproxy/criproxy.go
@@ -90,7 +90,7 @@ func runCriProxy(connect, listen, savedConfigPath string) error {
 }
 
 func installCriProxy(execPath, savedConfigPath string) error {
-	changed, err := criproxy.EnsureCRIProxy(&criproxy.BootstrapConfig{
+	bootstrap := criproxy.NewBootstrap(&criproxy.BootstrapConfig{
 		ApiServerHost:   *apiServerHost,
 		ConfigzBaseUrl:  "https://127.0.0.1:10250",
 		StatsBaseUrl:    "http://127.0.0.1:10255",
@@ -105,8 +105,9 @@ func installCriProxy(execPath, savedConfigPath string) error {
 			"docker,virtlet:/run/virtlet.sock",
 		},
 		ProxySocketPath: "/run/criproxy.sock",
-	})
-	if !changed {
+	}, nil)
+	changed, err := bootstrap.EnsureCRIProxy()
+	if err == nil && !changed {
 		glog.V(1).Infof("Node configuration unchanged")
 	}
 	return err

--- a/contrib/deploy/README.md
+++ b/contrib/deploy/README.md
@@ -7,8 +7,7 @@
 ```
 3. Create image server Deployment and Service:
 ```
-kubectl create -f image-server.yaml
-kubectl create -f image-service.yaml
+kubectl create -f image-server.yaml -f image-service.yaml
 ```
 4. Wait for image-server pod to become Running (this is important for virtlet initialization due to host network + cluster DNS [issue](https://github.com/kubernetes/kubernetes/issues/17406)):
 ```

--- a/contrib/deploy/README.md
+++ b/contrib/deploy/README.md
@@ -1,6 +1,10 @@
 # Deploying virtlet as a DaemonSet
 
-1. Start [kubeadm-dind-cluster](https://github.com/Mirants/kubeadm-dind-cluster) on [this k8s fork](https://github.com/ivan4th/kubernetes/tree/mixed-container-runtime-mode)
+1. Start [kubeadm-dind-cluster](https://github.com/Mirants/kubeadm-dind-cluster).
+   Virtlet may work with other cluster deployment methods too,
+   but the important part is passing
+   `--feature-gates=StreamingProxyRedirects=true` to apiserver and
+   `--feature-gates=DynamicKubeletConfig=true` to kubelet.
 2. 'Virtletify' `kube-node-1`:
 ```
 ./virtletify-dind-node.sh

--- a/contrib/deploy/virsh.sh
+++ b/contrib/deploy/virsh.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-# FIXME: trying to do `kubectl exec` in virtlet container may currently fail with unhelpful error message ("Error from server")
 opts=
 if [[ ${1:-} = "console" ]]; then
   # using -it with `virsh list` causes it to use \r\n as line endings,
   # which makes it less useful
   opts="-it"
 fi
-docker exec ${opts} kube-node-1 docker exec ${opts} $(docker exec kube-node-1 docker ps|grep mirantis/virtlet|sed 's/.* //') virsh "$@"
+pod=$(kubectl get pods -l runtime=virtlet -o name|head -1|sed 's@.*/@@')
+kubectl exec ${opts} "${pod}" -- virsh "$@"

--- a/contrib/deploy/virtlet-ds.yaml
+++ b/contrib/deploy/virtlet-ds.yaml
@@ -54,6 +54,10 @@ spec:
         # FIXME: E0102 08:26:02.959687      32 virtlet.go:50] Initializing server failed: cannot open path '/var/lib/libvirt/images': No such file or directory
         # - mountPath: /var/lib/libvirt
         #   name: libvirt
+        - mountPath: /etc/cni
+          name: cniconf
+        - mountPath: /opt/cni/bin
+          name: cnibin
         securityContext:
           privileged: true
         env:
@@ -80,3 +84,9 @@ spec:
       - hostPath:
           path: /var/lib/libvirt
         name: libvirt
+      - hostPath:
+          path: /etc/kubernetes/cni
+        name: cniconf
+      - hostPath:
+          path: /usr/lib/kubernetes/cni/bin
+        name: cnibin

--- a/contrib/deploy/virtlet-ds.yaml
+++ b/contrib/deploy/virtlet-ds.yaml
@@ -1,3 +1,9 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: virtlet
+---
 apiVersion: extensions/v1beta1 
 kind: DaemonSet
 metadata:
@@ -27,9 +33,48 @@ spec:
               }
             }
           }
+        # The init container checks if there's already saved kubelet config
+        # and considers that bootstrap is already done if it exists.
+        # If it doesn't, it drops criproxy binary into /opt/criproxy/bin/
+        # if it's not already there and then starts criproxy installation.
+        # The possibility to put criproxy binary in advance into
+        # /opt/criproxy/bin may be helpful for the purpose of
+        # debugging criproxy.
+        pod.beta.kubernetes.io/init-containers: >
+          [
+            {
+              "name": "bootstrap",
+              "image": "mirantis/virtlet",
+              "imagePullPolicy": "IfNotPresent",
+              "securityContext": { "privileged": true },
+              "command": ["/bin/sh", "-c", "if [ -f /etc/criproxy/kubelet.conf ]; then exit 0; fi; if [ ! -f /opt/criproxy/bin/criproxy ]; then cp /criproxy /opt/criproxy/bin/criproxy; fi; /opt/criproxy/bin/criproxy -alsologtostderr -v 2 -install && sleep Infinity"],
+              "volumeMounts": [
+                {
+                  "name": "criproxybin",
+                  "mountPath": "/opt/criproxy/bin"
+                },
+                {
+                  "name": "run",
+                  "mountPath": "/run"
+                },
+                {
+                  "name": "dockersock",
+                  "mountPath": "/var/run/docker.sock"
+                },
+                {
+                  "name": "criproxyconf",
+                  "mountPath": "/etc/criproxy"
+                }
+              ]
+            }
+          ]
     spec:
-      # TODO: hostPID: true for VMs to survive libvirt restart
       hostNetwork: true
+      # hostPID is true to (1) enable VMs to survive virtlet container restart
+      # (to be checked) and (2) to enable the use of nsenter in init container
+      hostPID: true
+      # bootstrap procedure needs admin access to apiserver
+      serviceAccountName: virtlet
       containers:
       - name: virtlet
         image: mirantis/virtlet
@@ -80,6 +125,12 @@ spec:
       - hostPath:
           path: /run
         name: run
+      # TODO: don't hardcode docker socket location here
+      # This will require CRI proxy installation to run
+      # in host mount namespace.
+      - hostPath:
+          path: /var/run/docker.sock
+        name: dockersock
       - hostPath:
           path: /var/lib/virtlet
         name: virtlet
@@ -95,3 +146,9 @@ spec:
       - hostPath:
           path: /var/lib/cni
         name: cnidata
+      - hostPath:
+          path: /opt/criproxy/bin
+        name: criproxybin
+      - hostPath:
+          path: /etc/criproxy
+        name: criproxyconf

--- a/contrib/deploy/virtlet-ds.yaml
+++ b/contrib/deploy/virtlet-ds.yaml
@@ -58,6 +58,8 @@ spec:
           name: cniconf
         - mountPath: /opt/cni/bin
           name: cnibin
+        - mountPath: /var/lib/cni
+          name: cnidata
         securityContext:
           privileged: true
         env:
@@ -90,3 +92,6 @@ spec:
       - hostPath:
           path: /usr/lib/kubernetes/cni/bin
         name: cnibin
+      - hostPath:
+          path: /var/lib/cni
+        name: cnidata

--- a/contrib/deploy/virtletify-dind-node.sh
+++ b/contrib/deploy/virtletify-dind-node.sh
@@ -17,25 +17,12 @@ container="${1:-kube-node-1}"
 build/cmd.sh build
 build/cmd.sh copy
 
-docker cp _output/criproxy kube-node-1:/usr/local/bin/
+docker exec kube-node-1 mkdir -p /opt/criproxy/bin
+docker cp _output/criproxy kube-node-1:/opt/criproxy/bin/criproxy
 
 # kubeadm-dind-cluster specific node naming
 node_name="$(docker exec "${container}" hostname --ip-address)"
 
-docker exec -d "${container}" bash -c '/usr/local/bin/criproxy -v 3 -alsologtostderr -connect docker,virtlet:/run/virtlet.sock >& /tmp/criproxy.log'
-
-# FIXME: --node-labels doesn't work here because of this issue:
-# https://github.com/kubernetes/kubernetes/issues/28051
-docker exec "${container}" sed -i \
-       "s@'\$@ --node-labels=extraRuntime=virtlet --experimental-cri --container-runtime=remote --container-runtime-endpoint=/run/criproxy.sock --image-service-endpoint=/run/criproxy.sock'@" \
-       /etc/systemd/system/kubelet.service.d/20-hostname-override.conf
-docker exec -i "${container}" systemctl stop kubelet
-docker exec -i "${container}" bash -c 'docker ps -qa|xargs docker rm -fv'
-docker exec -i "${container}" systemctl daemon-reload
-docker exec -i "${container}" systemctl start kubelet
-
-# Set node label because --node-labels doesn't update node labels after
-# restarting kubelet (see above)
 kubectl label node "${node_name}" extraRuntime=virtlet
 
 # kubectl create -f contrib/deploy/virtlet-ds.yaml

--- a/contrib/deploy/virtletify-dind-node.sh
+++ b/contrib/deploy/virtletify-dind-node.sh
@@ -22,12 +22,12 @@ docker cp _output/criproxy kube-node-1:/usr/local/bin/
 # kubeadm-dind-cluster specific node naming
 node_name="$(docker exec "${container}" hostname --ip-address)"
 
-docker exec -d "${container}" bash -c '/usr/local/bin/criproxy -v 3 -alsologtostderr -connect /var/run/dockershim.sock,virtlet:/run/virtlet.sock >& /tmp/criproxy.log'
+docker exec -d "${container}" bash -c '/usr/local/bin/criproxy -v 3 -alsologtostderr -connect docker,virtlet:/run/virtlet.sock >& /tmp/criproxy.log'
 
 # FIXME: --node-labels doesn't work here because of this issue:
 # https://github.com/kubernetes/kubernetes/issues/28051
 docker exec "${container}" sed -i \
-       "s@'\$@ --node-labels=extraRuntime=virtlet --experimental-cri --container-runtime=mixed --container-runtime-endpoint=/run/criproxy.sock --image-service-endpoint=/run/criproxy.sock'@" \
+       "s@'\$@ --node-labels=extraRuntime=virtlet --experimental-cri --container-runtime=remote --container-runtime-endpoint=/run/criproxy.sock --image-service-endpoint=/run/criproxy.sock'@" \
        /etc/systemd/system/kubelet.service.d/20-hostname-override.conf
 docker exec -i "${container}" systemctl stop kubelet
 docker exec -i "${container}" bash -c 'docker ps -qa|xargs docker rm -fv'

--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,56 @@
 hash: 9739db49ae71fa598fd4733433e8023a143fbf53a2d5e572cdd3eaa082a8a1b5
-updated: 2017-01-13T09:49:54.162567305+01:00
+updated: 2017-01-30T22:38:09.708345248+03:00
 imports:
+- name: bitbucket.org/ww/goautoneg
+  version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
+- name: cloud.google.com/go
+  version: 3b1ae45394a234c385be014e9a488f2bb6eef821
+  subpackages:
+  - compute/metadata
+  - internal
+- name: github.com/abbot/go-http-auth
+  version: c0ef4539dfab4d21c8ef20ba2924f9fc6f186d35
+- name: github.com/aws/aws-sdk-go
+  version: c924893c38ecc04b18d7aab8a7aa561cb8b4c4cc
+  subpackages:
+  - aws
+  - aws/awserr
+  - aws/awsutil
+  - aws/client
+  - aws/client/metadata
+  - aws/corehandlers
+  - aws/credentials
+  - aws/credentials/ec2rolecreds
+  - aws/defaults
+  - aws/ec2metadata
+  - aws/request
+  - aws/session
+  - private/endpoints
+  - private/protocol/ec2query
+  - private/protocol/json/jsonutil
+  - private/protocol/jsonrpc
+  - private/protocol/query
+  - private/protocol/query/queryutil
+  - private/protocol/rest
+  - private/protocol/restxml
+  - private/protocol/xml/xmlutil
+  - private/signer/v4
+  - private/waiter
+  - service/autoscaling
+  - service/ec2
+  - service/ecr
+  - service/elb
+  - service/route53
+- name: github.com/Azure/go-ansiterm
+  version: 70b2c90b260171e829f1ebd7c17f600c11858dbe
+  subpackages:
+  - winterm
+- name: github.com/beorn7/perks
+  version: 3ac7bf7a47d159a033b107610db8a1b6575507a4
+  subpackages:
+  - quantile
+- name: github.com/blang/semver
+  version: 31b736133b98f26d5e078ec9eb591666edfd091f
 - name: github.com/boltdb/bolt
   version: dfb21201d9270c1082d5fb0f07f500311ff72f18
 - name: github.com/containernetworking/cni
@@ -15,10 +65,107 @@ imports:
   version: fbb73372b87f6e89951c2b6b31470c2c9d5cfae3
   subpackages:
   - iptables
+- name: github.com/coreos/go-oidc
+  version: 5644a2f50e2d2d5ba0b474bc5bc55fea1925936d
+  subpackages:
+  - http
+  - jose
+  - key
+  - oauth2
+  - oidc
+- name: github.com/coreos/go-semver
+  version: 568e959cd89871e61434c1143528d9162da89ef2
+  subpackages:
+  - semver
+- name: github.com/coreos/go-systemd
+  version: 4484981625c1a6a2ecb40a390fcb6a9bcfee76e3
+  subpackages:
+  - activation
+  - daemon
+  - dbus
+  - journal
+  - unit
+  - util
+- name: github.com/coreos/pkg
+  version: fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8
+  subpackages:
+  - capnslog
+  - dlopen
+  - health
+  - httputil
+  - timeutil
+- name: github.com/coreos/rkt
+  version: a83419be28ac626876f94a28b4df2dbc9eac7448
+  subpackages:
+  - api/v1alpha
 - name: github.com/davecgh/go-spew
   version: 6cf5744a041a0022271cefed95ba843f6d87fd51
   subpackages:
   - spew
+- name: github.com/docker/distribution
+  version: cd27f179f2c10c5d300e6d09025b538c475b0d51
+  subpackages:
+  - digest
+  - reference
+- name: github.com/docker/docker
+  version: b9f10c951893f9a00865890a5232e85d770c1087
+  subpackages:
+  - pkg/jsonlog
+  - pkg/jsonmessage
+  - pkg/longpath
+  - pkg/mount
+  - pkg/stdcopy
+  - pkg/symlink
+  - pkg/system
+  - pkg/term
+  - pkg/term/windows
+- name: github.com/docker/engine-api
+  version: dea108d3aa0c67d7162a3fd8aa65f38a430019fd
+  subpackages:
+  - client
+  - client/transport
+  - client/transport/cancellable
+  - types
+  - types/blkiodev
+  - types/container
+  - types/filters
+  - types/network
+  - types/reference
+  - types/registry
+  - types/strslice
+  - types/time
+  - types/versions
+- name: github.com/docker/go-connections
+  version: f549a9393d05688dff0992ef3efd8bbe6c628aeb
+  subpackages:
+  - nat
+  - sockets
+  - tlsconfig
+- name: github.com/docker/go-units
+  version: 0bbddae09c5a5419a8c6dcdd7ff90da3d450393b
+- name: github.com/docker/spdystream
+  version: 449fdfce4d962303d702fec724ef0ad181c92528
+  subpackages:
+  - spdy
+- name: github.com/emicklei/go-restful
+  version: 89ef8af493ab468a45a42bb0d89a06fccdd2fb22
+  subpackages:
+  - log
+  - swagger
+- name: github.com/ghodss/yaml
+  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
+- name: github.com/go-ini/ini
+  version: 2e44421e256d82ebbf3d4d4fcabe8930b905eff3
+- name: github.com/go-openapi/jsonpointer
+  version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
+- name: github.com/go-openapi/jsonreference
+  version: 13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272
+- name: github.com/go-openapi/spec
+  version: 6aced65f8501fe1217321abf0749d354824ba2ff
+- name: github.com/go-openapi/swag
+  version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
+- name: github.com/godbus/dbus
+  version: c7fdd8b5cd55e87b4e1f4e372cdb1db61dd6c66f
 - name: github.com/gogo/protobuf
   version: e18d7aa8f8c624c915db340349aad4c49b10d173
   subpackages:
@@ -48,46 +195,214 @@ imports:
   - vanity
   - vanity/command
 - name: github.com/golang/glog
-  version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
+  version: 44145f04b68cf362d9c4df2182967c2275eaefed
+- name: github.com/golang/groupcache
+  version: 02826c3e79038b59d737d3b1c0a1d937f71a4433
+  subpackages:
+  - lru
 - name: github.com/golang/protobuf
   version: 8616e8ee5e20a1704615e6c8d7afcdac06087a67
   subpackages:
   - jsonpb
   - proto
+- name: github.com/google/cadvisor
+  version: a726d13de8cb32860e73d72a78dc8e0124267709
+  subpackages:
+  - api
+  - cache/memory
+  - client/v2
+  - collector
+  - container
+  - container/common
+  - container/docker
+  - container/libcontainer
+  - container/raw
+  - container/rkt
+  - container/systemd
+  - devicemapper
+  - events
+  - fs
+  - healthz
+  - http
+  - http/mux
+  - info/v1
+  - info/v2
+  - machine
+  - manager
+  - manager/watcher
+  - manager/watcher/raw
+  - manager/watcher/rkt
+  - metrics
+  - pages
+  - pages/static
+  - storage
+  - summary
+  - utils
+  - utils/cloudinfo
+  - utils/cpuload
+  - utils/cpuload/netlink
+  - utils/docker
+  - utils/oomparser
+  - utils/sysfs
+  - utils/sysinfo
+  - utils/tail
+  - validate
+  - version
+- name: github.com/google/gofuzz
+  version: bbcb9da2d746f8bdbd6a936686a0a6067ada0ec5
+- name: github.com/jmespath/go-jmespath
+  version: 3433f3ea46d9f8019119e7dd41274e112a2359a9
+- name: github.com/jonboulle/clockwork
+  version: 72f9bd7c4e0c2a40055ab3d0f09654f730cce982
+- name: github.com/juju/ratelimit
+  version: 77ed1c8a01217656d2080ad51981f6e99adaa177
+- name: github.com/kr/pty
+  version: f7ee69f31298ecbe5d2b349c711e2547a617d398
 - name: github.com/libvirt/libvirt-go
-  version: 73c68e67965b65c920e93535bdef7020d79baf6c
+  version: ea3aa1162f01b9a41d4ab1c183f3a4dc59f57273
+- name: github.com/mailru/easyjson
+  version: d5b7844b561a7bc640052f1b935f7b800330d7e0
+  subpackages:
+  - buffer
+  - jlexer
+  - jwriter
+- name: github.com/matttproud/golang_protobuf_extensions
+  version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
+  subpackages:
+  - pbutil
+- name: github.com/Microsoft/go-winio
+  version: 8f9387ea7efabb228a981b9c381142be7667967f
+- name: github.com/mistifyio/go-zfs
+  version: 1b4ae6fb4e77b095934d4430860ff202060169f8
+- name: github.com/mitchellh/go-wordwrap
+  version: ad45545899c7b13c020ea92b2072220eefad42b8
 - name: github.com/nu7hatch/gouuid
   version: 179d4d0c4d8d407a32af483c2354df1d2c91e6c3
+- name: github.com/opencontainers/runc
+  version: 45c30e75abfd52107b53048004a83165403ad0d1
+  subpackages:
+  - libcontainer
+  - libcontainer/apparmor
+  - libcontainer/cgroups
+  - libcontainer/cgroups/fs
+  - libcontainer/cgroups/systemd
+  - libcontainer/configs
+  - libcontainer/configs/validate
+  - libcontainer/criurpc
+  - libcontainer/keys
+  - libcontainer/label
+  - libcontainer/seccomp
+  - libcontainer/selinux
+  - libcontainer/stacktrace
+  - libcontainer/system
+  - libcontainer/user
+  - libcontainer/utils
+- name: github.com/pborman/uuid
+  version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 - name: github.com/pmezard/go-difflib
   version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
+- name: github.com/prometheus/client_golang
+  version: e51041b3fa41cece0dca035740ba6411905be473
+  subpackages:
+  - prometheus
+- name: github.com/prometheus/client_model
+  version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
+  subpackages:
+  - go
+- name: github.com/prometheus/common
+  version: ffe929a3f4c4faeaa10f2b9535c2b1be3ad15650
+  subpackages:
+  - expfmt
+  - model
+- name: github.com/prometheus/procfs
+  version: 454a56f35412459b5e684fd5ec0f9211b94f002a
+- name: github.com/PuerkitoBio/purell
+  version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
+- name: github.com/PuerkitoBio/urlesc
+  version: 5bd2802263f21d8788851d5305584c82a5c75d7e
+- name: github.com/seccomp/libseccomp-golang
+  version: 1b506fc7c24eec5a3693cdcbed40d9c226cfc6a1
+- name: github.com/Sirupsen/logrus
+  version: 51fe59aca108dc5680109e7b2051cbdcfa5a253c
+- name: github.com/spf13/pflag
+  version: 5ccb023bc27df288a957c5e994cd44fd19619465
+- name: github.com/syndtr/gocapability
+  version: e7cb7fa329f456b3855136a2642b197bad7366ba
+  subpackages:
+  - capability
+- name: github.com/ugorji/go
+  version: f1f1a805ed361a0e078bb537e4ea78cd37dcf065
+  subpackages:
+  - codec
+  - codec/codecgen
 - name: github.com/vishvananda/netlink
   version: a4f22d8ad2327663017dbb309b5e3f8b6f348020
   subpackages:
   - nl
 - name: github.com/vishvananda/netns
-  version: 8ba1072b58e0c2a240eb5f6120165c7776c3e7b8
+  version: 2c9454e4fc6e2edc1a1c84e64ed3d6e662fb6991
 - name: go.universe.tf/netboot
-  version: 57a1c9bea27f5d542444c409a768b331fc5e0cb9
+  version: 7e671a0899a237c12a78d95cc849584ff31bd683
   subpackages:
   - dhcp4
+- name: golang.org/x/exp
+  version: 292a51b8d262487dab23a588950e8052d63d9113
+  subpackages:
+  - inotify
 - name: golang.org/x/net
   version: e90d6d0afc4c315a0d87a568ae68577cc15149a0
   subpackages:
   - bpf
   - context
+  - context/ctxhttp
   - http2
   - http2/hpack
+  - idna
   - internal/iana
   - internal/timeseries
   - ipv4
   - lex/httplex
+  - proxy
   - trace
+  - websocket
+- name: golang.org/x/oauth2
+  version: 3c3a985cb79f52a3190fbc056984415ca6763d01
+  subpackages:
+  - google
+  - internal
+  - jws
+  - jwt
 - name: golang.org/x/sys
-  version: e11762ca30adc5b39fdbfd8c4250dabeb8e456d3
+  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
   subpackages:
   - unix
+- name: golang.org/x/text
+  version: 2910a502d2bf9e43193af9d68ca516529614eed3
+  subpackages:
+  - cases
+  - internal/tag
+  - language
+  - runes
+  - secure/bidirule
+  - secure/precis
+  - transform
+  - unicode/bidi
+  - unicode/norm
+  - width
+- name: google.golang.org/appengine
+  version: 4f7eeb5305a4ba1966344836ba4af9996b7b4e05
+  subpackages:
+  - internal
+  - internal/app_identity
+  - internal/base
+  - internal/datastore
+  - internal/log
+  - internal/modules
+  - internal/remote_api
+  - internal/urlfetch
+  - urlfetch
 - name: google.golang.org/grpc
   version: 231b4cfea0e79843053a33f5fe90bd4d84b23cd3
   subpackages:
@@ -99,17 +414,199 @@ imports:
   - naming
   - peer
   - transport
+- name: gopkg.in/inf.v0
+  version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
+- name: gopkg.in/yaml.v2
+  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
 - name: k8s.io/kubernetes
   version: 82450d03cb057bab0950214ef122b67c83fb11df
   repo: git://github.com/kubernetes/kubernetes.git
   vcs: git
   subpackages:
   - api/v1alpha/runtime
+  - pkg/api
+  - pkg/api/errors
+  - pkg/api/install
+  - pkg/api/meta
+  - pkg/api/meta/metatypes
+  - pkg/api/resource
+  - pkg/api/service
+  - pkg/api/unversioned
+  - pkg/api/v1
+  - pkg/api/validation/path
+  - pkg/apimachinery
+  - pkg/apimachinery/announced
+  - pkg/apimachinery/registered
+  - pkg/apis/apps
+  - pkg/apis/apps/install
+  - pkg/apis/apps/v1beta1
+  - pkg/apis/authentication
+  - pkg/apis/authentication/install
+  - pkg/apis/authentication/v1beta1
+  - pkg/apis/authorization
+  - pkg/apis/authorization/install
+  - pkg/apis/authorization/v1beta1
+  - pkg/apis/autoscaling
+  - pkg/apis/autoscaling/install
+  - pkg/apis/autoscaling/v1
+  - pkg/apis/batch
+  - pkg/apis/batch/install
+  - pkg/apis/batch/v1
+  - pkg/apis/batch/v2alpha1
+  - pkg/apis/certificates
+  - pkg/apis/certificates/install
+  - pkg/apis/certificates/v1alpha1
+  - pkg/apis/componentconfig
+  - pkg/apis/componentconfig/install
+  - pkg/apis/componentconfig/v1alpha1
+  - pkg/apis/extensions
+  - pkg/apis/extensions/install
+  - pkg/apis/extensions/v1beta1
+  - pkg/apis/policy
+  - pkg/apis/policy/install
+  - pkg/apis/policy/v1beta1
+  - pkg/apis/rbac
+  - pkg/apis/rbac/install
+  - pkg/apis/rbac/v1alpha1
+  - pkg/apis/storage
+  - pkg/apis/storage/install
+  - pkg/apis/storage/v1beta1
+  - pkg/auth/user
+  - pkg/client/cache
+  - pkg/client/clientset_generated/internalclientset
+  - pkg/client/clientset_generated/internalclientset/typed/apps/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/authentication/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/autoscaling/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/batch/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/certificates/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/core/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/policy/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/storage/internalversion
+  - pkg/client/metrics
+  - pkg/client/record
+  - pkg/client/restclient
+  - pkg/client/transport
+  - pkg/client/typed/discovery
+  - pkg/client/unversioned/clientcmd/api
+  - pkg/cloudprovider
+  - pkg/conversion
+  - pkg/conversion/queryparams
+  - pkg/credentialprovider
   - pkg/fields
+  - pkg/genericapiserver/openapi/common
+  - pkg/httplog
+  - pkg/kubelet/api
   - pkg/kubelet/api/v1alpha1/runtime
+  - pkg/kubelet/cadvisor
+  - pkg/kubelet/cm
+  - pkg/kubelet/cm/util
+  - pkg/kubelet/container
+  - pkg/kubelet/custommetrics
+  - pkg/kubelet/dockershim
+  - pkg/kubelet/dockershim/cm
+  - pkg/kubelet/dockershim/remote
+  - pkg/kubelet/dockertools
+  - pkg/kubelet/events
+  - pkg/kubelet/images
+  - pkg/kubelet/leaky
+  - pkg/kubelet/lifecycle
+  - pkg/kubelet/metrics
+  - pkg/kubelet/network
+  - pkg/kubelet/network/cni
+  - pkg/kubelet/network/hairpin
+  - pkg/kubelet/network/hostport
+  - pkg/kubelet/network/kubenet
+  - pkg/kubelet/prober/results
+  - pkg/kubelet/qos
+  - pkg/kubelet/server/portforward
+  - pkg/kubelet/server/remotecommand
+  - pkg/kubelet/server/streaming
+  - pkg/kubelet/types
+  - pkg/kubelet/util/cache
+  - pkg/kubelet/util/format
+  - pkg/kubelet/util/ioutils
+  - pkg/labels
+  - pkg/master/ports
+  - pkg/proxy
+  - pkg/proxy/healthcheck
+  - pkg/proxy/iptables
+  - pkg/runtime
+  - pkg/runtime/serializer
+  - pkg/runtime/serializer/json
+  - pkg/runtime/serializer/protobuf
+  - pkg/runtime/serializer/recognizer
+  - pkg/runtime/serializer/streaming
+  - pkg/runtime/serializer/versioning
+  - pkg/security/apparmor
+  - pkg/securitycontext
   - pkg/selection
-testImports:
-- name: github.com/sergi/go-diff
-  version: 83532ca1c1caa393179c677b6facf48e61f4ca5d
-  subpackages:
-  - diffmatchpatch
+  - pkg/types
+  - pkg/util
+  - pkg/util/bandwidth
+  - pkg/util/cert
+  - pkg/util/chmod
+  - pkg/util/chown
+  - pkg/util/clock
+  - pkg/util/config
+  - pkg/util/dbus
+  - pkg/util/diff
+  - pkg/util/ebtables
+  - pkg/util/errors
+  - pkg/util/exec
+  - pkg/util/flowcontrol
+  - pkg/util/framer
+  - pkg/util/hash
+  - pkg/util/httpstream
+  - pkg/util/httpstream/spdy
+  - pkg/util/integer
+  - pkg/util/interrupt
+  - pkg/util/intstr
+  - pkg/util/io
+  - pkg/util/iptables
+  - pkg/util/json
+  - pkg/util/jsonpath
+  - pkg/util/labels
+  - pkg/util/mount
+  - pkg/util/net
+  - pkg/util/net/sets
+  - pkg/util/oom
+  - pkg/util/parsers
+  - pkg/util/procfs
+  - pkg/util/rand
+  - pkg/util/runtime
+  - pkg/util/selinux
+  - pkg/util/sets
+  - pkg/util/slice
+  - pkg/util/strategicpatch
+  - pkg/util/strings
+  - pkg/util/sysctl
+  - pkg/util/term
+  - pkg/util/uuid
+  - pkg/util/validation
+  - pkg/util/validation/field
+  - pkg/util/wait
+  - pkg/util/workqueue
+  - pkg/util/wsstream
+  - pkg/util/yaml
+  - pkg/version
+  - pkg/volume
+  - pkg/volume/util
+  - pkg/watch
+  - pkg/watch/versioned
+  - plugin/pkg/client/auth
+  - plugin/pkg/client/auth/gcp
+  - plugin/pkg/client/auth/oidc
+  - plugin/pkg/scheduler/algorithm
+  - plugin/pkg/scheduler/algorithm/predicates
+  - plugin/pkg/scheduler/algorithm/priorities/util
+  - plugin/pkg/scheduler/api
+  - plugin/pkg/scheduler/schedulercache
+  - third_party/forked/golang/expansion
+  - third_party/forked/golang/json
+  - third_party/forked/golang/netutil
+  - third_party/forked/golang/reflect
+  - third_party/forked/golang/template
+testImports: []

--- a/pkg/criproxy/bootstrap.go
+++ b/pkg/criproxy/bootstrap.go
@@ -117,6 +117,10 @@ type Bootstrap struct {
 	kubeletCfg map[string]interface{}
 }
 
+// NewBootstrap creates a new Bootstrap object used for CRI proxy
+// bootstrap using the specified BootstrapConfig. cs argument
+// is used to pass a fake Clientset during tests, it should
+// be nil when performing real bootstrap.
 func NewBootstrap(config *BootstrapConfig, cs clientset.Interface) *Bootstrap {
 	return &Bootstrap{config: config, clientset: cs}
 }
@@ -313,6 +317,8 @@ func (b *Bootstrap) initClientset() error {
 	return nil
 }
 
+// EnsureCRIProxy checks whether kubelet configuration file exists
+// and performs CRI proxy bootstrap procedure if it doesn't.
 func (b *Bootstrap) EnsureCRIProxy() (bool, error) {
 	if b.config.ConfigzBaseUrl == "" || b.config.StatsBaseUrl == "" || b.config.ProxyPath == "" || b.config.ProxySocketPath == "" {
 		return false, errors.New("invalid BootstrapConfig")
@@ -364,6 +370,7 @@ func (b *Bootstrap) EnsureCRIProxy() (bool, error) {
 	return true, nil
 }
 
+// LoadKubeletConfig loads kubelet configuration from a json file
 func LoadKubeletConfig(path string) (*cfg.KubeletConfiguration, error) {
 	bs, err := ioutil.ReadFile(path)
 	if err != nil {

--- a/pkg/criproxy/bootstrap.go
+++ b/pkg/criproxy/bootstrap.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 Mirantis
+Copyright 2017 Mirantis
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/criproxy/bootstrap.go
+++ b/pkg/criproxy/bootstrap.go
@@ -1,0 +1,327 @@
+/*
+Copyright 2016 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package criproxy
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	// TODO: switch to https://github.com/docker/docker/tree/master/client
+	// Docker version used in k8s is too old for it
+	dockermessage "github.com/docker/docker/pkg/jsonmessage"
+	dockerclient "github.com/docker/engine-api/client"
+	dockertypes "github.com/docker/engine-api/types"
+	dockercontainer "github.com/docker/engine-api/types/container"
+	dockerfilters "github.com/docker/engine-api/types/filters"
+
+	// FIXME: use client-go
+	// In particular, see https://github.com/kubernetes/client-go/blob/master/examples/in-cluster/main.go
+	"k8s.io/kubernetes/pkg/api"
+	cfg "k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/client/restclient"
+)
+
+const (
+	// TODO: use the same constant/setting in different parts of code
+	proxyRuntimeEndpoint    = "/run/criproxy.sock"
+	internalDockerEndpoint  = "/var/run/docker.sock"
+	busyboxImageName        = "busybox:1.26.2"
+	proxyStopTimeoutSeconds = 5
+	confFileMode            = 0600
+)
+
+var kubeletSettingsForCriProxy map[string]interface{} = map[string]interface{}{
+	"containerRuntime":      "remote",
+	"enableCRI":             true,
+	"remoteRuntimeEndpoint": proxyRuntimeEndpoint,
+	"remoteImageEndpoint":   proxyRuntimeEndpoint,
+}
+
+func loadJson(baseUrl, suffix string) (map[string]interface{}, error) {
+	url := strings.TrimSuffix(baseUrl, "/") + suffix
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	client := &http.Client{Transport: tr}
+	res, err := client.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("trying to get %q: %v", url, err)
+	}
+
+	defer res.Body.Close()
+	var r map[string]interface{}
+	d := json.NewDecoder(res.Body)
+	d.UseNumber() // avoid getting floats
+	if err := d.Decode(&r); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal json from %q: %v", url, err)
+	}
+	return r, nil
+}
+
+func writeJson(data interface{}, path string) error {
+	bs, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("failed to marshal json: %v", err)
+	}
+	if err := ioutil.WriteFile(path, bs, confFileMode); err != nil {
+		return fmt.Errorf("error writing %q: %v", path, err)
+	}
+	return nil
+}
+
+func getKubeletConfig(configzBaseUrl string) (map[string]interface{}, error) {
+	cfg, err := loadJson(configzBaseUrl, "/configz")
+	if err != nil {
+		return nil, err
+	}
+	kubeletCfg, ok := cfg["componentconfig"].(map[string]interface{})
+	if !ok {
+		return nil, errors.New("couldn't get componentconfig from /configz")
+	}
+	return kubeletCfg, nil
+}
+
+func kubeletUpdated(kubeletCfg map[string]interface{}) bool {
+	for k, v := range kubeletSettingsForCriProxy {
+		if kubeletCfg[k] != v {
+			return false
+		}
+	}
+	return true
+}
+func updateKubeletConfig(kubeletCfg map[string]interface{}) {
+	for k, v := range kubeletSettingsForCriProxy {
+		kubeletCfg[k] = v
+	}
+}
+
+func getNodeNameFromKubelet(statsBaseUrl string) (string, error) {
+	stats, err := loadJson(statsBaseUrl, "/stats/summary")
+	if err != nil {
+		return "", err
+	}
+	nodeProps, ok := stats["node"].(map[string]interface{})
+	if !ok {
+		return "", errors.New("couldn't get node properties /stats/summary")
+	}
+	nodeName, _ := nodeProps["nodeName"].(string)
+	if nodeName == "" {
+		return "", errors.New("couldn't get node name via /stats/summary")
+	}
+	return nodeName, nil
+}
+
+func buildConfigMap(nodeName string, kubeletCfg map[string]interface{}) *api.ConfigMap {
+	text, err := json.Marshal(kubeletCfg)
+	if err != nil {
+		log.Panicf("couldn't marshal kubelet config: %v", err)
+	}
+	return &api.ConfigMap{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "kubelet-" + nodeName,
+			Namespace: "kube-system",
+		},
+		Data: map[string]string{
+			"kubelet.config": string(text),
+		},
+	}
+}
+
+func putConfigMap(cs clientset.Interface, configMap *api.ConfigMap) error {
+	_, err := cs.Core().ConfigMaps("kube-system").Create(configMap)
+	return err
+}
+
+func patchKubeletConfig(configzBaseUrl, statsBaseUrl, savedConfigPath string, cs clientset.Interface) (patched bool, dockerEndpoint string, err error) {
+	kubeletCfg, err := getKubeletConfig(configzBaseUrl)
+	if err != nil {
+		return false, "", err
+	}
+	if kubeletUpdated(kubeletCfg) {
+		return false, "", nil
+	}
+	if err := writeJson(kubeletCfg, savedConfigPath); err != nil {
+		return false, "", err
+	}
+	updateKubeletConfig(kubeletCfg)
+
+	dockerEp, ok := kubeletCfg["dockerEndpoint"].(string)
+	if !ok {
+		return false, "", errors.New("failed to retrieve docker endpoint from kubelet config")
+	}
+
+	nodeName, err := getNodeNameFromKubelet(statsBaseUrl)
+	if err != nil {
+		return false, "", err
+	}
+	if err := putConfigMap(cs, buildConfigMap(nodeName, kubeletCfg)); err != nil {
+		return false, "", fmt.Errorf("failed to put ConfigMap: %v", err)
+	}
+	return true, dockerEp, nil
+}
+
+func pullImage(ctx context.Context, client *dockerclient.Client, imageName string, print bool) error {
+	resp, err := client.ImagePull(ctx, imageName, dockertypes.ImagePullOptions{})
+	if err != nil {
+		return fmt.Errorf("Failed to pull busybox image: %v", err)
+	}
+
+	decoder := json.NewDecoder(resp)
+	for {
+		var msg dockermessage.JSONMessage
+		err := decoder.Decode(&msg)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("error decoding docker message: %v", err)
+		}
+		if msg.Error != nil {
+			return msg.Error
+		}
+		if print {
+			fmt.Println(msg.Status)
+		}
+	}
+	return nil
+}
+
+func installCriProxyContainer(dockerEndpoint, endpointToPass, proxyPath string, args []string) (string, error) {
+	ctx := context.Background()
+
+	client, err := dockerclient.NewClient(dockerEndpoint, "", nil, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create Docker client: %v", err)
+	}
+
+	filterArgs := dockerfilters.NewArgs()
+	filterArgs.Add("label", "criproxy")
+	containers, err := client.ContainerList(ctx, dockertypes.ContainerListOptions{
+		Filter: filterArgs,
+	})
+	if len(containers) > 0 {
+		for _, container := range containers {
+			if err := client.ContainerRemove(ctx, container.ID, dockertypes.ContainerRemoveOptions{
+				Force: true,
+			}); err != nil {
+				return "", fmt.Errorf("failed to remove old container: %v", err)
+			}
+		}
+	}
+
+	if err := pullImage(ctx, client, busyboxImageName, true); err != nil {
+		return "", fmt.Errorf("failed to pull busybox image: %v", err)
+	}
+
+	binds := []string{
+		"/run:/run",
+		fmt.Sprintf("%s:%s", proxyPath, "/criproxy"),
+	}
+	if strings.HasPrefix(endpointToPass, "unix://") {
+		// mount the endpoint as a fixed path into the proxy container
+		socketPath := strings.TrimPrefix(endpointToPass, "unix://")
+		binds = append(binds, fmt.Sprintf("%s:%s", socketPath, internalDockerEndpoint))
+		endpointToPass = "unix://" + internalDockerEndpoint
+	}
+	containerName := fmt.Sprintf("criproxy-%d", time.Now().UnixNano())
+	resp, err := client.ContainerCreate(ctx, &dockercontainer.Config{
+		Image:  busyboxImageName,
+		Labels: map[string]string{"criproxy": "true"},
+		Env:    []string{"DOCKER_HOST=" + endpointToPass},
+		Cmd:    append([]string{"/criproxy"}, args...),
+	}, &dockercontainer.HostConfig{
+		// the proxy should be able to connect to a docker endpoint on localhost, too
+		NetworkMode: "host",
+		Binds:       binds,
+		RestartPolicy: dockercontainer.RestartPolicy{
+			Name: "always",
+		},
+	}, nil, containerName)
+	if err != nil {
+		return "", fmt.Errorf("failed to create CRI proxy container: %v", err)
+	}
+	if err := client.ContainerStart(ctx, resp.ID); err != nil {
+		client.ContainerRemove(ctx, resp.ID, dockertypes.ContainerRemoveOptions{
+			Force: true,
+		})
+		return "", fmt.Errorf("failed to start CRI proxy container: %v", err)
+	}
+	return resp.ID, nil
+}
+
+type BootstrapConfig struct {
+	ConfigzBaseUrl  string
+	StatsBaseUrl    string
+	SavedConfigPath string
+	ProxyPath       string
+	ProxyArgs       []string
+	ProxySocketPath string
+}
+
+func EnsureCRIProxy(bootConfig *BootstrapConfig) (bool, error) {
+	if bootConfig.ConfigzBaseUrl == "" || bootConfig.StatsBaseUrl == "" || bootConfig.ProxyPath == "" || bootConfig.ProxySocketPath == "" {
+		return false, errors.New("invalid BootstrapConfig")
+	}
+	config, err := restclient.InClusterConfig()
+	if err != nil {
+		return false, fmt.Errorf("failed to get REST client config: %v", err)
+	}
+
+	clientset, err := clientset.NewForConfig(config)
+	if err != nil {
+		return false, fmt.Errorf("failed to create ClientSet: %v", err)
+	}
+
+	patched, dockerEndpoint, err := patchKubeletConfig(bootConfig.ConfigzBaseUrl, bootConfig.StatsBaseUrl, bootConfig.SavedConfigPath, clientset)
+	if err != nil {
+		return false, err
+	}
+	if !patched {
+		return false, nil
+	}
+
+	_, err = installCriProxyContainer(dockerEndpoint, dockerEndpoint, bootConfig.ProxyPath, bootConfig.ProxyArgs)
+
+	if err != nil {
+		return false, err
+	}
+
+	err = waitForSocket(bootConfig.ProxySocketPath)
+	return err == nil, err
+}
+
+func LoadKubeletConfig(path string) (*cfg.KubeletConfiguration, error) {
+	bs, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var cfg cfg.KubeletConfiguration
+	if err := json.Unmarshal(bs, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to load kubelet config from %q: %v", path, err)
+	}
+	return &cfg, err
+}

--- a/pkg/criproxy/bootstrap.go
+++ b/pkg/criproxy/bootstrap.go
@@ -172,7 +172,7 @@ func (b *Bootstrap) getNodeNameFromKubelet() (string, error) {
 func (b *Bootstrap) buildConfigMap(nodeName string) *api.ConfigMap {
 	text, err := json.Marshal(b.kubeletCfg)
 	if err != nil {
-		log.Panicf("couldn't marshal kubelet config: %v", err)
+		log.Panicf("Couldn't marshal kubelet config: %v", err)
 	}
 	return &api.ConfigMap{
 		ObjectMeta: api.ObjectMeta{
@@ -194,7 +194,7 @@ func (b *Bootstrap) putConfigMap(configMap *api.ConfigMap) error {
 func (b *Bootstrap) needToPatch() (bool, error) {
 	_, err := os.Stat(b.config.SavedConfigPath)
 	if err == nil {
-		glog.V(1).Infof("config file already exists: %q", b.config.SavedConfigPath)
+		glog.V(1).Infof("Config file already exists: %q", b.config.SavedConfigPath)
 		return false, nil
 	}
 	if os.IsNotExist(err) {

--- a/pkg/criproxy/bootstrap_test.go
+++ b/pkg/criproxy/bootstrap_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 Mirantis
+Copyright 2017 Mirantis
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/criproxy/bootstrap_test.go
+++ b/pkg/criproxy/bootstrap_test.go
@@ -369,8 +369,5 @@ func TestInstallCriProxyContainer(t *testing.T) {
 // That's 'readOnlyPort' -- may use this to get node name,
 // then access configz via the proxy. (/stats/exec is also available via configz)
 //
-// "k8s.io/kubernetes/pkg/api" (perhaps try using client-go instead?)
-// api.Scheme.Default
-// TODO: test 'don't patch config again'
 // TODO: patching kubelet config from existing configmap
 // (see setKubeletConfiguration in k8s' test/e2e_node/util.go)

--- a/pkg/criproxy/bootstrap_test.go
+++ b/pkg/criproxy/bootstrap_test.go
@@ -1,0 +1,355 @@
+/*
+Copyright 2016 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package criproxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	dockerstdcopy "github.com/docker/docker/pkg/stdcopy"
+	dockerclient "github.com/docker/engine-api/client"
+	dockertypes "github.com/docker/engine-api/types"
+	dockercontainer "github.com/docker/engine-api/types/container"
+
+	// TODO: use client-go
+	"k8s.io/kubernetes/pkg/api"
+	_ "k8s.io/kubernetes/pkg/api/testapi"
+	cfg "k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1"
+	clientsetfake "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
+	testingcore "k8s.io/kubernetes/pkg/client/testing/core"
+	"k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/stats"
+)
+
+func getStruct(s interface{}) reflect.Value {
+	v := reflect.ValueOf(s)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		log.Panicf("struct or pointer to struct expected, but got %#v", s)
+	}
+	return v
+}
+
+func diffStructs(old, new interface{}) map[string]interface{} {
+	vOld := getStruct(old)
+	vNew := getStruct(new)
+	if vOld.Type() != vNew.Type() {
+		log.Panicf("got different struct types")
+	}
+	r := make(map[string]interface{})
+	for i, n := 0, vOld.NumField(); i < n; i++ {
+		if !reflect.DeepEqual(vOld.Field(i).Interface(), vNew.Field(i).Interface()) {
+			r[vOld.Type().Field(i).Name] = vNew.Field(i).Interface()
+		}
+	}
+	return r
+}
+
+func mustMarshalJson(data interface{}) []byte {
+	text, err := json.Marshal(data)
+	if err != nil {
+		panic("failed to marshal json")
+	}
+	return text
+}
+
+func TestPatchKubeletConfig(t *testing.T) {
+	var kubeCfg cfg.KubeletConfiguration
+	api.Scheme.Default(&kubeCfg)
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var v interface{}
+		switch r.URL.Path {
+		case "/configz":
+			v = map[string]interface{}{"componentconfig": &kubeCfg}
+		case "/stats/summary":
+			v = &stats.Summary{Node: stats.NodeStats{NodeName: "samplenode"}}
+		default:
+			http.NotFound(w, r)
+			return
+		}
+		w.Write(mustMarshalJson(v))
+	}))
+
+	tc := clientsetfake.NewSimpleClientset()
+
+	tmpDir, err := ioutil.TempDir("", "criproxy-test")
+	if err != nil {
+		t.Fatalf("TempDir(): %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	confFileName := path.Join(tmpDir, "kubelet.conf")
+
+	patched, dockerEndpoint, err := patchKubeletConfig(s.URL, s.URL, confFileName, tc)
+	if err != nil {
+		t.Fatalf("patchKubeletConfig(): %v", err)
+	}
+
+	savedCfg, err := LoadKubeletConfig(confFileName)
+	if err != nil {
+		t.Fatalf("loadKubeletConfig: %v", err)
+	}
+
+	if string(mustMarshalJson(savedCfg)) != string(mustMarshalJson(kubeCfg)) {
+		t.Fatalf("bad saved kubelet config: %s", spew.Sdump(savedCfg))
+	}
+
+	if dockerEndpoint != "unix:///var/run/docker.sock" {
+		t.Errorf("unexpected dockerEndpoint: %q", dockerEndpoint)
+	}
+
+	if !patched {
+		t.Errorf("patchKubeletConfig returned false")
+	}
+
+	actions := tc.Fake.Actions()
+	if len(actions) != 1 || actions[0].GetNamespace() != "kube-system" || actions[0].GetVerb() != "create" {
+		t.Fatalf("invalid clientset actions: %s", spew.Sdump(actions))
+	}
+	o := actions[0].(testingcore.CreateAction).GetObject()
+	cfgMap, ok := o.(*api.ConfigMap)
+	if !ok || cfgMap.Name != "kubelet-samplenode" || cfgMap.Namespace != "kube-system" || cfgMap.Data["kubelet.config"] == "" {
+		t.Fatalf("invalid object created: %s", spew.Sdump(o))
+	}
+
+	var newKubeCfg cfg.KubeletConfiguration
+	if err := json.Unmarshal([]byte(cfgMap.Data["kubelet.config"]), &newKubeCfg); err != nil {
+		t.Fatalf("Failed to unmarshal kubelet config: %v", err)
+	}
+
+	expectedDiff := map[string]interface{}{
+		"EnableCRI":             true,
+		"ContainerRuntime":      "remote",
+		"RemoteRuntimeEndpoint": "/run/criproxy.sock",
+		"RemoteImageEndpoint":   "/run/criproxy.sock",
+	}
+	diff := diffStructs(&kubeCfg, &newKubeCfg)
+	if !reflect.DeepEqual(diff, expectedDiff) {
+		m, err := json.MarshalIndent(diff, "", "  ")
+		if err != nil {
+			t.Fatalf("can't marshal struct diff: %v", err)
+		}
+		t.Errorf("bad kubelet config diff:\n%s", m)
+	}
+
+	kubeCfg = newKubeCfg
+	patched, _, err = patchKubeletConfig(s.URL, s.URL, confFileName, tc)
+	if err != nil {
+		t.Errorf("Calling patchKubeletConfig() with already patched config failed: %v", err)
+	}
+	if patched {
+		t.Errorf("patchKubeletConfig() with already patched config call returned true")
+	}
+}
+
+// This is a simple way to do it (untested), but it requires docker client to be present in build container:
+//
+// func runCommandViaDocker(t *testing.T, shellCommand, stdin string) string {
+// 	cmd := exec.Command("docker", "exec", "-i", "-v", "/tmp:/tmp", "--rm", busyboxImageName, "/bin/sh", "-c", shellCommand)
+// 	if stdin != "" {
+// 		cmd.Stdin = strings.NewReader(stdin)
+// 	}
+// 	out, err := cmd.Output()
+// 	if err != nil {
+// 		t.Fatalf("failed to run %q via docker: %v", shellCommand, err)
+// 	}
+// 	return strings.TrimSpace(string(out))
+// }
+
+func removeContainer(t *testing.T, containerId string) {
+	ctx := context.Background()
+	client, err := dockerclient.NewEnvClient()
+	if err != nil {
+		t.Fatalf("Can't create Docker client: %v", err)
+	}
+	if err := client.ContainerRemove(ctx, containerId, dockertypes.ContainerRemoveOptions{
+		Force: true,
+	}); err != nil {
+		t.Fatalf("ContainerRemove(): %v")
+	}
+}
+
+func runCommandViaDocker(t *testing.T, shellCommand, stdin string) string {
+	ctx := context.Background()
+	client, err := dockerclient.NewEnvClient()
+	if err != nil {
+		t.Fatalf("Can't create Docker client: %v", err)
+	}
+
+	if err := pullImage(ctx, client, busyboxImageName, false); err != nil {
+		t.Fatalf("Failed to pull busybox image: %v", err)
+	}
+
+	haveStdin := stdin != ""
+	containerName := fmt.Sprintf("criproxy-test-%d", time.Now().UnixNano())
+	resp, err := client.ContainerCreate(ctx, &dockercontainer.Config{
+		Image:       busyboxImageName,
+		Cmd:         []string{"/bin/sh", "-c", shellCommand},
+		AttachStdin: haveStdin,
+		OpenStdin:   haveStdin,
+		StdinOnce:   haveStdin,
+	}, &dockercontainer.HostConfig{
+		Binds: []string{"/tmp:/tmp", "/run:/run"},
+	}, nil, containerName)
+	containerId := resp.ID
+
+	defer removeContainer(t, containerId)
+
+	var hijacked dockertypes.HijackedResponse
+	if haveStdin {
+		hijacked, err = client.ContainerAttach(ctx, containerId, dockertypes.ContainerAttachOptions{
+			Stdin:  true,
+			Stream: true,
+		})
+		if err != nil {
+			t.Fatalf("ContainerAttach(): %v", err)
+		}
+	}
+
+	if err := client.ContainerStart(ctx, containerId); err != nil {
+		if hijacked.Conn != nil {
+			hijacked.Conn.Close()
+		}
+		t.Fatalf("failed to start CRI proxy container: %v", err)
+	}
+
+	if haveStdin {
+		if _, err := hijacked.Conn.Write([]byte(stdin)); err != nil {
+			hijacked.Conn.Close()
+			t.Fatalf("Failed to write to hijacked connection: %v", err)
+		}
+
+		if err := hijacked.Conn.Close(); err != nil {
+			t.Fatalf("Failed to close hijacked connection: %v", err)
+		}
+	}
+
+	status, err := client.ContainerWait(ctx, containerId)
+	if err != nil {
+		t.Fatalf("ContainerWait(): %v", err)
+	}
+
+	// We prefer to grabs logs there instead of attaching to container's stdout/stderr
+	// because of this issue: https://github.com/docker/docker/issues/29285
+	logs, err := client.ContainerLogs(ctx, containerId, dockertypes.ContainerLogsOptions{
+		ShowStdout: true,
+		ShowStderr: true,
+	})
+	if err != nil {
+		t.Fatalf("ContainerLogs(): %v", err)
+	}
+	defer logs.Close()
+
+	var outBuf, errBuf bytes.Buffer
+	_, err = dockerstdcopy.StdCopy(&outBuf, &errBuf, logs)
+	if err != nil {
+		t.Fatalf("stdcopy: %v", err)
+	}
+
+	if status != 0 {
+		t.Fatalf("%q: container exited with non-zero code: %d. Stderr:\n%s", shellCommand, status, errBuf.String())
+	}
+
+	return strings.TrimSpace(outBuf.String())
+}
+
+func writeScript(t *testing.T, text string) string {
+	return runCommandViaDocker(t, "name=`mktemp`;cat >$name;chmod +x $name;echo $name", text)
+}
+
+const (
+	fakeProxyScriptText = `#!/bin/sh
+if [ ! -f @@ ]; then
+  # the checker will have to wait
+  echo >&2 "/run not mounted"
+elif [ "$1" != a -o "$2" != b ]; then
+  echo "fail: args not passed" >@@
+elif [ ! -S /var/run/docker.sock ]; then
+  echo "Failed to locate /var/run/docker.sock" >@@
+else
+  echo ok > @@
+fi
+sleep 10000
+`
+	checkerScriptText = `#!/bin/sh
+for i in $(seq 1 60); do
+  if grep fail @@; then
+    cat >&2 @@
+  elif grep ok @@; then
+    exit 0
+  fi
+  sleep 1
+done
+echo >&2 "Timed out wating for test results"
+exit 1
+`
+)
+
+func TestInstallCriProxyContainer(t *testing.T) {
+	endpointToPass := os.Getenv("CRIPROXY_TEST_REMOTE_DOCKER_ENDPOINT")
+	if endpointToPass == "" {
+		t.Skip("You must set CRIPROXY_TEST_REMOTE_DOCKER_ENDPOINT to run this test")
+	}
+	dockerEndpoint := os.Getenv("DOCKER_HOST")
+	if dockerEndpoint == "" {
+		dockerEndpoint = dockerclient.DefaultDockerHost
+	}
+
+	var rm []string
+	checkFile := runCommandViaDocker(t, "mktemp /run/criproxy-check-XXXXXX", "")
+	rm = append(rm, checkFile)
+	defer runCommandViaDocker(t, "rm -f "+strings.Join(rm, " "), "")
+
+	fakeProxyScript := writeScript(t, strings.Replace(fakeProxyScriptText, "@@", checkFile, -1))
+	rm = append(rm, fakeProxyScript)
+
+	checkerScript := writeScript(t, strings.Replace(checkerScriptText, "@@", checkFile, -1))
+	rm = append(rm, checkerScript)
+
+	containerId, err := installCriProxyContainer(dockerEndpoint, endpointToPass, fakeProxyScript, []string{"a", "b"})
+	if err != nil {
+		t.Fatalf("Failed to install CRI proxy container: %v", err)
+	}
+	defer removeContainer(t, containerId)
+
+	runCommandViaDocker(t, checkerScript, "")
+}
+
+// TODO: concerning getting node name et al:
+// https://github.com/kubernetes/kubernetes/blob/v1.5.2/test/e2e_node/util.go#L48
+// That's 'readOnlyPort' -- may use this to get node name,
+// then access configz via the proxy. (/stats/exec is also available via configz)
+//
+// "k8s.io/kubernetes/pkg/api" (perhaps try using client-go instead?)
+// api.Scheme.Default
+// TODO: test 'don't patch config again'
+// TODO: patching kubelet config from existing configmap
+// (see setKubeletConfiguration in k8s' test/e2e_node/util.go)

--- a/pkg/criproxy/bootstrap_test.go
+++ b/pkg/criproxy/bootstrap_test.go
@@ -53,7 +53,7 @@ func getStruct(s interface{}) reflect.Value {
 		v = v.Elem()
 	}
 	if v.Kind() != reflect.Struct {
-		log.Panicf("struct or pointer to struct expected, but got %#v", s)
+		log.Panicf("Struct or pointer to struct expected, but got %#v", s)
 	}
 	return v
 }
@@ -62,7 +62,7 @@ func diffStructs(old, new interface{}) map[string]interface{} {
 	vOld := getStruct(old)
 	vNew := getStruct(new)
 	if vOld.Type() != vNew.Type() {
-		log.Panicf("got different struct types")
+		log.Panicf("Got different struct types")
 	}
 	r := make(map[string]interface{})
 	for i, n := 0, vOld.NumField(); i < n; i++ {

--- a/pkg/criproxy/dockershim.go
+++ b/pkg/criproxy/dockershim.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 Mirantis
+Copyright 2017 Mirantis
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/criproxy/dockershim.go
+++ b/pkg/criproxy/dockershim.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2016 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package criproxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+
+	"github.com/golang/glog"
+
+	dockerclient "github.com/docker/engine-api/client"
+
+	"k8s.io/kubernetes/pkg/apis/componentconfig"
+	cfg "k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1"
+	"k8s.io/kubernetes/pkg/kubelet/dockershim"
+	dockerremote "k8s.io/kubernetes/pkg/kubelet/dockershim/remote"
+	"k8s.io/kubernetes/pkg/kubelet/dockertools"
+	"k8s.io/kubernetes/pkg/kubelet/server/streaming"
+)
+
+const (
+	dockerShimSocket = "/var/run/proxy-dockershim.sock"
+	// This label is used to identify the containers from non-CRI docker runtime
+	plainDockerRuntimeContainerLabel = "io.kubernetes.container.hash"
+)
+
+// effectiveHairpinMode determines the effective hairpin mode given the
+// configured mode, container runtime, and whether cbr0 should be configured.
+// From kubelet_network.go
+func effectiveHairpinMode(hairpinMode componentconfig.HairpinMode, containerRuntime string, networkPlugin string) (componentconfig.HairpinMode, error) {
+	// The hairpin mode setting doesn't matter if:
+	// - We're not using a bridge network. This is hard to check because we might
+	//   be using a plugin.
+	// - It's set to hairpin-veth for a container runtime that doesn't know how
+	//   to set the hairpin flag on the veth's of containers. Currently the
+	//   docker runtime is the only one that understands this.
+	// - It's set to "none".
+	if hairpinMode == componentconfig.PromiscuousBridge || hairpinMode == componentconfig.HairpinVeth {
+		// Only on docker.
+		if containerRuntime != "docker" {
+			glog.Warningf("Hairpin mode set to %q but container runtime is %q, ignoring", hairpinMode, containerRuntime)
+			return componentconfig.HairpinNone, nil
+		}
+		if hairpinMode == componentconfig.PromiscuousBridge && networkPlugin != "kubenet" {
+			// This is not a valid combination, since promiscuous-bridge only works on kubenet. Users might be using the
+			// default values (from before the hairpin-mode flag existed) and we
+			// should keep the old behavior.
+			glog.Warningf("Hairpin mode set to %q but kubenet is not enabled, falling back to %q", hairpinMode, componentconfig.HairpinVeth)
+			return componentconfig.HairpinVeth, nil
+		}
+	} else if hairpinMode != componentconfig.HairpinNone {
+		return "", fmt.Errorf("unknown value: %q", hairpinMode)
+	}
+	return hairpinMode, nil
+}
+
+func getAddressForStreaming() (string, error) {
+	// FIXME: see kubelet.setNodeAddress
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "", err
+	}
+	addrs, err := net.LookupIP(hostname)
+	for _, addr := range addrs {
+		if !addr.IsLoopback() && addr.To4() != nil {
+			return addr.String(), nil
+		}
+	}
+	return "", errors.New("unable to get IP address")
+}
+
+func StartDockerShim(kubeCfg *cfg.KubeletConfiguration) (string, error) {
+	hairpinMode, err := effectiveHairpinMode(componentconfig.HairpinMode(kubeCfg.HairpinMode), kubeCfg.ContainerRuntime, kubeCfg.NetworkPluginName)
+	if err != nil {
+		return "", fmt.Errorf("invalid hairpin mode: %v", err)
+	}
+
+	streamingAddr, err := getAddressForStreaming()
+	if err != nil {
+		return "", err
+	}
+
+	cniBinDir := kubeCfg.CNIBinDir
+	if cniBinDir == "" {
+		cniBinDir = kubeCfg.NetworkPluginDir
+	}
+	pluginSettings := dockershim.NetworkPluginSettings{
+		HairpinMode:       hairpinMode,
+		NonMasqueradeCIDR: kubeCfg.NonMasqueradeCIDR,
+		PluginName:        kubeCfg.NetworkPluginName,
+		PluginConfDir:     kubeCfg.CNIConfDir,
+		PluginBinDir:      cniBinDir,
+		MTU:               int(kubeCfg.NetworkPluginMTU),
+	}
+	dockerClient := dockertools.ConnectToDockerOrDie(kubeCfg.DockerEndpoint, kubeCfg.RuntimeRequestTimeout.Duration)
+
+	streamingConfig := &streaming.Config{
+		Addr:                  streamingAddr + ":12345", // FIXME
+		StreamIdleTimeout:     kubeCfg.StreamingConnectionIdleTimeout.Duration,
+		StreamCreationTimeout: streaming.DefaultConfig.StreamCreationTimeout,
+		SupportedProtocols:    streaming.DefaultConfig.SupportedProtocols,
+	}
+
+	ds, err := dockershim.NewDockerService(dockerClient, kubeCfg.SeccompProfileRoot, kubeCfg.PodInfraContainerImage, streamingConfig, &pluginSettings, kubeCfg.RuntimeCgroups)
+	if err != nil {
+		return "", err
+	}
+
+	httpServer := &http.Server{
+		Addr:    streamingConfig.Addr,
+		Handler: ds,
+		// TODO: TLSConfig?
+	}
+	go func() {
+		if err := httpServer.ListenAndServe(); err != nil {
+			glog.Errorf("Failed to start http server: %v", err)
+		}
+	}()
+
+	server := dockerremote.NewDockerServer(dockerShimSocket, ds)
+	glog.V(2).Infof("Starting the GRPC server for the docker CRI shim.")
+	if err := server.Start(); err != nil {
+		return "", err
+	}
+
+	return dockerShimSocket, nil
+}
+
+func RemoveContainersFromDefaultDockerRuntime(kubeCfg *cfg.KubeletConfiguration) error {
+	// The following is the same as this command:
+	// docker ps -f label=io.kubernetes.container.hash -qa|xargs docker rm -fv
+	client, err := dockerclient.NewClient(kubeCfg.DockerEndpoint, "", nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create Docker client: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := removeContainersByLabels(ctx, client, plainDockerRuntimeContainerLabel); err != nil {
+		return fmt.Errorf("failed to remove the containers from plain docker runtime: %v", err)
+	}
+	return nil
+}
+
+// TODO: kill of 'plain' docker containers:
+// docker ps -f label=io.kubernetes.container.hash -qa|xargs docker rm -fv

--- a/pkg/criproxy/dockershim.go
+++ b/pkg/criproxy/dockershim.go
@@ -87,6 +87,8 @@ func getAddressForStreaming() (string, error) {
 	return "", errors.New("unable to get IP address")
 }
 
+// StartDockerShim starts in-process docker-shim using the specified
+// kubelet configuration
 func StartDockerShim(kubeCfg *cfg.KubeletConfiguration) (string, error) {
 	hairpinMode, err := effectiveHairpinMode(componentconfig.HairpinMode(kubeCfg.HairpinMode), kubeCfg.ContainerRuntime, kubeCfg.NetworkPluginName)
 	if err != nil {

--- a/pkg/criproxy/dockertools.go
+++ b/pkg/criproxy/dockertools.go
@@ -83,5 +83,3 @@ func pullImage(ctx context.Context, client *dockerclient.Client, imageName strin
 	}
 	return nil
 }
-
-// TODO: remove containers by label(s)

--- a/pkg/criproxy/dockertools.go
+++ b/pkg/criproxy/dockertools.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 Mirantis
+Copyright 2017 Mirantis
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/criproxy/dockertools.go
+++ b/pkg/criproxy/dockertools.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2016 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package criproxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	// TODO: switch to https://github.com/docker/docker/tree/master/client
+	// Docker version used in k8s is too old for it
+	dockermessage "github.com/docker/docker/pkg/jsonmessage"
+	dockerclient "github.com/docker/engine-api/client"
+	dockertypes "github.com/docker/engine-api/types"
+	dockerfilters "github.com/docker/engine-api/types/filters"
+
+	"github.com/golang/glog"
+)
+
+func removeContainersByLabels(ctx context.Context, client *dockerclient.Client, labels ...string) error {
+	filterArgs := dockerfilters.NewArgs()
+	for _, label := range labels {
+		filterArgs.Add("label", label)
+	}
+	containers, err := client.ContainerList(ctx, dockertypes.ContainerListOptions{
+		Filter: filterArgs,
+		All:    true,
+	})
+	if err != nil {
+		return fmt.Errorf("error listing containers: %v", err)
+	}
+	if len(containers) > 0 {
+		for _, container := range containers {
+			glog.V(1).Infof("Removing old CRI proxy container %s", container.ID)
+			if err := client.ContainerRemove(ctx, container.ID, dockertypes.ContainerRemoveOptions{
+				Force: true,
+			}); err != nil {
+				return fmt.Errorf("failed to remove old container: %v", err)
+			}
+		}
+	}
+	return nil
+}
+
+func pullImage(ctx context.Context, client *dockerclient.Client, imageName string, print bool) error {
+	glog.V(1).Infof("Pulling image %q", imageName)
+	resp, err := client.ImagePull(ctx, imageName, dockertypes.ImagePullOptions{})
+	if err != nil {
+		return fmt.Errorf("Failed to pull busybox image: %v", err)
+	}
+
+	decoder := json.NewDecoder(resp)
+	for {
+		var msg dockermessage.JSONMessage
+		err := decoder.Decode(&msg)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("error decoding docker message: %v", err)
+		}
+		if msg.Error != nil {
+			return msg.Error
+		}
+		if print {
+			fmt.Println(msg.Status)
+		}
+	}
+	return nil
+}
+
+// TODO: remove containers by label(s)

--- a/pkg/criproxy/proxy.go
+++ b/pkg/criproxy/proxy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 Mirantis
+Copyright 2017 Mirantis
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/criproxy/proxy_test.go
+++ b/pkg/criproxy/proxy_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 Mirantis
+Copyright 2017 Mirantis
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/criproxy/proxy_test.go
+++ b/pkg/criproxy/proxy_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/glog"
 	"github.com/pmezard/go-difflib/difflib"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -55,9 +56,10 @@ type ServerWithReadinessFeedback interface {
 
 func startServer(t *testing.T, s ServerWithReadinessFeedback, addr string) {
 	readyCh := make(chan struct{})
-	errCh := make(chan error)
+	errCh := make(chan error, 1)
 	go func() {
 		if err := s.Serve(addr, readyCh); err != nil {
+			glog.Errorf("error starting server @ %q: %v", addr, err)
 			errCh <- err
 		}
 	}()
@@ -89,18 +91,15 @@ func puint64(v uint64) *uint64 {
 }
 
 type proxyTester struct {
-	journal *proxytest.SimpleJournal
-	servers []*proxytest.FakeCriServer
-	proxy   *RuntimeProxy
-	conn    *grpc.ClientConn
+	hookCallCount int
+	journal       *proxytest.SimpleJournal
+	servers       []*proxytest.FakeCriServer
+	proxy         *RuntimeProxy
+	conn          *grpc.ClientConn
 }
 
 func newProxyTester(t *testing.T) *proxyTester {
 	journal := proxytest.NewSimpleJournal()
-	proxy, err := NewRuntimeProxy([]string{fakeCriSocketPath1, altSocketSpec}, connectionTimeoutForTests)
-	if err != nil {
-		t.Fatalf("failed to create runtime proxy: %v", err)
-	}
 	servers := []*proxytest.FakeCriServer{
 		proxytest.NewFakeCriServer(proxytest.NewPrefixJournal(journal, "1/")),
 		proxytest.NewFakeCriServer(proxytest.NewPrefixJournal(journal, "2/")),
@@ -114,11 +113,19 @@ func newProxyTester(t *testing.T) *proxyTester {
 	servers[1].SetFakeImages(fakeImageNames2)
 	servers[1].SetFakeImageSize(fakeImageSize2)
 
-	return &proxyTester{
+	tester := &proxyTester{
 		journal: journal,
 		servers: servers,
-		proxy:   proxy,
 	}
+	var err error
+	tester.proxy, err = NewRuntimeProxy([]string{fakeCriSocketPath1, altSocketSpec}, connectionTimeoutForTests, func() {
+		tester.hookCallCount++
+	})
+	if err != nil {
+		t.Fatalf("failed to create runtime proxy: %v", err)
+	}
+
+	return tester
 }
 
 func (tester *proxyTester) startServers(t *testing.T, which int) {
@@ -206,7 +213,7 @@ func TestCriProxy(t *testing.T) {
 	tester.startProxy(t)
 	tester.connectToProxy(t)
 
-	for _, step := range []struct {
+	testCases := []struct {
 		name, method string
 		in, resp     interface{}
 		ins          []interface{}
@@ -1092,7 +1099,10 @@ func TestCriProxy(t *testing.T) {
 			},
 			journal: []string{"1/image/ListImages", "2/image/ListImages"},
 		},
-	} {
+	}
+
+	nCalls := 0
+	for _, step := range testCases {
 		var ins []interface{}
 		if step.ins == nil {
 			ins = []interface{}{step.in}
@@ -1108,11 +1118,15 @@ func TestCriProxy(t *testing.T) {
 			if len(ins) > 1 {
 				name = fmt.Sprintf("%s [%d]", name, n+1)
 			}
+			nCalls++
 			t.Run(name, func(t *testing.T) {
 				tester.verifyCall(t, step.method, in, step.resp, step.error)
 				tester.verifyJournal(t, step.journal)
 			})
 		}
+	}
+	if tester.hookCallCount != nCalls {
+		t.Errorf("unexpected hook call count: %d instead of %d", tester.hookCallCount, nCalls)
 	}
 }
 

--- a/pkg/criproxy/util.go
+++ b/pkg/criproxy/util.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 Mirantis
+Copyright 2017 Mirantis
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/criproxy/util.go
+++ b/pkg/criproxy/util.go
@@ -44,8 +44,7 @@ func waitForSocket(path string) error {
 	for {
 		if _, err = os.Stat(path); err != nil {
 			glog.V(1).Infof("%q is not here yet: %s", path, err)
-		}
-		if conn, err := dial(path, connectWaitTimeout); err != nil {
+		} else if conn, err := dial(path, connectWaitTimeout); err != nil {
 			glog.V(1).Infof("can't connect to %q yet: %s", path, err)
 		} else {
 			conn.Close()

--- a/pkg/criproxy/util.go
+++ b/pkg/criproxy/util.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2016 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package criproxy
+
+import (
+	"context"
+	"net"
+	"os"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/golang/glog"
+)
+
+const (
+	connectAttemptInterval = 500 * time.Millisecond
+)
+
+// getContextWithTimeout returns a context with timeout.
+func getContextWithTimeout(timeout time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), timeout)
+}
+
+// dial creates a net.Conn by unix socket addr.
+func dial(addr string, timeout time.Duration) (net.Conn, error) {
+	return net.DialTimeout("unix", addr, timeout)
+}
+
+func waitForSocket(path string) error {
+	var err error
+	for {
+		if _, err = os.Stat(path); err != nil {
+			glog.V(1).Infof("%q is not here yet: %s", path, err)
+		}
+		if conn, err := dial(path, connectWaitTimeout); err != nil {
+			glog.V(1).Infof("can't connect to %q yet: %s", path, err)
+		} else {
+			conn.Close()
+			break
+		}
+		time.Sleep(connectAttemptInterval)
+	}
+	return err
+}
+
+// TODO: remove this
+func init() {
+	// Make spew output more readable for k8s runtime API objects
+	spew.Config.DisableMethods = true
+	spew.Config.DisablePointerMethods = true
+}


### PR DESCRIPTION
As of now, attaching to docker containers behind the proxy only works when the node is reachable from the host where `kubectl` is run. It also uses default config for docker-shim at the moment.

Fixes #190 

- [x] Basic support for running docker-shim
- [x] Fix kubectl exec/attach (the problem was with missing StreamingProxyRedirects feature gate for apiserver, solved on kubeadm-dind-cluster side
- [x] Fix networking in pods
- [x] Add a way to get docker-shim related kubelet options from kubelet
- [x] Deploy CRI proxy from virtlet DaemonSet
- [x] Update sample cluster config

Concerning options, one way is to make it possible to run something like `criproxy grab` before switching kubelet to using criproxy. This command will create a config file for the proxy which
contains necessary options that will be used for docker-shim.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/188)
<!-- Reviewable:end -->
