### PR TITLE
metadata: Refactor boltdb storage

### DIFF
--- a/pkg/bolttools/sandbox.go
+++ b/pkg/bolttools/sandbox.go
@@ -201,7 +201,7 @@ func (b *BoltClient) RemovePodSandbox(podId string) error {
 	})
 }
 
-func (b *BoltClient) fetchSandBoxValueByKey(podId string, key string) ([]byte, error ){
+func (b *BoltClient) fetchSandBoxValueByKey(podId string, key string) ([]byte, error) {
 	var value []byte
 	err := b.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte("sandbox"))
@@ -222,7 +222,6 @@ func (b *BoltClient) fetchSandBoxValueByKey(podId string, key string) ([]byte, e
 
 	return value, err
 }
-
 
 func (b *BoltClient) GetPodSandboxContainerID(podId string) (string, error) {
 	byteContID, err := b.fetchSandBoxValueByKey(podId, "ContainerID")

--- a/pkg/bolttools/virtualization.go
+++ b/pkg/bolttools/virtualization.go
@@ -24,19 +24,9 @@ import (
 
 	"github.com/boltdb/bolt"
 	kubeapi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
-)
 
-type ContainerInfo struct {
-	CreatedAt             int64
-	StartedAt             int64
-	SandboxId             string
-	Image                 string
-	RootImageSnapshotName string
-	Labels                map[string]string
-	Annotations           map[string]string
-	SandBoxAnnotations    map[string]string
-	State                 kubeapi.ContainerState
-}
+	"github.com/Mirantis/virtlet/pkg/metadata"
+)
 
 func (b *BoltClient) EnsureVirtualizationSchema() error {
 	err := b.db.Update(func(tx *bolt.Tx) error {
@@ -167,8 +157,8 @@ func (b *BoltClient) UpdateState(containerId string, state byte) error {
 	return err
 }
 
-func (b *BoltClient) GetContainerInfo(containerId string) (*ContainerInfo, error) {
-	var containerInfo *ContainerInfo
+func (b *BoltClient) GetContainerInfo(containerId string) (*metadata.ContainerInfo, error) {
+	var containerInfo *metadata.ContainerInfo
 
 	if err := b.db.View(func(tx *bolt.Tx) error {
 		parentBucket := tx.Bucket([]byte("virtualization"))
@@ -264,7 +254,7 @@ func (b *BoltClient) GetContainerInfo(containerId string) (*ContainerInfo, error
 			return err
 		}
 
-		containerInfo = &ContainerInfo{
+		containerInfo = &metadata.ContainerInfo{
 			CreatedAt: createdAt,
 			StartedAt: startedAt,
 			SandboxId: sandboxId,

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -31,6 +31,7 @@ import (
 	"github.com/Mirantis/virtlet/pkg/bolttools"
 	"github.com/Mirantis/virtlet/pkg/cni"
 	"github.com/Mirantis/virtlet/pkg/libvirttools"
+	"github.com/Mirantis/virtlet/pkg/metadata"
 )
 
 const (
@@ -45,13 +46,13 @@ type VirtletManager struct {
 	libvirtConnTool           *libvirttools.ConnectionTool
 	libvirtImageTool          *libvirttools.ImageTool
 	libvirtVirtualizationTool *libvirttools.VirtualizationTool
-	// bolt
-	boltClient *bolttools.BoltClient
+	// metadata
+	metadataStore metadata.MetadataStore
 	// cni
 	cniClient *cni.Client
 }
 
-func NewVirtletManager(libvirtUri, poolName, storageBackend, boltPath, cniPluginsDir, cniConfigsDir string) (*VirtletManager, error) {
+func NewVirtletManager(libvirtUri, poolName, storageBackend, metadataPath, cniPluginsDir, cniConfigsDir string) (*VirtletManager, error) {
 	libvirtConnTool, err := libvirttools.NewConnectionTool(libvirtUri)
 	if err != nil {
 		return nil, err
@@ -68,7 +69,7 @@ func NewVirtletManager(libvirtUri, poolName, storageBackend, boltPath, cniPlugin
 		return nil, err
 	}
 
-	boltClient, err := bolttools.NewBoltClient(boltPath)
+	boltClient, err := bolttools.NewBoltClient(metadataPath)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +84,7 @@ func NewVirtletManager(libvirtUri, poolName, storageBackend, boltPath, cniPlugin
 		libvirtConnTool:           libvirtConnTool,
 		libvirtImageTool:          libvirtImageTool,
 		libvirtVirtualizationTool: libvirtVirtualizationTool,
-		boltClient:                boltClient,
+		metadataStore:             boltClient,
 		cniClient:                 cniClient,
 	}
 
@@ -161,7 +162,7 @@ func (v *VirtletManager) RunPodSandbox(ctx context.Context, in *kubeapi.RunPodSa
 	}
 	glog.V(3).Infof("CNI configuration for pod %s (%s): %s", name, podId, string(bytesNetConfig))
 
-	if err := v.boltClient.SetPodSandbox(config, bytesNetConfig); err != nil {
+	if err := v.metadataStore.SetPodSandbox(config, bytesNetConfig); err != nil {
 		glog.Errorf("Error when creating pod sandbox for pod %s (%s): %v", name, podId, err)
 		return nil, err
 	}
@@ -176,7 +177,7 @@ func (v *VirtletManager) StopPodSandbox(ctx context.Context, in *kubeapi.StopPod
 	podSandboxId := in.GetPodSandboxId()
 	glog.V(2).Infof("StopPodSandbox called for pod %s", in.GetPodSandboxId())
 	glog.V(3).Infof("StopPodSandbox: %s", spew.Sdump(in))
-	if err := v.boltClient.UpdatePodState(podSandboxId, byte(kubeapi.PodSandboxState_SANDBOX_NOTREADY)); err != nil {
+	if err := v.metadataStore.UpdatePodState(podSandboxId, byte(kubeapi.PodSandboxState_SANDBOX_NOTREADY)); err != nil {
 		glog.Errorf("Error when stopping pod sandbox '%s': %v", podSandboxId, err)
 		return nil, err
 	}
@@ -190,7 +191,7 @@ func (v *VirtletManager) RemovePodSandbox(ctx context.Context, in *kubeapi.Remov
 	glog.V(2).Infof("RemovePodSandbox called for pod %s", podSandboxId)
 	glog.V(3).Infof("RemovePodSandbox: %s", spew.Sdump(in))
 
-	if err := v.boltClient.RemovePodSandbox(podSandboxId); err != nil {
+	if err := v.metadataStore.RemovePodSandbox(podSandboxId); err != nil {
 		glog.Errorf("Error when removing pod sandbox '%s': %v", podSandboxId, err)
 		return nil, err
 	}
@@ -214,13 +215,13 @@ func (v *VirtletManager) PodSandboxStatus(ctx context.Context, in *kubeapi.PodSa
 	glog.V(3).Infof("PodSandboxStatusStatus: %s", spew.Sdump(in))
 	podSandboxId := in.GetPodSandboxId()
 
-	status, err := v.boltClient.GetPodSandboxStatus(podSandboxId)
+	status, err := v.metadataStore.GetPodSandboxStatus(podSandboxId)
 	if err != nil {
 		glog.Errorf("Error when getting pod sandbox '%s': %v", podSandboxId, err)
 		return nil, err
 	}
 
-	netAsBytes, err := v.boltClient.GetPodNetworkConfigurationAsBytes(podSandboxId)
+	netAsBytes, err := v.metadataStore.GetPodNetworkConfigurationAsBytes(podSandboxId)
 	if err != nil {
 		glog.Errorf("Error when retrieving pod network configuration for sandbox '%s': %v", podSandboxId, err)
 		return nil, err
@@ -247,7 +248,7 @@ func (v *VirtletManager) PodSandboxStatus(ctx context.Context, in *kubeapi.PodSa
 func (v *VirtletManager) ListPodSandbox(ctx context.Context, in *kubeapi.ListPodSandboxRequest) (*kubeapi.ListPodSandboxResponse, error) {
 	filter := in.GetFilter()
 	glog.V(3).Infof("Listing sandboxes with filter: %s", spew.Sdump(filter))
-	podSandboxList, err := v.boltClient.ListPodSandbox(filter)
+	podSandboxList, err := v.metadataStore.ListPodSandbox(filter)
 	if err != nil {
 		glog.Errorf("Error when listing (with filter: %s) pod sandboxes: %v", spew.Sdump(filter), err)
 		return nil, err
@@ -284,7 +285,7 @@ func (v *VirtletManager) CreateContainer(ctx context.Context, in *kubeapi.Create
 	}
 
 	// TODO: get it as string
-	netAsBytes, err := v.boltClient.GetPodNetworkConfigurationAsBytes(podSandboxId)
+	netAsBytes, err := v.metadataStore.GetPodNetworkConfigurationAsBytes(podSandboxId)
 	if err != nil {
 		glog.Errorf("Error when retrieving pod network configuration for sandbox '%s': %v", podSandboxId, err)
 		return nil, err
@@ -302,7 +303,7 @@ func (v *VirtletManager) CreateContainer(ctx context.Context, in *kubeapi.Create
 	// TODO: we should not pass whole "in" to CreateContainer - we should pass there only needed info for CreateContainer
 	// without whole data container
 	// TODO: use network configuration by CreateContainer
-	uuid, err := v.libvirtVirtualizationTool.CreateContainer(v.boltClient, in, imageFilePath, netNSPath, string(netAsBytes))
+	uuid, err := v.libvirtVirtualizationTool.CreateContainer(v.metadataStore, in, imageFilePath, netNSPath, string(netAsBytes))
 	if err != nil {
 		glog.Errorf("Error when creating container %s: %v", name, err)
 		return nil, err
@@ -350,14 +351,14 @@ func (v *VirtletManager) RemoveContainer(ctx context.Context, in *kubeapi.Remove
 		return nil, err
 	}
 
-	containerInfo, err := v.boltClient.GetContainerInfo(containerId)
+	containerInfo, err := v.metadataStore.GetContainerInfo(containerId)
 	if err != nil {
-		glog.Errorf("Error when retrieving container '%s' info from bolt: %v", containerId, err)
+		glog.Errorf("Error when retrieving container '%s' info from metadata store: %v", containerId, err)
 		return nil, err
 	}
 
-	if err := v.boltClient.RemoveContainer(containerId); err != nil {
-		glog.Errorf("Error when removing container '%s' from bolt: %v", containerId, err)
+	if err := v.metadataStore.RemoveContainer(containerId); err != nil {
+		glog.Errorf("Error when removing container '%s' from metadata store: %v", containerId, err)
 		return nil, err
 	}
 
@@ -381,7 +382,7 @@ func (v *VirtletManager) ListContainers(ctx context.Context, in *kubeapi.ListCon
 	filter := in.GetFilter()
 	glog.V(3).Infof("Listing containers with filter: %s", spew.Sdump(filter))
 	glog.V(3).Infof("ListContainers: %s", spew.Sdump(in))
-	containers, err := v.libvirtVirtualizationTool.ListContainers(v.boltClient, filter)
+	containers, err := v.libvirtVirtualizationTool.ListContainers(v.metadataStore, filter)
 	if err != nil {
 		glog.Errorf("Error when listing containers with filter %s: %v", spew.Sdump(filter), err)
 		return nil, err
@@ -394,7 +395,7 @@ func (v *VirtletManager) ListContainers(ctx context.Context, in *kubeapi.ListCon
 func (v *VirtletManager) ContainerStatus(ctx context.Context, in *kubeapi.ContainerStatusRequest) (*kubeapi.ContainerStatusResponse, error) {
 	containerId := in.GetContainerId()
 	glog.V(3).Infof("ContainerStatus: %s", spew.Sdump(in))
-	status, err := v.libvirtVirtualizationTool.ContainerStatus(v.boltClient, containerId)
+	status, err := v.libvirtVirtualizationTool.ContainerStatus(v.metadataStore, containerId)
 	if err != nil {
 		glog.Errorf("Error when getting container '%s' status: %v", containerId, err)
 		return nil, err
@@ -455,7 +456,7 @@ func (v *VirtletManager) Status(context.Context, *kubeapi.StatusRequest) (*kubea
 //
 
 func (v *VirtletManager) imageFromVolumeInfo(volumeInfo *libvirttools.VolumeInfo) (*kubeapi.Image, error) {
-	imageName, err := v.boltClient.GetImageName(volumeInfo.Name)
+	imageName, err := v.metadataStore.GetImageName(volumeInfo.Name)
 	if err != nil {
 		glog.Errorf("Error when checking for existing image with volume %q: %v", volumeInfo.Name, err)
 		return nil, err
@@ -517,7 +518,7 @@ func (v *VirtletManager) ImageStatus(ctx context.Context, in *kubeapi.ImageStatu
 	// This query is also done in imageFromVolumeInfo() so images
 	// that have volumes but aren't in virtlet db will not be retuned
 	// anyway.
-	existingImageName, err := v.boltClient.GetImageName(volumeName)
+	existingImageName, err := v.metadataStore.GetImageName(volumeName)
 	if err != nil {
 		glog.Errorf("Error when checking for existing image with volume %q: %v", volumeName, err)
 		return nil, err
@@ -563,7 +564,7 @@ func (v *VirtletManager) PullImage(ctx context.Context, in *kubeapi.PullImageReq
 	// 2. PullIfNotPresent
 	// So need to check whether the image with such URL was already downloaded
 
-	existingImageName, err := v.boltClient.GetImageName(volumeName)
+	existingImageName, err := v.metadataStore.GetImageName(volumeName)
 	if err != nil {
 		glog.Errorf("PullImage: error when checking for existing image %q: %v", imageName, err)
 		return nil, err
@@ -579,7 +580,7 @@ func (v *VirtletManager) PullImage(ctx context.Context, in *kubeapi.PullImageReq
 		return nil, err
 	}
 
-	err = v.boltClient.SetImageName(volumeName, imageName)
+	err = v.metadataStore.SetImageName(volumeName, imageName)
 	if err != nil {
 		glog.Errorf("Error when setting image name %q for volume %q: %v", imageName, volumeName, err)
 		return nil, err
@@ -604,7 +605,7 @@ func (v *VirtletManager) RemoveImage(ctx context.Context, in *kubeapi.RemoveImag
 		return nil, err
 	}
 
-	if err = v.boltClient.RemoveImage(volumeName); err != nil {
+	if err = v.metadataStore.RemoveImage(volumeName); err != nil {
 		glog.Errorf("Error removing image %q from bolt: %v", imageName, volumeName, err)
 		return nil, err
 	}

--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -33,15 +33,15 @@ type ContainerInfo struct {
 	State                 kubeapi.ContainerState
 }
 
-// MetadataStore contains methods to store/retrieve metadata
-// for images/sandboxes/containers
-type MetadataStore interface {
-	// images
+// ImageMetadataStore contains methods to operate on VM images
+type ImageMetadataStore interface {
 	SetImageName(volumeName, imageName string) error
 	GetImageName(volumeName string) (string, error)
 	RemoveImage(volumeName string) error
+}
 
-	// sandbox
+// SandboxMetadataStore contains methods to operate on POD sandboxes
+type SandboxMetadataStore interface {
 	SetPodSandbox(config *kubeapi.PodSandboxConfig, networkConfiguration []byte) error
 	UpdatePodState(podId string, state byte) error
 	RemovePodSandbox(podId string) error
@@ -50,11 +50,20 @@ type MetadataStore interface {
 	GetPodSandboxStatus(podId string) (*kubeapi.PodSandboxStatus, error)
 	ListPodSandbox(filter *kubeapi.PodSandboxFilter) ([]*kubeapi.PodSandbox, error)
 	GetPodNetworkConfigurationAsBytes(podId string) ([]byte, error)
+}
 
-	// containers - virtualization
+// ContainerMetadataStore contains methods to operate on containers (VMs)
+type ContainerMetadataStore interface {
 	SetContainer(containerId, sandboxId, image, rootImageSnapshotName string, labels, annotations map[string]string) error
 	UpdateStartedAt(containerId string, startedAt string) error
 	UpdateState(containerId string, state byte) error
 	GetContainerInfo(containerId string) (*ContainerInfo, error)
 	RemoveContainer(containerId string) error
+}
+
+// MetadataStore provides single interface for metadata storage implementation
+type MetadataStore interface {
+	ImageMetadataStore
+	SandboxMetadataStore
+	ContainerMetadataStore
 }

--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2016-2017 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metadata
+
+import (
+	kubeapi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
+)
+
+// ContainerInfo contains metadata informations about container instance
+type ContainerInfo struct {
+	CreatedAt             int64
+	StartedAt             int64
+	SandboxId             string
+	Image                 string
+	RootImageSnapshotName string
+	Labels                map[string]string
+	Annotations           map[string]string
+	SandBoxAnnotations    map[string]string
+	State                 kubeapi.ContainerState
+}
+
+// MetadataStore contains methods to store/retrieve metadata
+// for images/sandboxes/containers
+type MetadataStore interface {
+	// images
+	SetImageName(volumeName, imageName string) error
+	GetImageName(volumeName string) (string, error)
+	RemoveImage(volumeName string) error
+
+	// sandbox
+	SetPodSandbox(config *kubeapi.PodSandboxConfig, networkConfiguration []byte) error
+	UpdatePodState(podId string, state byte) error
+	RemovePodSandbox(podId string) error
+	GetPodSandboxContainerID(podId string) (string, error)
+	GetPodSandboxAnnotations(podId string) (map[string]string, error)
+	GetPodSandboxStatus(podId string) (*kubeapi.PodSandboxStatus, error)
+	ListPodSandbox(filter *kubeapi.PodSandboxFilter) ([]*kubeapi.PodSandbox, error)
+	GetPodNetworkConfigurationAsBytes(podId string) ([]byte, error)
+
+	// containers - virtualization
+	SetContainer(containerId, sandboxId, image, rootImageSnapshotName string, labels, annotations map[string]string) error
+	UpdateStartedAt(containerId string, startedAt string) error
+	UpdateState(containerId string, state byte) error
+	GetContainerInfo(containerId string) (*ContainerInfo, error)
+	RemoveContainer(containerId string) error
+}


### PR DESCRIPTION
Added new interface for metadata accessing so now all libvirt based
methods can be unittested without real usage of boltdb.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/205)
<!-- Reviewable:end -->
