### PR TITLE
Update DS defs for calico-flannel branch of DIND

### DIFF
--- a/deploy/virtlet-ds-dev.yaml
+++ b/deploy/virtlet-ds-dev.yaml
@@ -154,12 +154,10 @@ spec:
           path: /var/lib/libvirt
         name: libvirt
       - hostPath:
-          path: /etc/kubernetes/cni
-          # after calico-flannel is landed in kubeadm-dind-cluster:
-          # path: /etc/cni
+          path: /etc/cni
         name: cniconf
       - hostPath:
-          path: /usr/lib/kubernetes/cni/bin
+          path: /opt/cni/bin
         name: cnibin
       - hostPath:
           path: /var/lib/cni

--- a/deploy/virtlet-ds.yaml
+++ b/deploy/virtlet-ds.yaml
@@ -146,12 +146,10 @@ spec:
           path: /var/lib/libvirt
         name: libvirt
       - hostPath:
-          path: /etc/kubernetes/cni
-          # after calico-flannel is landed in kubeadm-dind-cluster:
-          # path: /etc/cni
+          path: /etc/cni
         name: cniconf
       - hostPath:
-          path: /usr/lib/kubernetes/cni/bin
+          path: /opt/cni/bin
         name: cnibin
       - hostPath:
           path: /var/lib/cni


### PR DESCRIPTION
Please don't merge this PR until [calico-flannel](https://github.com/Mirantis/kubeadm-dind-cluster/tree/calico-flannel) branch of `kubeadm-dind-cluster` is merged.
It currently has some of CI tests failing and most straightforward way to fix it is
to resolve kubernetes/kubeadm#221 (@jellonek already found the exact cause for the problem and will fix it soon)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/234)
<!-- Reviewable:end -->
