### PR TITLE
Provide qemu-kvm process inbound/outbound connectivity.

### DIFF
--- a/cmd/vmwrapper/vmwrapper.go
+++ b/cmd/vmwrapper/vmwrapper.go
@@ -46,18 +46,34 @@ const (
 // Spawn child process and wait for its termination.
 // If process receives EOF on pipe from parent or SIGTERM
 // it forwards SIGKILL or SIGTERM to child accordingly.
-func runCommand(name string, args []string, exitEOF chan bool, sigTERM chan os.Signal) (error, bool) {
+func runCommand(name string, args []string, exitEOF chan bool, sigTERM chan os.Signal, tapFile *os.File) (error, bool) {
 	var err error
 	cmd := exec.Command(name, args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 
-	pipeR, _, _ := os.Pipe()
+	if len(args) >= 1 && args[0] == "-child" && tapFile != nil {
+		glog.Error("Unexpected combination of input args: '-child' and tapFile are set simultaneously")
+		return fmt.Errorf("Unexpected combination of input args: '-child' and tapFile are set simultaneously"), false
+	}
+
+	if tapFile != nil {
+		cmd.ExtraFiles = []*os.File{
+			tapFile,
+		}
+		defer tapFile.Close()
+	}
+
 	if len(args) >= 1 && args[0] == "-child" {
+		pipeR, _, err := os.Pipe()
+		if err != nil {
+			glog.Errorf("Failed to create pipe: %v", err)
+		}
 		cmd.ExtraFiles = []*os.File{
 			pipeR,
 		}
+		defer pipeR.Close()
 	}
 
 	if err = cmd.Start(); err != nil {
@@ -100,11 +116,11 @@ L:
 	return err, procTerminated
 }
 
-func runCommandIfExists(path string, args []string, exitEOF chan bool, sigTERM chan os.Signal) (error, bool) {
+func runCommandIfExists(path string, args []string, exitEOF chan bool, sigTERM chan os.Signal, tapFile *os.File) (error, bool) {
 	_, err := os.Stat(path)
 	switch {
 	case err == nil:
-		return runCommand(path, args, exitEOF, sigTERM)
+		return runCommand(path, args, exitEOF, sigTERM, tapFile)
 	case os.IsNotExist(err):
 		return nil, false
 	default:
@@ -160,7 +176,7 @@ func parent(exitEOF chan bool, sigTERM chan os.Signal) {
 	}
 
 	childArgs := append([]string{"-child"}, emulatorArgs...)
-	runCommandIfExists("/vmwrapper", childArgs, exitEOF, sigTERM)
+	runCommandIfExists("/vmwrapper", childArgs, exitEOF, sigTERM, nil)
 }
 
 func child(exitEOF chan bool, sigTERM chan os.Signal) {
@@ -179,7 +195,7 @@ func child(exitEOF chan bool, sigTERM chan os.Signal) {
 
 	// TODO: use cleaner way to do this
 	runHook := func(name string) {
-		err, procTerminated := runCommandIfExists(name, append([]string{emulator, nsPath, os.Getenv(cniConfigEnvVar)}, emulatorArgs...), exitEOF, sigTERM)
+		err, procTerminated := runCommandIfExists(name, append([]string{emulator, nsPath, os.Getenv(cniConfigEnvVar)}, emulatorArgs...), exitEOF, sigTERM, nil)
 		if err != nil {
 			glog.Errorf("Hook %q: %v", name, err)
 			if procTerminated {
@@ -214,8 +230,14 @@ func child(exitEOF chan bool, sigTERM chan os.Signal) {
 		}
 	}
 
+	virtletNS, err := ns.GetCurrentNS()
+	if err != nil {
+		glog.Errorf("Failed to get current net namespace: %v", err)
+		os.Exit(1)
+	}
+
 	if err := vmNS.Do(func(ns.NetNS) error {
-		info, err = nettools.SetupContainerSideNetwork(info)
+		info, tapFile, err := nettools.SetupContainerSideNetwork(info)
 		if err != nil {
 			return err
 		}
@@ -240,16 +262,23 @@ func child(exitEOF chan bool, sigTERM chan os.Signal) {
 
 		netArgs := []string{
 			"-netdev",
-			"tap,id=tap0,ifname=tap0,script=no,downscript=no",
+			// Qemu process is started with 3d FD set to already opened TAP device
+			"tap,id=tap0,fd=3",
 			"-device",
 			"virtio-net-pci,netdev=tap0,id=net0,mac=" + peerHwAddr.String(),
 		}
 
-		// Running qemu process
+		// Running qemu process inside virtlet' net namespace
 		// On domain's shutdown/destroy libvirt terminates corresponding qemu process using SIGTERM or SIGKILL.
 		// SIGKILL is detected by catching EOF on a pipe from parent process.
 		// On catching SIGTERM just forward it to qemu process and wait for it to exit.
-		err, _ := runCommand(emulator, append(emulatorArgs, netArgs...), exitEOF, sigTERM)
+
+		if err = virtletNS.Do(func(ns.NetNS) error {
+			err, _ := runCommand(emulator, append(emulatorArgs, netArgs...), exitEOF, sigTERM, tapFile)
+			return err
+		}); err != nil {
+			glog.Error("Error occurred while starting subprocess in Virtlet base network namespace: %s", err)
+		}
 
 		select {
 		case dhcpErr := <-errCh:

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -6,25 +6,33 @@ Virtlet have the same behavior and default values for `--cni-bin-dir` and `--cni
 ## Netwoking scheme
 
 ```
-+--------------------------------------------------------------------------------------------------+
-| +-------------------+                                                                            |
-| | VM                |                                                                            |
-| |                   |                                                                            |
-| | +---+ eth0        |                                                                            |
-| | +---+ ip addr set |                                                                            |
-| |   |               |                                                                            |
-| +---|---------------+                                                                            |
-|     |                                                      virtlet-eth0 (veth netns end          |                 veth0 (veth host end
-|     |    +---+ tap0            +---+ br0             +---+ created by CNI)                       |           +---+ created by CNI)
-|     +----|   |-----------------|   |-----------------|   |---------------------------------------------------|   | ip addr set
-|          +---+                 +---+                 +---+                                       |           +---+
-|                              169.254.254.2/24                                                    |
-|                                                                                                  |
-|                                                                                                  |
-|                +-------------------+                                                             |
-|                |local dhcp server  |                                                             |
-|                +-------------------+                                      pod's netns            |            
-+--------------------------------------------------------------------------------------------------+
++--------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|               +-------------------+                                                                                             Virlet                       |
+|               | VM                |                                                                                             network                      |
+|               |                   | Qemu process                                                                                namespace                    |
+|               | +---+ eth0        |                                                                                                                          |
+|               | +---+ ip addr set |                                                                                                                          |
+|               |   /\              |                                                                                                                          |
+|               +---||--------------+                                                                                                                          |
+|                   \/                                                                                                                                         |
+|               FD of the tap device                                                                                                                           |
+|                                                                                                                                                              |
+|                                                                                                                                                              |
+|               +--------------------------------------------------------------------------------------------------+                                           |
+|               |                                                                                                  |                                           |
+|               |                                                            virtlet-eth0 (veth netns end          |                 veth0 (veth host end      |
+|               |          +---+ tap0            +---+ br0             +---+ created by CNI)                       |           +---+ created by CNI)           |
+|               |          |   |-----------------|   |-----------------|   |---------------------------------------------------|   | ip addr set               |
+|               |          +---+                 +---+                 +---+                                       |           +---+                           |
+|               |                              169.254.254.2/24                                                    |                                           |
+|               |                                                                                                  |                                           |
+|               |                                                                                                  |                                           |
+|               |                +-------------------+                                                             |                                           |
+|               |                |local dhcp server  |                                                             |                                           |
+|               |                +-------------------+                                      pod's netns            |                                           |
+|               +--------------------------------------------------------------------------------------------------+                                           |
+|                                                                                                                                                              |
++--------------------------------------------------------------------------------------------------------------------------------------------------------------+
 ```
 
 Current workflow using CNI plugin which is expected to create veth pair with one end belongs to pod network namespace:
@@ -43,16 +51,18 @@ Current workflow using CNI plugin which is expected to create veth pair with one
 </commandline>
 ...
 
-where 
-- VIRTLET_EMULATOR - the fully qualified path to the device model emulator binary, ex: /usr/bin/kvm. 
+where
+- VIRTLET_EMULATOR - the fully qualified path to the device model emulator binary, ex: /usr/bin/kvm.
 - VIRTLET_NS - the fully qualified path to the netns, ex: /var/run/netns/8d6f7a19-c865-11e6-ae2c-02424d6b591d
 - VIRTLET_CNI_CONFIG - json sting with CNI settings, ex: {"ip4":{"ip":"10.1.91.2/24","gateway":"10.1.91.1","routes":[{"dst":"0.0.0.0/0"}]},"dns":{}}
 ```
- - On CreateContainer request virlet calls libvirt api to start domain, which in its turn leads to running VMwrapper with all qemu args. Using info from set env vars VMWrapper sets up networking and runs dhcp-server and VM inside pod's netns.
+ - On CreateContainer request virlet calls libvirt api to start domain, which in its turn leads to running VMwrapper with all qemu args. Using info from set env vars VMWrapper sets up networking and runs dhcp-server inside pod's netns. The qemu-kvm process of running VM is started inside virtlet's base netns to provide inbound and outbound connectivity.
 In more details, VMWrapper inside pod's netns performs the following:
-    1. creates tap for domain and br0, strips ip from veth end inside netns
-    2. runs dhcp-server to pass ip to VM's eth stipped from veth and default routes
+    1. creates tap0 for domain and br0, strips ip and routes from veth end inside netns
+    2. opens tap0 device and keeps its FD
+    3. runs dhcp-server to pass ip to VM's eth stipped from veth and default routes
 
+Finally vmwrapper spawns qemu-kvm (or qemu, if KVM is disabled) inside original virtlet's netns and passes to it file descriptor corresponding to tap0 device.
 
 **NOTE:** Currently we ignore hostNetwork setting, i.e. on RunPodSandBox request from kubelet new network namespace will be created by virtlet with name=PodId regardless of hostNetwork setting. As it's kubelet's work to decide when and which api request should be called, if hostNetwork setting will be changed for the running VM, kubelet SyncPod workflow will kill and re-create everything despite of fact that it won't change networking for VM.
 

--- a/pkg/nettools/nettools_test.go
+++ b/pkg/nettools/nettools_test.go
@@ -313,7 +313,7 @@ func TestExtractLinkInfo(t *testing.T) {
 }
 
 func verifyContainerSideNetwork(t *testing.T, origContVeth netlink.Link, info *types.Result) {
-	returnedInfo, err := SetupContainerSideNetwork(info)
+	returnedInfo, _, err := SetupContainerSideNetwork(info)
 	if err != nil {
 		log.Panicf("failed to set up container side network: %v", err)
 	}
@@ -434,7 +434,7 @@ func TestTeardownContainerSideNetwork(t *testing.T) {
 		if err := StripLink(origContVeth); err != nil {
 			log.Panicf("StripLink() failed: %v", err)
 		}
-		returnedInfo, err := SetupContainerSideNetwork(&expectedExtractedLinkInfo)
+		returnedInfo, _, err := SetupContainerSideNetwork(&expectedExtractedLinkInfo)
 		if err != nil {
 			log.Panicf("failed to set up container side network: %v", err)
 		}

--- a/tests/e2e/e2e.sh
+++ b/tests/e2e/e2e.sh
@@ -51,3 +51,19 @@ fi
 if ! kubectl exec "${virtlet_pod_name}" --namespace=kube-system -- /bin/sh -c "virsh list | grep cirros-vm-rbd.*running"; then
   exit 1
 fi
+
+# check vnc consoles are available for both domains
+if ! kubectl exec "${virtlet_pod_name}" --namespace=kube-system -- /bin/sh -c "apt-get install -y vncsnapshot"; then
+  echo "Failed to install vncsnapshot inside virtlet container"
+  exit 1
+fi
+
+if ! kubectl exec "${virtlet_pod_name}" --namespace=kube-system -- /bin/sh -c "vncsnapshot :0 /domain_1.jpeg"; then
+  echo "Failed to addtach and get screenshot for vnc console for domain with 1 id"
+  exit 1
+fi
+
+if ! kubectl exec "${virtlet_pod_name}" --namespace=kube-system -- /bin/sh -c "vncsnapshot :1 /domain_2.jpeg"; then
+  echo "Failed to addtach and get screenshot for vnc console for domain with 2 id"
+  exit 1
+fi

--- a/tests/e2e/e2e.sh
+++ b/tests/e2e/e2e.sh
@@ -37,14 +37,7 @@ done
 cd "${SCRIPT_DIR}"
 "${SCRIPT_DIR}/vmchat.exp" $("${virsh}" list --name)
 
-# NOTE: Temp workaround for testing functionality
-# until connectivity issues caused by qemu is inside
-# separate network namespace will be resolved
-
-pod_name=$(kubectl get pods --namespace=kube-system | grep virtlet | awk '{print $1}')
-kubectl exec $pod_name --namespace=kube-system -- cp /vmwrapper /vmwrapper_orig
-kubectl exec $pod_name --namespace=kube-system -- rm /vmwrapper
-kubectl exec $pod_name --namespace=kube-system -- ln -s /usr/bin/qemu-system-x86_64 /vmwrapper
+virtlet_pod_name=$(kubectl get pods --namespace=kube-system | grep virtlet | awk '{print $1}')
 
 # Run one-node ceph cluster
 ${SCRIPT_DIR}/run_ceph.sh ${SCRIPT_DIR}
@@ -55,6 +48,6 @@ done
 if [ "$(${virsh} domblklist 2 | grep rbd-test-image | wc -l)" != "1" ]; then
   exit 1
 fi
-if ! kubectl exec $pod_name --namespace=kube-system -- /bin/sh -c "virsh list | grep cirros-vm-rbd.*running"; then
+if ! kubectl exec "${virtlet_pod_name}" --namespace=kube-system -- /bin/sh -c "virsh list | grep cirros-vm-rbd.*running"; then
   exit 1
 fi

--- a/tests/network/vm_network_test.go
+++ b/tests/network/vm_network_test.go
@@ -102,7 +102,7 @@ func TestVmNetwork(t *testing.T) {
 	}
 
 	if contNS.Do(func(ns.NetNS) error {
-		_, err = nettools.SetupContainerSideNetwork(info)
+		_, _, err = nettools.SetupContainerSideNetwork(info)
 		if err != nil {
 			return fmt.Errorf("failed to set up container side network: %v", err)
 		}


### PR DESCRIPTION
Now process is spawned inside virtlet's netns and receives opened tap device FD to set up netdev.
Fixes #240

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/248)
<!-- Reviewable:end -->
