### PR TITLE
Default to KVM, add KVM detection to demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ By default, CNI bridge plugin is used for cluster networking. Another option is 
 CNI_PLUGIN=flannel ./demo.sh
 ```
 
+The demo script will check for KVM support on the host and will make Virtlet use KVM if it's available on Docker host. If KVM is not available, plain QEMU will be used.
+
 The demo is based on [kubeadm-dind-cluster](https://github.com/Mirantis/kubeadm-dind-cluster) project. **Docker btrfs storage driver is currently unsupported.** Please refer to `kubeadm-dind-cluster` documentation for more info.
 
 ## Need any help with Virtlet?

--- a/build/cmd.sh
+++ b/build/cmd.sh
@@ -138,7 +138,7 @@ case "${cmd}" in
         ( vcmd "./autogen.sh && ./configure && make" )
         ;;
     test)
-        ( vcmd 'VIRTLET_DISABLE_KVM=1 build/do-test.sh' )
+        ( vcmd 'VIRTLET_DISABLE_KVM=y build/do-test.sh' )
         ;;
     run)
         vcmd "$*"

--- a/deploy/demo.sh
+++ b/deploy/demo.sh
@@ -122,11 +122,27 @@ function demo::vm-ready {
   fi
 }
 
+function demo::kvm-ok {
+  demo::step "Checking for KVM support..."
+  # The check is done inside node-1 container because it has proper /lib/modules
+  # from the docker host. Also, it'll have to use mirantis/virtlet image
+  # later anyway.
+  if ! docker exec kube-node-1 docker run --privileged --rm -v /lib/modules:/lib/modules mirantis/virtlet kvm-ok; then
+    return 1
+  fi
+}
+
 function demo::start-virtlet {
-  demo::step "Deploying Virtlet DaemonSet"
+  local jq_filter='.items[1].spec.template.spec.containers[0].env|=.+[{"name": "VIRTLET_DOWNLOAD_PROTOCOL","value":"http"}]'
+  if demo::kvm-ok; then
+    demo::step "Deploying Virtlet DaemonSet with KVM support"
+  else
+    demo::step "Deploying Virtlet DaemonSet *without* KVM support"
+    jq_filter="${jq_filter}"'|.items[1].spec.template.spec.containers[0].env|=.+[{"name": "VIRTLET_DISABLE_KVM","value":"y"}]'
+  fi
   "${kubectl}" convert -f "${BASE_LOCATION}/deploy/virtlet-ds.yaml" --local -o json |
-          docker exec -i kube-master jq '.items[1].spec.template.spec.containers[0].env|=.+[{"name": "VIRTLET_DOWNLOAD_PROTOCOL","value":"http"}]' |
-          "${kubectl}" create -f -
+      docker exec -i kube-master jq "${jq_filter}" |
+      "${kubectl}" create -f -
   demo::wait-for "Virtlet DaemonSet" demo::pods-ready runtime=virtlet
 }
 

--- a/deploy/virtlet-ds-dev.yaml
+++ b/deploy/virtlet-ds-dev.yaml
@@ -126,10 +126,11 @@ spec:
         env:
         - name: VIRTLET_LOGLEVEL
           value: "3"
-        - name: VIRTLET_DISABLE_KVM
-          value: "1"
         - name: VIRTLET_DOWNLOAD_PROTOCOL
           value: "http"
+        # comment out the following to enable KVM
+        - name: VIRTLET_DISABLE_KVM
+          value: "y"
       volumes:
       - hostPath:
           path: /sys/fs/cgroup

--- a/deploy/virtlet-ds.yaml
+++ b/deploy/virtlet-ds.yaml
@@ -118,10 +118,11 @@ spec:
         env:
         - name: VIRTLET_LOGLEVEL
           value: "3"
-        - name: VIRTLET_DISABLE_KVM
-          value: "1"
         - name: VIRTLET_DOWNLOAD_PROTOCOL
           value: "https"
+        # Uncomment the following to disable KVM:
+        # - name: VIRTLET_DISABLE_KVM
+        #   value: "y"
       volumes:
       - hostPath:
           path: /sys/fs/cgroup

--- a/docs/devel/running-local-environment.md
+++ b/docs/devel/running-local-environment.md
@@ -55,3 +55,8 @@ set `CNI_PLUGIN` environment variable:
 ```
 $ export CNI_PLUGIN=flannel
 ```
+
+Note that KVM is disabled by default for the development environment.
+In order to enable it, comment out `VIRTLET_DISABLE_KVM` environment
+variable setting in `deploy/virtlet-ds-dev.yaml` before doing
+`build/cmd.sh start-dind`.

--- a/image_skel/start.sh
+++ b/image_skel/start.sh
@@ -5,12 +5,20 @@ set -o pipefail
 set -o errtrace
 
 if [[ ! ${VIRTLET_DISABLE_KVM:-} ]]; then
-    modprobe kvm || ((echo "Missing kvm module on host" && exit 1))
+  if ! kvm-ok >&/dev/null; then
+    # try to fix the environment by loading appropriate modules
+    modprobe kvm || ((echo "Missing kvm module on the host" >&2 && exit 1))
     if grep vmx /proc/cpuinfo &>/dev/null; then
-	modprobe kvm_intel || (echo "Missing kvm_intel module on host" && exit 1)
+      modprobe kvm_intel || (echo "Missing kvm_intel module on the host" >&2 && exit 1)
     elif grep svm /proc/cpuinfo &>/dev/null; then
-	modprobe kvm_amd || (echo "Missing kvm_amd module on host" && exit 1)
+      modprobe kvm_amd || (echo "Missing kvm_amd module on the host" >&2 && exit 1)
     fi
+  fi
+  if ! kvm-ok; then
+    echo "*** VIRTLET_DISABLE_KVM is not set but KVM extensions are not available ***" >&2
+    echo "*** Virtlet startup failed ***" >&2
+    exit 1
+  fi
 fi
 
 chown root:root /etc/libvirt/libvirtd.conf
@@ -19,24 +27,24 @@ chmod 644 /etc/libvirt/libvirtd.conf
 chmod 644 /etc/libvirt/qemu.conf
 
 if [[ ${LIBVIRT_CLEANUP:-} ]]; then
-	/usr/sbin/libvirtd -d
-	/cleanup.py
-	kill -9 $(cat /var/run/libvirtd.pid)
+  /usr/sbin/libvirtd -d
+  /cleanup.py
+  kill -9 $(cat /var/run/libvirtd.pid)
 fi
 
 if [[ ! ${VIRTLET_DISABLE_KVM:-} ]]; then
-    chown root:kvm /dev/kvm
+  chown root:kvm /dev/kvm
 fi
 
 /usr/sbin/libvirtd --listen -d
 
 while ! nc -z -v -w1 localhost 16509 >& /dev/null; do
-    echo >&1 "Waiting for libvirt..."
-    sleep 0.3
+  echo >&1 "Waiting for libvirt..."
+  sleep 0.3
 done
 
 PROTOCOL="${VIRTLET_DOWNLOAD_PROTOCOL:-https}"
 
 if [[ ${1:-} != -novirtlet ]]; then
-    /usr/local/bin/virtlet -v=${VIRTLET_LOGLEVEL:-2} -logtostderr=true -libvirt-uri=qemu+tcp://localhost/system -image-download-protocol="${PROTOCOL}"
+  /usr/local/bin/virtlet -v=${VIRTLET_LOGLEVEL:-2} -logtostderr=true -libvirt-uri=qemu+tcp://localhost/system -image-download-protocol="${PROTOCOL}"
 fi

--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -147,7 +147,7 @@ type Sound struct {
 
 func canUseKvm() bool {
 	if os.Getenv("VIRTLET_DISABLE_KVM") != "" {
-		glog.V(2).Infof("VIRTLET_DISABLE_KVM env var not empty, using plain qemu")
+		glog.V(0).Infof("VIRTLET_DISABLE_KVM env var not empty, using plain qemu")
 		return false
 	}
 	return true


### PR DESCRIPTION
Detect KVM availability in demo using kvm-ok.
Ensure KVM availability during virtlet startup
unless VIRTLET_DISABLE_KVM is turned off.
Use 'y' instead of '1' as non-empty VIRTLET_DISABLE_KVM value so there's
hopefully less confusion.
Increase log verbosity for VIRTLET_DISABLE_KVM log message.

Fixes #223

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/247)
<!-- Reviewable:end -->
