### PR TITLE
Handle image redownloading always when kubelet asks for it

### DIFF
--- a/docs/images.md
+++ b/docs/images.md
@@ -21,8 +21,10 @@ Virtlet supports QCOW2 format for VM images.
 1. Kubelet sends `PullImage` gRPC request to Virtlet.
 (Note, that `PullImage` request can be skipped by kubelet unless the pod has `imagePullPolicy: PullAlways` or `imagePullPolicy: PullIfNotPreset` and the image is not pulled yet.)
 1. Virtlet uses image url fragment after last slash as internal image name that it looks up in the list of existent images on the host.
-1. In case if there's no image with such name in the list, the image will be downloaded using specified url prepended with `scheme://`. After that Virtlet creates libvirt volume in "**default**" libvirt pool under `/var/lib/libvirt/images` and copies the image content to it.
-1. In case if there's an entry with such name in list, `PullImage` call just return success.
+1. The image will be downloaded using specified url prepended with `scheme://`. After that Virtlet creates libvirt volume in "**default**" libvirt pool under `/var/lib/libvirt/images` and copies the image content to it. As there is no versioning of QCOW2 images Virtlet downloads the image each time, using the image name with `scheme://` prefix added.
 
-**Note:** In order to safe disk space and to be able to reuse existing guest OS volumes Virtlet creates separate volume which uses the original one as backing store.
-All snapshot volumes are stored in "**volumes**" libvirt pool under `/var/lib/virtlet/volumes`.
+**Note:** Virtual machines are started from volumes which are clones of boot images.
+Original images are stored in libvirt `default` pool (`/var/lib/libvirt/images` on filesystem).
+Clones used as boot images are stored in "**volumes**" libvirt pool under `/var/lib/virtlet/volumes`
+during the VM execution time and are automatically garbage collected by Virtlet
+after stopping VM pod environment (sandbox).

--- a/docs/volumes.md
+++ b/docs/volumes.md
@@ -54,9 +54,8 @@ From [Libvirt spec](http://libvirt.org/formatdomain.html#elementsDisks):
           "CapacityUnit": "MB"
 ```
 
-All ephemeral volumes created by request as well as snapshot for boot image are stored
+All ephemeral volumes created by request as well as clones of boot images are stored
 at local storage libvirt pool "**volumes**" under `/var/lib/virtlet/volumes`.
-
 
 Volume settings for ephemeral local storage volumes are passed via pod's metadata Annotations.
 
@@ -97,10 +96,10 @@ spec:
 ```
 
 According to this definition will be created VM-POD with VM with 2 equal volumes, attached, which can be found in "volumes" pool under `<domain-uuid>-vol1` and `<domain-uuid>-vol2`
-Boot image is exposed to the guest OS under **vda** device.
+A clone of boot image is exposed as **vda** device to the guest OS.
 On a typical linux system the additional volume disks are assigned to /dev/vdX devices in an alphabetical order, so vol1 will be /dev/vdb and vol2 will be /dev/vdc, but please refer to caveat #3 at the beginning of this document.
 
-On pod remove expected all volumes and snapshot related to VM should be removed.
+When a pod is removed, all the volumes related to it are removed too. This includes the root disk (a clone of the boot image) and any additional volumes.
 
 ## Persistent Storage
 
@@ -235,7 +234,7 @@ spec:
 # virsh domblklist 2
 Target     Source
 ------------------------------------------------
-vda        /var/lib/virtlet/snapshot_de0ae972-4154-4f8f-70ff-48335987b5ce
+vda        /var/lib/virtlet/root_de0ae972-4154-4f8f-70ff-48335987b5ce
 vdb        libvirt-pool/rbd-test-image
 ```
 

--- a/pkg/bolttools/utils_test.go
+++ b/pkg/bolttools/utils_test.go
@@ -179,7 +179,7 @@ func SetUpBolt(t *testing.T, sandboxConfigs []*kubeapi.PodSandboxConfig, contain
 	}
 
 	for _, container := range containerConfigs {
-		if err := b.SetContainer(container.Name, container.ContainerId, container.SandboxId, container.Image, container.RootImageSnapshotName, container.Labels, container.Annotations); err != nil {
+		if err := b.SetContainer(container.Name, container.ContainerId, container.SandboxId, container.Image, container.RootImageVolumeName, container.Labels, container.Annotations); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/pkg/bolttools/virtualization.go
+++ b/pkg/bolttools/virtualization.go
@@ -40,7 +40,7 @@ func (b *BoltClient) EnsureVirtualizationSchema() error {
 	return err
 }
 
-func (b *BoltClient) SetContainer(name, containerId, sandboxId, image, rootImageSnapshotName string, labels, annotations map[string]string) error {
+func (b *BoltClient) SetContainer(name, containerId, sandboxId, image, rootImageVolumeName string, labels, annotations map[string]string) error {
 	strLabels, err := json.Marshal(labels)
 	if err != nil {
 		return err
@@ -93,7 +93,7 @@ func (b *BoltClient) SetContainer(name, containerId, sandboxId, image, rootImage
 			return err
 		}
 
-		if err := bucket.Put([]byte("rootImageSnapshotName"), []byte(rootImageSnapshotName)); err != nil {
+		if err := bucket.Put([]byte("rootImageVolumeName"), []byte(rootImageVolumeName)); err != nil {
 			return err
 		}
 
@@ -223,7 +223,7 @@ func (b *BoltClient) GetContainerInfo(containerId string) (*metadata.ContainerIn
 			return err
 		}
 
-		rootImageSnapshotName, err := getString(bucket, "rootImageSnapshotName")
+		rootImageVolumeName, err := getString(bucket, "rootImageVolumeName")
 		if err != nil {
 			return err
 		}
@@ -264,16 +264,16 @@ func (b *BoltClient) GetContainerInfo(containerId string) (*metadata.ContainerIn
 		}
 
 		containerInfo = &metadata.ContainerInfo{
-			Name:      name,
-			CreatedAt: createdAt,
-			StartedAt: startedAt,
-			SandboxId: sandboxId,
-			Image:     image,
-			RootImageSnapshotName: rootImageSnapshotName,
-			Labels:                labels,
-			SandBoxAnnotations:    sandBoxAnnotations,
-			Annotations:           annotations,
-			State:                 kubeapi.ContainerState(byteState[0]),
+			Name:                name,
+			CreatedAt:           createdAt,
+			StartedAt:           startedAt,
+			SandboxId:           sandboxId,
+			Image:               image,
+			RootImageVolumeName: rootImageVolumeName,
+			Labels:              labels,
+			SandBoxAnnotations:  sandBoxAnnotations,
+			Annotations:         annotations,
+			State:               kubeapi.ContainerState(byteState[0]),
 		}
 
 		return nil

--- a/pkg/libvirttools/image.go
+++ b/pkg/libvirttools/image.go
@@ -63,14 +63,6 @@ func (i *ImageTool) ListImagesAsVolumeInfos() ([]*VolumeInfo, error) {
 	return i.tool.ListVolumes()
 }
 
-func (i *ImageTool) ImageFilePath(volumeName string) (string, error) {
-	vol, err := i.tool.LookupVolume(volumeName)
-	if err != nil {
-		return "", err
-	}
-	return vol.GetPath()
-}
-
 func (i *ImageTool) ImageAsVolumeInfo(volumeName string) (*VolumeInfo, error) {
 	vol, err := i.tool.LookupVolume(volumeName)
 	if err != nil {
@@ -91,4 +83,8 @@ func (i *ImageTool) PullImageToVolume(imageName, volumeName string) error {
 
 func (i *ImageTool) RemoveImage(volumeName string) error {
 	return i.tool.RemoveVolume(volumeName)
+}
+
+func (i *ImageTool) GetStorageTool() *StorageTool {
+	return i.tool
 }

--- a/pkg/libvirttools/image.go
+++ b/pkg/libvirttools/image.go
@@ -18,6 +18,7 @@ package libvirttools
 
 import (
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/Mirantis/virtlet/pkg/utils"
@@ -77,6 +78,9 @@ func (i *ImageTool) PullRemoteImageToVolume(imageName, volumeName string) error 
 	if err != nil {
 		return err
 	}
+	defer func() {
+		os.Remove(path)
+	}()
 
 	return i.tool.PullFileToVolume(path, volumeName)
 }

--- a/pkg/libvirttools/image.go
+++ b/pkg/libvirttools/image.go
@@ -71,7 +71,7 @@ func (i *ImageTool) ImageAsVolumeInfo(volumeName string) (*VolumeInfo, error) {
 	return vol.Info()
 }
 
-func (i *ImageTool) PullImageToVolume(imageName, volumeName string) error {
+func (i *ImageTool) PullRemoteImageToVolume(imageName, volumeName string) error {
 	// TODO(nhlfr): Handle AuthConfig from PullImageRequest.
 	path, err := utils.DownloadFile(i.protocol, stripTagFromImageName(imageName), volumeName)
 	if err != nil {

--- a/pkg/libvirttools/image.go
+++ b/pkg/libvirttools/image.go
@@ -73,12 +73,12 @@ func (i *ImageTool) ImageAsVolumeInfo(volumeName string) (*VolumeInfo, error) {
 
 func (i *ImageTool) PullRemoteImageToVolume(imageName, volumeName string) error {
 	// TODO(nhlfr): Handle AuthConfig from PullImageRequest.
-	path, err := utils.DownloadFile(i.protocol, stripTagFromImageName(imageName), volumeName)
+	path, err := utils.DownloadFile(i.protocol, stripTagFromImageName(imageName))
 	if err != nil {
 		return err
 	}
 
-	return i.tool.PullImageToVolume(path, volumeName)
+	return i.tool.PullFileToVolume(path, volumeName)
 }
 
 func (i *ImageTool) RemoveImage(volumeName string) error {

--- a/pkg/libvirttools/storage_interface.go
+++ b/pkg/libvirttools/storage_interface.go
@@ -87,10 +87,12 @@ func (l LibvirtStorageOperations) VolumeGetPath(volume *libvirt.StorageVol) (str
 }
 
 func (l LibvirtStorageOperations) PullImageToVolume(pool *libvirt.StoragePool, shortName, filepath, volXML string) error {
-	// if we have such image already in store - just ignore request
+	// if we have such image already in store - remove it
 	existing_vol, _ := l.LookupVolumeByName(pool, shortName)
 	if existing_vol != nil {
-		return nil
+		if err := l.RemoveVolume(existing_vol); err != nil {
+			return err
+		}
 	}
 
 	f, err := os.Open(filepath)

--- a/pkg/libvirttools/storage_interface.go
+++ b/pkg/libvirttools/storage_interface.go
@@ -26,6 +26,7 @@ import (
 type StorageOperations interface {
 	CreateFromXML(xmlConfig string) (*libvirt.StoragePool, error)
 	CreateVolFromXML(pool *libvirt.StoragePool, xmlConfig string) (*libvirt.StorageVol, error)
+	CreateVolCloneFromXML(pool *libvirt.StoragePool, xmlConfig string, from *libvirt.StorageVol) (*libvirt.StorageVol, error)
 	ListAllVolumes(pool *libvirt.StoragePool) ([]libvirt.StorageVol, error)
 	LookupByName(name string) (*libvirt.StoragePool, error)
 	LookupVolumeByName(pool *libvirt.StoragePool, name string) (*libvirt.StorageVol, error)
@@ -51,6 +52,10 @@ func (l LibvirtStorageOperations) CreateFromXML(xmlConfig string) (*libvirt.Stor
 
 func (l LibvirtStorageOperations) CreateVolFromXML(pool *libvirt.StoragePool, xmlConfig string) (*libvirt.StorageVol, error) {
 	return pool.StorageVolCreateXML(xmlConfig, 0)
+}
+
+func (l LibvirtStorageOperations) CreateVolCloneFromXML(pool *libvirt.StoragePool, xmlConfig string, from *libvirt.StorageVol) (*libvirt.StorageVol, error) {
+	return pool.StorageVolCreateXMLFrom(xmlConfig, from, 0)
 }
 
 func (l LibvirtStorageOperations) ListAllVolumes(pool *libvirt.StoragePool) ([]libvirt.StorageVol, error) {

--- a/pkg/libvirttools/storage_interface.go
+++ b/pkg/libvirttools/storage_interface.go
@@ -88,9 +88,9 @@ func (l LibvirtStorageOperations) VolumeGetPath(volume *libvirt.StorageVol) (str
 
 func (l LibvirtStorageOperations) PullImageToVolume(pool *libvirt.StoragePool, shortName, filepath, volXML string) error {
 	// if we have such image already in store - remove it
-	existing_vol, _ := l.LookupVolumeByName(pool, shortName)
-	if existing_vol != nil {
-		if err := l.RemoveVolume(existing_vol); err != nil {
+	existingVol, _ := l.LookupVolumeByName(pool, shortName)
+	if existingVol != nil {
+		if err := l.RemoveVolume(existingVol); err != nil {
 			return err
 		}
 	}

--- a/pkg/libvirttools/storage_pool.go
+++ b/pkg/libvirttools/storage_pool.go
@@ -286,7 +286,7 @@ func (s *StorageTool) CreateQCOW2Volume(name string, capacity uint64, capacityUn
 	return s.pool.CreateVolume(name, volumeXML)
 }
 
-func (s *StorageTool) CreateVolumeClone(name string, from *Volume) (*Volume, error) {
+func (s *StorageTool) CloneVolume(name string, from *Volume) (*Volume, error) {
 	cloneXMLtemplate := `
 <volume type='file'>
     <name>%s</name>

--- a/pkg/libvirttools/storage_pool.go
+++ b/pkg/libvirttools/storage_pool.go
@@ -432,7 +432,7 @@ func generateRawDeviceXML(path, device string) string {
 	return fmt.Sprintf(rawDeviceTemplateXML, path, device)
 }
 
-func (s *StorageTool) PullImageToVolume(path, volumeName string) error {
+func (s *StorageTool) PullFileToVolume(path, volumeName string) error {
 	imageSize, err := getFileSize(path)
 	if err != nil {
 		return err

--- a/pkg/libvirttools/storage_pool.go
+++ b/pkg/libvirttools/storage_pool.go
@@ -216,6 +216,14 @@ func (p *Pool) LookupVolume(name string) (*Volume, error) {
 	return &Volume{tool: p.tool, Name: name, volume: vol}, nil
 }
 
+func (p *Pool) CloneVolume(name, volXML string, from *Volume) (*Volume, error) {
+	vol, err := p.tool.CreateVolCloneFromXML(p.pool, volXML, from.volume)
+	if err != nil {
+		return nil, err
+	}
+	return &Volume{tool: p.tool, Name: name, volume: vol}, nil
+}
+
 func (p *Pool) ListVolumes() ([]*VolumeInfo, error) {
 	volumes, err := p.tool.ListAllVolumes(p.pool)
 	if err != nil {
@@ -278,23 +286,17 @@ func (s *StorageTool) CreateQCOW2Volume(name string, capacity uint64, capacityUn
 	return s.pool.CreateVolume(name, volumeXML)
 }
 
-func (s *StorageTool) CreateSnapshot(name string, capacity uint64, capacityUnit string, backingStorePath string) (*Volume, error) {
-	snapshotXML := `
+func (s *StorageTool) CreateVolumeClone(name string, from *Volume) (*Volume, error) {
+	cloneXMLtemplate := `
 <volume type='file'>
     <name>%s</name>
-    <allocation>0</allocation>
-    <capacity unit="%s">%d</capacity>
     <target>
          <format type='qcow2'/>
     </target>
-    <backingStore>
-         <path>%s</path>
-         <format type='qcow2'/>
-     </backingStore>
 </volume>`
-	snapshotXML = fmt.Sprintf(snapshotXML, name, capacityUnit, capacity, backingStorePath)
-	glog.V(2).Infof("Create volume using XML description: %s", snapshotXML)
-	return s.pool.CreateVolume(name, snapshotXML)
+	cloneXML := fmt.Sprintf(cloneXMLtemplate, name)
+	glog.V(2).Infof("Creating volume clone with name '%s' from volume '%s'.", name, from.Name)
+	return s.pool.CloneVolume(name, cloneXML, from)
 }
 
 func (s *StorageTool) LookupVolume(name string) (*Volume, error) {

--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -187,7 +187,7 @@ func canUseKvm() bool {
 	return true
 }
 
-func generateDomXML(useKvm bool, name string, memory int64, memoryUnit string, uuid string, cpuNum int, cpuShare int64, cpuPeriod int64, cpuQuota int64, imageFilepath, netNSPath, cniConfig string) string {
+func generateDomXML(useKvm bool, name string, memory int64, memoryUnit string, uuid string, cpuNum int, cpuShare int64, cpuPeriod int64, cpuQuota int64, rootDiskFilepath, netNSPath, cniConfig string) string {
 	domainType := defaultDomainType
 	emulator := defaultEmulator
 	if !useKvm {
@@ -246,12 +246,21 @@ func generateDomXML(useKvm bool, name string, memory int64, memoryUnit string, u
       <env name='VIRTLET_CNI_CONFIG' value='%s'/>
     </commandline>
 </domain>`
-	return fmt.Sprintf(domXML, domainType, uuid, name, uuid, memoryUnit, memory, cpuNum, cpuShare, cpuPeriod, cpuQuota, imageFilepath, emulator, netNSPath, cniConfigEscaped)
+	return fmt.Sprintf(domXML, domainType, uuid, name, uuid, memoryUnit, memory, cpuNum, cpuShare, cpuPeriod, cpuQuota, rootDiskFilepath, emulator, netNSPath, cniConfigEscaped)
 }
 
-func (v *VirtualizationTool) createBootImageSnapshot(imageName, backingStorePath string, size uint64) (string, error) {
-	vol, err := v.volumeStorage.CreateSnapshot(imageName, size, "B", backingStorePath)
+func (v *VirtualizationTool) createBootImageClone(cloneName, imageName string) (string, error) {
+	imageVolumeName, err := ImageNameToVolumeName(imageName)
+	if err != nil {
+		return "", err
+	}
 
+	imageVolume, err := v.imagesStorage.LookupVolume(imageVolumeName)
+	if err != nil {
+		return "", err
+	}
+
+	vol, err := v.volumeStorage.CreateVolumeClone(cloneName, imageVolume)
 	if err != nil {
 		return "", err
 	}
@@ -399,19 +408,20 @@ func (v *VirtualizationTool) addAttachedVolumesXML(podID, podName, uuid, virtlet
 type VirtualizationTool struct {
 	tool           DomainOperations
 	volumeStorage  *StorageTool
+	imagesStorage  *StorageTool
 	volumePoolName string
 }
 
-func NewVirtualizationTool(conn *libvirt.Connect, poolName, rawDevices string) (*VirtualizationTool, error) {
-	storageTool, err := NewStorageTool(conn, poolName, rawDevices)
+func NewVirtualizationTool(conn *libvirt.Connect, volumesPoolName string, imagesStorage *StorageTool, rawDevices string) (*VirtualizationTool, error) {
+	storageTool, err := NewStorageTool(conn, volumesPoolName, rawDevices)
 	if err != nil {
 		return nil, err
 	}
 	tool := NewLibvirtDomainOperations(conn)
-	return &VirtualizationTool{tool: tool, volumeStorage: storageTool}, nil
+	return &VirtualizationTool{tool: tool, volumeStorage: storageTool, imagesStorage: imagesStorage}, nil
 }
 
-func (v *VirtualizationTool) CreateContainer(metadataStore metadata.MetadataStore, in *kubeapi.CreateContainerRequest, imageFilepath string, imageSize uint64, netNSPath, cniConfig string) (string, error) {
+func (v *VirtualizationTool) CreateContainer(metadataStore metadata.MetadataStore, in *kubeapi.CreateContainerRequest, imageName string, netNSPath, cniConfig string) (string, error) {
 	uuid, err := utils.NewUuid()
 	if err != nil {
 		return "", err
@@ -445,13 +455,13 @@ func (v *VirtualizationTool) CreateContainer(metadataStore metadata.MetadataStor
 		}
 	}
 
-	snapshotName := "snapshot_" + uuid
-	snapshotImage, err := v.createBootImageSnapshot(snapshotName, imageFilepath, imageSize)
+	cloneName := "root_" + uuid
+	cloneImage, err := v.createBootImageClone(cloneName, imageName)
 	if err != nil {
 		return "", err
 	}
 
-	metadataStore.SetContainer(name, uuid, in.PodSandboxId, config.Image.Image, snapshotName, config.Labels, config.Annotations)
+	metadataStore.SetContainer(name, uuid, in.PodSandboxId, config.Image.Image, cloneName, config.Labels, config.Annotations)
 
 	var memory, cpuShares, cpuPeriod, cpuQuota int64
 	if config.Linux != nil && config.Linux.Resources != nil {
@@ -471,7 +481,7 @@ func (v *VirtualizationTool) CreateContainer(metadataStore metadata.MetadataStor
 		return "", err
 	}
 
-	domXML := generateDomXML(canUseKvm(), name, memory, memoryUnit, uuid, cpuNum, cpuShares, cpuPeriod, cpuQuota, snapshotImage, netNSPath, cniConfig)
+	domXML := generateDomXML(canUseKvm(), name, memory, memoryUnit, uuid, cpuNum, cpuShares, cpuPeriod, cpuQuota, cloneImage, netNSPath, cniConfig)
 
 	virtletVolsDesc, _ := sandBoxAnnotations[VirtletVolumesAnnotationKeyName]
 	domXML, err = v.addAttachedVolumesXML(in.PodSandboxId, in.SandboxConfig.Metadata.Name, uuid, virtletVolsDesc, domXML)

--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -260,7 +260,7 @@ func (v *VirtualizationTool) createBootImageClone(cloneName, imageName string) (
 		return "", err
 	}
 
-	vol, err := v.volumeStorage.CreateVolumeClone(cloneName, imageVolume)
+	vol, err := v.volumeStorage.CloneVolume(cloneName, imageVolume)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -65,7 +65,7 @@ func NewVirtletManager(libvirtUri, poolName, downloadProtocol, storageBackend, m
 	}
 
 	// TODO: pool name should be passed like for imageTool
-	libvirtVirtualizationTool, err := libvirttools.NewVirtualizationTool(libvirtConnTool.Connection(), "volumes", rawDevices)
+	libvirtVirtualizationTool, err := libvirttools.NewVirtualizationTool(libvirtConnTool.Connection(), "volumes", libvirtImageTool.GetStorageTool(), rawDevices)
 	if err != nil {
 		return nil, err
 	}
@@ -301,24 +301,6 @@ func (v *VirtletManager) CreateContainer(ctx context.Context, in *kubeapi.Create
 	glog.V(3).Infof("CreateContainer: %s", spew.Sdump(in))
 	glog.V(3).Infof("CreateContainer config: %s", spew.Sdump(config))
 
-	volumeName, err := libvirttools.ImageNameToVolumeName(imageName)
-	if err != nil {
-		glog.Errorf("CreateContainer: error getting volume name for image %q: %v", imageName, err)
-		return nil, err
-	}
-
-	imageFilePath, err := v.libvirtImageTool.ImageFilePath(volumeName)
-	if err != nil {
-		glog.Errorf("Error when getting file path for image %q (volume %q): %v", imageName, volumeName, err)
-		return nil, err
-	}
-
-	volumeInfo, err := v.libvirtImageTool.ImageAsVolumeInfo(volumeName)
-	if err != nil {
-		glog.Errorf("Error when getting volume info for image %q (volume %q): %v", imageName, volumeName, err)
-		return nil, err
-	}
-
 	// TODO: get it as string
 	netAsBytes, err := v.metadataStore.GetPodNetworkConfigurationAsBytes(podSandboxId)
 	if err != nil {
@@ -333,12 +315,12 @@ func (v *VirtletManager) CreateContainer(ctx context.Context, in *kubeapi.Create
 	}
 
 	netNSPath := cni.PodNetNSPath(podSandboxId)
-	glog.V(2).Infof("CreateContainer: imageName %s, imageFilepath %s, ip %s, network namespace %s", imageName, imageFilePath, netResult.IP4.IP.IP.String(), netNSPath)
+	glog.V(2).Infof("CreateContainer: imageName %s, ip %s, network namespace %s", imageName, netResult.IP4.IP.IP.String(), netNSPath)
 
 	// TODO: we should not pass whole "in" to CreateContainer - we should pass there only needed info for CreateContainer
 	// without whole data container
 	// TODO: use network configuration by CreateContainer
-	uuid, err := v.libvirtVirtualizationTool.CreateContainer(v.metadataStore, in, imageFilePath, volumeInfo.Size, netNSPath, string(netAsBytes))
+	uuid, err := v.libvirtVirtualizationTool.CreateContainer(v.metadataStore, in, imageName, netNSPath, string(netAsBytes))
 	if err != nil {
 		glog.Errorf("Error when creating container %s: %v", name, err)
 		return nil, err
@@ -394,8 +376,8 @@ func (v *VirtletManager) RemoveContainer(ctx context.Context, in *kubeapi.Remove
 		return nil, err
 	}
 
-	if err := v.libvirtVirtualizationTool.RemoveVolume(containerInfo.RootImageSnapshotName); err != nil {
-		glog.Errorf("Error when removing image snapshot with name '%s': %v", containerInfo.RootImageSnapshotName, err)
+	if err := v.libvirtVirtualizationTool.RemoveVolume(containerInfo.RootImageVolumeName); err != nil {
+		glog.Errorf("Error when removing root volume with name '%s': %v", containerInfo.RootImageVolumeName, err)
 		return nil, err
 	}
 

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -571,24 +571,7 @@ func (v *VirtletManager) PullImage(ctx context.Context, in *kubeapi.PullImageReq
 		return nil, err
 	}
 
-	// PullPolicy is not accessible directly within remote runtime
-	// But PullImage request can be called in 2 cases:
-	// 1. PullAlways
-	// 2. PullIfNotPresent
-	// So need to check whether the image with such URL was already downloaded
-
-	existingImageName, err := v.metadataStore.GetImageName(volumeName)
-	if err != nil {
-		glog.Errorf("PullImage: error when checking for existing image %q: %v", imageName, err)
-		return nil, err
-	}
-
-	if existingImageName != "" {
-		// Image has been downloaded already
-		return &kubeapi.PullImageResponse{ImageRef: imageName}, nil
-	}
-
-	if err = v.libvirtImageTool.PullImageToVolume(imageName, volumeName); err != nil {
+	if err = v.libvirtImageTool.PullRemoteImageToVolume(imageName, volumeName); err != nil {
 		glog.Errorf("Error when pulling image %q: %v", imageName, err)
 		return nil, err
 	}

--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -22,16 +22,16 @@ import (
 
 // ContainerInfo contains metadata informations about container instance
 type ContainerInfo struct {
-	Name                  string
-	CreatedAt             int64
-	StartedAt             int64
-	SandboxId             string
-	Image                 string
-	RootImageSnapshotName string
-	Labels                map[string]string
-	Annotations           map[string]string
-	SandBoxAnnotations    map[string]string
-	State                 kubeapi.ContainerState
+	Name                string
+	CreatedAt           int64
+	StartedAt           int64
+	SandboxId           string
+	Image               string
+	RootImageVolumeName string
+	Labels              map[string]string
+	Annotations         map[string]string
+	SandBoxAnnotations  map[string]string
+	State               kubeapi.ContainerState
 }
 
 // ImageMetadataStore contains methods to operate on VM images
@@ -55,7 +55,7 @@ type SandboxMetadataStore interface {
 
 // ContainerMetadataStore contains methods to operate on containers (VMs)
 type ContainerMetadataStore interface {
-	SetContainer(name, containerId, sandboxId, image, rootImageSnapshotName string, labels, annotations map[string]string) error
+	SetContainer(name, containerId, sandboxId, image, rootImageVolumeName string, labels, annotations map[string]string) error
 	UpdateStartedAt(containerId string, startedAt string) error
 	UpdateState(containerId string, state byte) error
 	GetContainerInfo(containerId string) (*ContainerInfo, error)

--- a/pkg/utils/download.go
+++ b/pkg/utils/download.go
@@ -19,23 +19,23 @@ package utils
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
-	"os"
 
 	"github.com/golang/glog"
 )
 
 // DownloadFile downloads a file via an URL constructed as 'protocol://location'
-// and saves it under the specified fileName in /tmp
-func DownloadFile(protocol, location, fileName string) (string, error) {
+// and saves it in temporary file in default system directory for temporary files.
+// Returns path to this temporary file.
+func DownloadFile(protocol, location string) (string, error) {
 	url := fmt.Sprintf("%s://%s", protocol, location)
 
-	path := "/tmp/" + fileName
-	fp, err := os.Create(path)
+	tempFile, err := ioutil.TempFile("", "virtlet_")
 	if err != nil {
 		return "", err
 	}
-	defer fp.Close()
+	defer tempFile.Close()
 
 	glog.V(2).Infof("Start downloading %s", url)
 
@@ -45,10 +45,10 @@ func DownloadFile(protocol, location, fileName string) (string, error) {
 	}
 	defer resp.Body.Close()
 
-	_, err = io.Copy(fp, resp.Body)
+	_, err = io.Copy(tempFile, resp.Body)
 	if err != nil {
 		return "", err
 	}
-	glog.V(2).Infof("Data from url %s saved in %s", url, path)
-	return path, nil
+	glog.V(2).Infof("Data from url %s saved in %s", url, tempFile.Name())
+	return tempFile.Name(), nil
 }

--- a/tests/criapi/fake.go
+++ b/tests/criapi/fake.go
@@ -9,13 +9,13 @@ import (
 )
 
 type ContainerTestConfig struct {
-	Name                  string
-	SandboxId             string
-	ContainerId           string
-	Image                 string
-	RootImageSnapshotName string
-	Labels                map[string]string
-	Annotations           map[string]string
+	Name                string
+	SandboxId           string
+	ContainerId         string
+	Image               string
+	RootImageVolumeName string
+	Labels              map[string]string
+	Annotations         map[string]string
 }
 
 func GetSandboxes(sandboxNum int) []*kubeapi.PodSandboxConfig {
@@ -86,13 +86,13 @@ func GetContainersConfig(sandboxConfigs []*kubeapi.PodSandboxConfig) []*Containe
 		}
 
 		containerConf := &ContainerTestConfig{
-			Name:      "container-for-" + sandbox.Metadata.Name,
-			SandboxId: sandbox.Metadata.Uid,
-			Image:     "testImage",
-			RootImageSnapshotName: "sample_name",
-			ContainerId:           uid,
-			Labels:                map[string]string{"foo": "bar", "fizz": "buzz"},
-			Annotations:           map[string]string{"hello": "world", "virt": "let"},
+			Name:                "container-for-" + sandbox.Metadata.Name,
+			SandboxId:           sandbox.Metadata.Uid,
+			Image:               "testImage",
+			RootImageVolumeName: "sample_name",
+			ContainerId:         uid,
+			Labels:              map[string]string{"foo": "bar", "fizz": "buzz"},
+			Annotations:         map[string]string{"hello": "world", "virt": "let"},
 		}
 		containers = append(containers, containerConf)
 	}


### PR DESCRIPTION
- [x] switch root disks usage from taking/using snapshots to using volume clones
- [x] remove tests for volume existence during image import
- [x] make sure that temporary file have unique name
- [x] (re)create volume from downloaded image
- [x] remove temporary file
- [x] update docs

Partially resolves #244 - removes names conflict in `/tmp` during image download.
Closes #228

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/272)
<!-- Reviewable:end -->
