### PR TITLE
Fixed unmarshaling VirtletVolumes json in sandbox annotations

### DIFF
--- a/pkg/libvirttools/storage_pool.go
+++ b/pkg/libvirttools/storage_pool.go
@@ -41,7 +41,7 @@ type Volume struct {
 type VirtletVolume struct {
 	Name         string `json:"Name"`
 	Format       string `json:"Format"`
-	Capacity     int    `json:"Capacity"`
+	Capacity     int    `json:"Capacity,string"`
 	CapacityUnit string `json:"CapacityUnit"`
 }
 

--- a/tests/integration/container_create_test.go
+++ b/tests/integration/container_create_test.go
@@ -48,8 +48,8 @@ func TestContainerCreateStartListRemove(t *testing.T) {
 		t.Fatalf("Failed to generate array of sandbox configs: %v", err)
 	}
 
-	sandboxes[0].Annotations["VirtletVolumes"] = `[{"Name": "vol1"}, {"Name": "vol2"}, {"Name": "vol3"}]`
-	sandboxes[0].Annotations["VirtletVolumes"] = `[{"Name": "vol1"}, {"Name": "vol2"}]`
+	sandboxes[0].Annotations["VirtletVolumes"] = `[{"Name": "vol1"}, {"Name": "vol2", "Format": "qcow2", "Capacity": "2", "CapacityUnit": "MB"}, {"Name": "vol3"}]`
+	sandboxes[1].Annotations["VirtletVolumes"] = `[{"Name": "vol1", "Format": "qcow2", "CapacityUnit": "KB"}, {"Name": "vol2", "Capacity": "2"}]`
 
 	containers, err := criapi.GetContainersConfig(sandboxes)
 	if err != nil {
@@ -192,7 +192,7 @@ func TestContainerCreateStartListRemove(t *testing.T) {
 		t.Logf("Formed CMD to lookup attached volumes: %s\n", cmd)
 		expRes := "0"
 		if _, exists := sandbox.Annotations["VirtletVolumes"]; exists {
-			expRes = fmt.Sprintf("%d", len(strings.Split(sandbox.Annotations["VirtletVolumes"], ",")))
+			expRes = fmt.Sprintf("%d", len(strings.Split(sandbox.Annotations["VirtletVolumes"], "Name"))-1)
 		}
 		out, err := exec.Command("bash", "-c", cmd).Output()
 		if err != nil {


### PR DESCRIPTION
On attempt to add pods with definition:
pod.yaml: http://paste.openstack.org/show/607181/
got error the following http://paste.openstack.org/show/607182/

The reason is to set key for JSON interpeter for Capacity field, that it's integer encoded string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/263)
<!-- Reviewable:end -->
