### PR TITLE
Fixed stopping/removal of VM and extended integration test to check it

### DIFF
--- a/contrib/images/local-cluster/start.sh
+++ b/contrib/images/local-cluster/start.sh
@@ -16,4 +16,9 @@ export KUBERNETES_PROVIDER=local
 export EXPERIMENTAL_CRI=true
 export CONTAINER_RUNTIME=remote
 export CONTAINER_RUNTIME_ENDPOINT=/run/virtlet.sock
+while [[ ! -e "$CONTAINER_RUNTIME_ENDPOINT" ]]
+do
+   echo "Waiting for $CONTAINER_RUNTIME_ENDPOINT"
+   sleep 2
+done
 hack/local-up-cluster.sh -o _output/local/bin/linux/amd64

--- a/pkg/libvirttools/domain_interface.go
+++ b/pkg/libvirttools/domain_interface.go
@@ -20,6 +20,10 @@ import (
 	libvirt "github.com/libvirt/libvirt-go"
 )
 
+// NOTE: Implementation of GetLastError in libvirt-go resets error at the end.
+// All DomainOperations methods invoke GetLastError, so
+// repeated call returns no error and doesn't make sense.
+
 type DomainOperations interface {
 	Create(domain *libvirt.Domain) error
 	DefineFromXML(xmlConfig string) (*libvirt.Domain, error)
@@ -31,8 +35,6 @@ type DomainOperations interface {
 	LookupByUUIDString(uuid string) (*libvirt.Domain, error)
 	GetDomainInfo(domain *libvirt.Domain) (*libvirt.DomainInfo, error)
 	GetUUIDString(domain *libvirt.Domain) (string, error)
-
-	GetLastError() libvirt.Error
 }
 
 type LibvirtDomainOperations struct {
@@ -41,10 +43,6 @@ type LibvirtDomainOperations struct {
 
 func NewLibvirtDomainOperations(conn *libvirt.Connect) DomainOperations {
 	return LibvirtDomainOperations{conn: conn}
-}
-
-func (l LibvirtDomainOperations) GetLastError() libvirt.Error {
-	return libvirt.GetLastError()
 }
 
 func (l LibvirtDomainOperations) Create(domain *libvirt.Domain) error {

--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -44,6 +44,10 @@ const (
 	noKvmEmulator     = "/usr/bin/qemu-system-x86_64"
 
 	VirtletVolumesAnnotationKeyName = "VirtletVolumes"
+	domainShutdownRetryInterval     = 10 * time.Second
+	domainShutdownTimeout           = 60 * time.Second
+	domainDestroyCheckInterval      = 500 * time.Millisecond
+	domainDestroyTimeout            = 5 * time.Second
 )
 
 type Driver struct {
@@ -371,12 +375,12 @@ func (v *VirtualizationTool) StopContainer(containerId string) error {
 	if err != nil {
 		return err
 	}
-	if err := v.tool.Shutdown(domain); err != nil {
-		return err
-	}
 
-	// Wait until domain is really stopped or timeout after 10 sec.
+	// To process cases when VM is booting and cannot handle the shutdown signal
+	// send sequential shutdown requests with 1 sec interval until domain is shutoff or time after 60 sec.
 	return utils.WaitLoop(func() (bool, error) {
+		v.tool.Shutdown(domain)
+
 		domain, err := v.tool.LookupByUUIDString(containerId)
 		if err != nil {
 			return true, err
@@ -386,9 +390,8 @@ func (v *VirtualizationTool) StopContainer(containerId string) error {
 		if err != nil {
 			return false, err
 		}
-
-		return di.State == libvirt.DOMAIN_SHUTDOWN, nil
-	}, 10*time.Second)
+		return di.State == libvirt.DOMAIN_SHUTDOWN || di.State == libvirt.DOMAIN_SHUTOFF, nil
+	}, domainShutdownRetryInterval, domainShutdownTimeout)
 }
 
 // RemoveContainer tries to gracefully stop domain, then forcibly removes it
@@ -396,16 +399,17 @@ func (v *VirtualizationTool) StopContainer(containerId string) error {
 // it waits up to 5 sec for doing the job by libvirt
 func (v *VirtualizationTool) RemoveContainer(containerId string) error {
 	// Give a chance to gracefully stop domain
-	// TODO: handle errors - there could be e.x. connection error
-	v.StopContainer(containerId)
+	// TODO: handle errors - there could be e.x. connection errori
 
 	domain, err := v.tool.LookupByUUIDString(containerId)
 	if err != nil {
 		return err
 	}
 
-	if err := v.tool.Destroy(domain); err != nil {
-		return err
+	if err := v.StopContainer(containerId); err != nil {
+		if err := v.tool.Destroy(domain); err != nil {
+			return err
+		}
 	}
 
 	if err := v.tool.Undefine(domain); err != nil {
@@ -424,14 +428,17 @@ func (v *VirtualizationTool) RemoveContainer(containerId string) error {
 			return false, errors.New("libvirt returned no domain and no error - this is incorrect")
 		}
 
-		lastLibvirtErr := v.tool.GetLastError()
+		lastLibvirtErr, ok := err.(libvirt.Error)
+		if !ok {
+			return false, errors.New("Failed to cast error to libvirt.Error type")
+		}
 		if lastLibvirtErr.Code == libvirt.ERR_NO_DOMAIN {
 			return true, nil
 		}
 
 		// Other error occured
 		return false, err
-	}, 5*time.Second)
+	}, domainDestroyCheckInterval, domainDestroyTimeout)
 }
 
 func libvirtToKubeState(domainState libvirt.DomainState, lastState kubeapi.ContainerState) kubeapi.ContainerState {

--- a/pkg/utils/wait.go
+++ b/pkg/utils/wait.go
@@ -22,8 +22,8 @@ import (
 )
 
 // WaitLoop executes test func in loop until it returns error, true, or timeout passes
-func WaitLoop(test func() (bool, error), timeout time.Duration) error {
-	for start := time.Now(); time.Since(start) < timeout; time.Sleep(500 * time.Millisecond) {
+func WaitLoop(test func() (bool, error), retryPeriod time.Duration, timeout time.Duration) error {
+	for start := time.Now(); time.Since(start) < timeout; time.Sleep(retryPeriod) {
 		result, err := test()
 		if err != nil {
 			return err

--- a/tests/integration/container_create_test.go
+++ b/tests/integration/container_create_test.go
@@ -17,12 +17,11 @@ limitations under the License.
 package integration
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
 	"testing"
-
-	"fmt"
 
 	"github.com/Mirantis/virtlet/tests/criapi"
 	"golang.org/x/net/context"
@@ -236,7 +235,7 @@ func TestContainerCreateStartListRemove(t *testing.T) {
 		}
 	}
 	for _, container := range containers {
-		//Stop container request
+		// Stop container request
 		containerStopIn := &kubeapi.StopContainerRequest{
 			ContainerId: &container.ContainerId,
 		}
@@ -245,7 +244,7 @@ func TestContainerCreateStartListRemove(t *testing.T) {
 			t.Fatalf("Stopping container %s failure: %v", container.ContainerId, err)
 		}
 
-		//Remove container request
+		// Remove container request
 		containerRemoveIn := &kubeapi.RemoveContainerRequest{
 			ContainerId: &container.ContainerId,
 		}
@@ -253,7 +252,7 @@ func TestContainerCreateStartListRemove(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Removing container %s failure: %v", container.ContainerId, err)
 		}
-		//check all volumes related to VM have been removed
+		// Check all volumes related to VM have been removed
 		cmd := "virsh vol-list --pool volumes | grep " + container.ContainerId + " | wc -l"
 		t.Logf("Formed CMD to lookup volumes: %s\n", cmd)
 		out, err := exec.Command("bash", "-c", cmd).Output()
@@ -262,7 +261,7 @@ func TestContainerCreateStartListRemove(t *testing.T) {
 		}
 		outRes := strings.TrimSpace(string(out))
 		if outRes != "0" {
-			t.Errorf("Expected no ephemeral volumes for %s doamin but instead found %s!", container.ContainerId, outRes)
+			t.Errorf("Expected no ephemeral volumes for %s domain but instead found %s!", container.ContainerId, outRes)
 		}
 	}
 }


### PR DESCRIPTION
For now test fails with 
`
E0201 09:29:47.607864   20472 manager.go:324] Error when stopping container 88fa8fe6-b4a4-4fef-64b6-7797f2382f86: timeout reached
`

However, if keep build_virtlet container running after test failure, domains can be manually deleted without issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/198)
<!-- Reviewable:end -->
