### PR TITLE
Fix RNG init in virtlet and vmwrapper

### DIFF
--- a/cmd/virtlet/virtlet.go
+++ b/cmd/virtlet/virtlet.go
@@ -18,7 +18,9 @@ package main
 
 import (
 	"flag"
+	"math/rand"
 	"os"
+	"time"
 
 	"github.com/Mirantis/virtlet/pkg/manager"
 
@@ -44,6 +46,8 @@ var (
 
 func main() {
 	flag.Parse()
+
+	rand.Seed(time.Now().UnixNano())
 
 	server, err := manager.NewVirtletManager(*libvirtUri, *pool, *storageBackend, *boltPath, *cniPluginsDir, *cniConfigsDir)
 	if err != nil {

--- a/cmd/vmwrapper/vmwrapper.go
+++ b/cmd/vmwrapper/vmwrapper.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"math/rand"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -278,6 +279,8 @@ func child(exitEOF chan bool, sigTERM chan os.Signal) {
 }
 
 func main() {
+	rand.Seed(time.Now().UnixNano())
+
 	exitEOF := make(chan bool, 1)
 	sigTERM := make(chan os.Signal)
 	signal.Notify(sigTERM, syscall.SIGTERM)


### PR DESCRIPTION
RNG was not being initialized properly.
As one of the consequences VMs were getting same MAC addresses,
preventing them from talking to each other over the network.

Fixes #230

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/235)
<!-- Reviewable:end -->
