### PR TITLE
Fix potential volumes from images collision

### DIFF
--- a/pkg/libvirttools/image.go
+++ b/pkg/libvirttools/image.go
@@ -68,7 +68,7 @@ func NewImageTool(conn *libvirt.Connect, poolName, protocol string) (*ImageTool,
 	return &ImageTool{tool: storageTool, protocol: protocol}, nil
 }
 
-func (i *ImageTool) ListImagesAsVolumeInfos() ([]*VolumeInfo, error) {
+func (i *ImageTool) ListLibvirtVolumesAsVolumeInfos() ([]*VolumeInfo, error) {
 	return i.tool.ListVolumes()
 }
 
@@ -99,4 +99,9 @@ func (i *ImageTool) RemoveImage(volumeName string) error {
 
 func (i *ImageTool) GetStorageTool() *StorageTool {
 	return i.tool
+}
+
+func ImageNameFromLibvirtVolumeName(volumeName string) string {
+	parts := strings.SplitN(volumeName, "_", 2)
+	return parts[1]
 }

--- a/pkg/libvirttools/image.go
+++ b/pkg/libvirttools/image.go
@@ -17,6 +17,9 @@ limitations under the License.
 package libvirttools
 
 import (
+	"crypto/sha1"
+	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"strings"
@@ -38,8 +41,13 @@ func ImageNameToVolumeName(imageName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	h := sha1.New()
+	io.WriteString(h, u.Path)
+
 	segments := strings.Split(u.Path, "/")
-	volumeName := segments[len(segments)-1]
+
+	volumeName := fmt.Sprintf("%x_%s", h.Sum(nil), segments[len(segments)-1])
 
 	return volumeName, nil
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -469,26 +469,26 @@ func (v *VirtletManager) Status(context.Context, *kubeapi.StatusRequest) (*kubea
 //
 
 func (v *VirtletManager) imageFromVolumeInfo(volumeInfo *libvirttools.VolumeInfo) (*kubeapi.Image, error) {
-	imageName, err := v.metadataStore.GetImageName(volumeInfo.Name)
+	libvirtVolumeName, err := v.metadataStore.GetImageName(volumeInfo.Name)
 	if err != nil {
 		glog.Errorf("Error when checking for existing image with volume %q: %v", volumeInfo.Name, err)
 		return nil, err
 	}
 
-	if imageName == "" {
+	if libvirtVolumeName == "" {
 		// the image doesn't exist
 		return nil, nil
 	}
 
 	return &kubeapi.Image{
-		Id:       volumeInfo.Name,
-		RepoTags: []string{imageName},
+		Id:       libvirttools.ImageNameFromLibvirtVolumeName(volumeInfo.Name),
+		RepoTags: []string{libvirtVolumeName},
 		Size_:    volumeInfo.Size,
 	}, nil
 }
 
 func (v *VirtletManager) ListImages(ctx context.Context, in *kubeapi.ListImagesRequest) (*kubeapi.ListImagesResponse, error) {
-	volumeInfos, err := v.libvirtImageTool.ListImagesAsVolumeInfos()
+	volumeInfos, err := v.libvirtImageTool.ListLibvirtVolumesAsVolumeInfos()
 	if err != nil {
 		glog.Errorf("Error when listing images: %v", err)
 		return nil, err

--- a/tests/integration/image_test.go
+++ b/tests/integration/image_test.go
@@ -182,7 +182,11 @@ func TestListImagesWithFilter(t *testing.T) {
 }
 
 func getImageFileModificationTime() (time.Time, error) {
-	fileInfo, err := os.Stat(path.Join("/var/lib/libvirt/images", imageCirrosId))
+	// Hardcoded file name for image:
+	// "download.cirros-cloud.net/0.3.4/cirros-0.3.4-x86_64-disk.img"
+	// used by it.pullImage
+	imageFileName := "cdb29fccb47c1a69b1931685596258cfb760cb87_cirros-0.3.4-x86_64-disk.img"
+	fileInfo, err := os.Stat(path.Join("/var/lib/libvirt/images", imageFileName))
 	if err != nil {
 		return time.Time{}, err
 	}


### PR DESCRIPTION
Addresses last part of #244 not covered by #272.
Hash of whole image definition received from kubelet is there added at the beginning of volume name.

- [x] add hash at the beginning of volume name

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/273)
<!-- Reviewable:end -->
