### PR TITLE
Fix CRI Proxy runtime disconnections and Virtlet removal

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -31,3 +31,27 @@ kubectl create -f virtlet-ds.yaml
 kubectl get pods -w -n kube-system
 ```
 5. Go to `examples/` directory and follow [the instructions](../examples/README.md) from there.
+
+## Removing Virtlet
+
+In order to remove Virtlet, first you need to delete all the VM pods.
+
+You can remove Virtlet DaemonSet with the following command:
+```bash
+kubectl delete daemonset -R -n kube-system virtlet
+```
+
+To undo the changes made by CRI proxy bootstrap, first remove the
+configmaps for the nodes that run Virtlet, e.g. for node named
+`kube-node-1` this is done using the following command:
+```
+kubectl delete configmap -n kube-system kubelet-kube-node-1
+```
+
+Then restart kubelet on the nodes, remove criproxy containers and the
+saved kubelet config:
+```
+systemctl restart kubelet
+docker rm -fv $(docker ps -qf label=criproxy=true)
+rm /etc/criproxy/kubelet.conf
+```

--- a/deploy/real-cluster.md
+++ b/deploy/real-cluster.md
@@ -200,3 +200,20 @@ You can also ssh into the VM:
 ```
 ./vmssh.sh cirros@cirros-vm
 ```
+
+## Removing Virtlet
+
+In order to remove Virtlet, first you need to delete all the VM pods.
+
+You can remove Virtlet DaemonSet with the following command:
+```bash
+kubectl delete daemonset -R -n kube-system virtlet
+```
+
+After doing this, remove CRI proxy from each node by reverting the
+changes in Kubelet flags, e.g. by removing
+`/etc/systemd/system/kubelet.service.d/20-virtlet.conf` in case of
+kubeadm scenario described above. After this you need to restart
+kubelet and remove the CRI Proxy binary (`/usr/local/bin/criproxy`)
+and its saved kubelet configuration file
+(`/etc/criproxy/kubelet.conf`).

--- a/pkg/criproxy/bootstrap.go
+++ b/pkg/criproxy/bootstrap.go
@@ -50,11 +50,12 @@ import (
 const (
 	BusyboxImageName = "busybox:1.26.2"
 	// TODO: use the same constant/setting in different parts of code
-	proxyRuntimeEndpoint      = "/run/criproxy.sock"
-	proxyStopTimeoutSeconds   = 5
-	confFileMode              = 0600
-	confDirMode               = 0700
-	kubeletConfigPollInterval = 1 * time.Second
+	proxyRuntimeEndpoint             = "/run/criproxy.sock"
+	proxyStopTimeoutSeconds          = 5
+	confFileMode                     = 0600
+	confDirMode                      = 0700
+	kubeletConfigPollInterval        = 1 * time.Second
+	waitForCriProxySocketNumAttempts = 600
 )
 
 var kubeletSettingsForCriProxy map[string]interface{} = map[string]interface{}{
@@ -399,7 +400,7 @@ func (b *Bootstrap) EnsureCRIProxy() (bool, error) {
 		return false, err
 	}
 
-	if err = waitForSocket(b.config.ProxySocketPath); err != nil {
+	if err = waitForSocket(b.config.ProxySocketPath, waitForCriProxySocketNumAttempts, nil); err != nil {
 		return false, err
 	}
 

--- a/pkg/criproxy/proxy.go
+++ b/pkg/criproxy/proxy.go
@@ -49,6 +49,7 @@ import (
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	runtimeapi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 )
 
@@ -95,10 +96,7 @@ func (c *apiClient) currentState() clientState {
 	return c.state
 }
 
-func (c *apiClient) connect() chan error {
-	c.Lock()
-	defer c.Unlock()
-
+func (c *apiClient) connectNonLocked() chan error {
 	if c.state == clientStateConnected {
 		errCh := make(chan error, 1)
 		errCh <- nil
@@ -139,9 +137,13 @@ func (c *apiClient) connect() chan error {
 	return errCh
 }
 
-func (c *apiClient) stop() {
+func (c *apiClient) connect() chan error {
 	c.Lock()
 	defer c.Unlock()
+	return c.connectNonLocked()
+}
+
+func (c *apiClient) stopNonLocked() {
 	if c.conn == nil {
 		return
 	}
@@ -151,9 +153,32 @@ func (c *apiClient) stop() {
 	c.conn = nil
 	c.RuntimeServiceClient = nil
 	c.ImageServiceClient = nil
+	c.state = clientStateOffline
 }
 
-func (c *apiClient) wrapError(err error) error {
+func (c *apiClient) stop() {
+	c.Lock()
+	defer c.Unlock()
+	c.stopNonLocked()
+}
+
+// handleError checks whether an error returned by grpc call has
+// 'Unavailable' code in which case it disconnects from the client and
+// starts trying to reestablish the connection. In case if
+// tolerateDisconnect is true, it also returns nil in this case. In
+// other cases, including non-'Unavailable' errors, it returns the
+// original err value
+func (c *apiClient) handleError(err error, tolerateDisconnect bool) error {
+	if grpc.Code(err) == codes.Unavailable {
+		c.Lock()
+		defer c.Unlock()
+		c.stopNonLocked()
+		c.connectNonLocked()
+
+		if tolerateDisconnect {
+			return nil
+		}
+	}
 	return fmt.Errorf("%q: %v", c.addr, err)
 }
 
@@ -395,7 +420,7 @@ func (r *RuntimeProxy) StopPodSandbox(ctx context.Context, in *runtimeapi.StopPo
 	resp, err := client.StopPodSandbox(ctx, in)
 	if err != nil {
 		glog.Errorf("FAIL: StopPodSandbox() [%s]: StopPodSandbox %q from runtime service failed: %v", client.id, in.PodSandboxId, err)
-		return nil, client.wrapError(err)
+		return nil, client.handleError(err, false)
 	}
 
 	glog.Infof("LEAVE: StopPodSandbox() [%s]: %s", client.id, spew.Sdump(resp))
@@ -416,14 +441,14 @@ func (r *RuntimeProxy) RemovePodSandbox(ctx context.Context, in *runtimeapi.Remo
 	resp, err := client.RemovePodSandbox(ctx, in)
 	if err != nil {
 		glog.Errorf("FAIL: RemovePodSandbox() [%s]: RemovePodSandbox %q from runtime service failed: %v", client.id, in.PodSandboxId, err)
-		return nil, client.wrapError(err)
+		return nil, client.handleError(err, false)
 	}
 
 	glog.Infof("LEAVE: RemovePodSandbox() [%s]: %s", client.id, spew.Sdump(resp))
 	return resp, nil
 }
 
-// PodSandboxStatus returns ruRemoteRuntimeServicentiSandbox.
+// PodSandboxStatus returns the status of a PodSandbox.
 func (r *RuntimeProxy) PodSandboxStatus(ctx context.Context, in *runtimeapi.PodSandboxStatusRequest) (*runtimeapi.PodSandboxStatusResponse, error) {
 	client, unprefixed, err := r.clientForId(in.PodSandboxId)
 	if err != nil {
@@ -437,7 +462,7 @@ func (r *RuntimeProxy) PodSandboxStatus(ctx context.Context, in *runtimeapi.PodS
 	resp, err := client.PodSandboxStatus(ctx, in)
 	if err != nil {
 		glog.Errorf("FAIL: PodSandboxStatus(): PodSandboxStatus %q from runtime service failed: %v", in.PodSandboxId, err)
-		return nil, client.wrapError(err)
+		return nil, client.handleError(err, false)
 	}
 
 	if resp.GetStatus() != nil {
@@ -474,9 +499,12 @@ func (r *RuntimeProxy) ListPodSandbox(ctx context.Context, in *runtimeapi.ListPo
 
 		resp, err := client.ListPodSandbox(ctx, in)
 		if err != nil {
-			err = client.wrapError(err)
-			glog.Errorf("FAIL: ListPodSandbox() [%s]: ListPodSandbox with filter %#v from runtime service failed: %v", clientStr, in.GetFilter(), err)
-			return nil, err
+			err = client.handleError(err, true)
+			// if the runtime server is gone, let's just skip it
+			if err != nil {
+				glog.Errorf("FAIL: ListPodSandbox() [%s]: ListPodSandbox with filter %#v from runtime service failed: %v", clientStr, in.GetFilter(), err)
+				return nil, err
+			}
 		}
 		sandboxes = append(sandboxes, client.prefixSandboxes(resp.GetItems())...)
 	}
@@ -502,7 +530,7 @@ func (r *RuntimeProxy) CreateContainer(ctx context.Context, in *runtimeapi.Creat
 	}
 
 	image := in.GetConfig().Image
-	imageClient, unprefixedImage, err := r.clientForImage(image)
+	imageClient, unprefixedImage, err := r.clientForImage(image, false)
 	if err != nil {
 		glog.Errorf("FAIL: CreateContainer(): %v", err)
 		return nil, err
@@ -516,7 +544,7 @@ func (r *RuntimeProxy) CreateContainer(ctx context.Context, in *runtimeapi.Creat
 	resp, err := client.CreateContainer(ctx, in)
 	if err != nil {
 		glog.Errorf("FAIL: CreateContainer() [%s]: CreateContainer in sandbox %q from runtime service failed: %v", client.id, in.PodSandboxId, err)
-		return nil, client.wrapError(err)
+		return nil, client.handleError(err, false)
 	}
 
 	resp.ContainerId = client.augmentId(resp.ContainerId)
@@ -537,7 +565,7 @@ func (r *RuntimeProxy) StartContainer(ctx context.Context, in *runtimeapi.StartC
 	resp, err := client.StartContainer(ctx, in)
 	if err != nil {
 		glog.Errorf("FAIL: StartContainer() [%s]: StartContainer %q from runtime service failed: %v", client.id, in.ContainerId, err)
-		return nil, client.wrapError(err)
+		return nil, client.handleError(err, false)
 	}
 
 	glog.Infof("LEAVE: StartContainer() [%s]: %s", client.id, spew.Sdump(resp))
@@ -557,7 +585,7 @@ func (r *RuntimeProxy) StopContainer(ctx context.Context, in *runtimeapi.StopCon
 	resp, err := client.StopContainer(ctx, in)
 	if err != nil {
 		glog.Errorf("FAIL: StopContainer() [%s]: StopContainer %q from runtime service failed: %v", client.id, in.ContainerId, err)
-		return nil, client.wrapError(err)
+		return nil, client.handleError(err, false)
 	}
 
 	glog.Infof("LEAVE: StopContainer() [%s]: %s", client.id, spew.Sdump(resp))
@@ -578,7 +606,7 @@ func (r *RuntimeProxy) RemoveContainer(ctx context.Context, in *runtimeapi.Remov
 	resp, err := client.RemoveContainer(ctx, in)
 	if err != nil {
 		glog.Errorf("FAIL: RemoveContainer() [%s]: RemoveContainer %q from runtime service failed: %v", client.id, in.ContainerId, err)
-		return nil, client.wrapError(err)
+		return nil, client.handleError(err, false)
 	}
 
 	glog.Infof("LEAVE: RemoveContainer() [%s]: %s", client.id, spew.Sdump(resp))
@@ -645,9 +673,12 @@ func (r *RuntimeProxy) ListContainers(ctx context.Context, in *runtimeapi.ListCo
 
 		resp, err := client.ListContainers(ctx, in)
 		if err != nil {
-			err = client.wrapError(err)
-			glog.Errorf("FAIL: ListContainers() [%s]: ListContainers with filter %q from runtime service failed: %v", clientStr, in.GetFilter(), err)
-			return nil, err
+			err = client.handleError(err, true)
+			// if the runtime server is gone, let's just skip it
+			if err != nil {
+				glog.Errorf("FAIL: ListContainers() [%s]: ListContainers with filter %q from runtime service failed: %v", clientStr, in.GetFilter(), err)
+				return nil, err
+			}
 		}
 		containers = append(containers, client.prefixContainers(resp.GetContainers())...)
 	}
@@ -670,7 +701,7 @@ func (r *RuntimeProxy) ContainerStatus(ctx context.Context, in *runtimeapi.Conta
 	resp, err := client.ContainerStatus(ctx, in)
 	if err != nil {
 		glog.Errorf("FAIL: ContainerStatus() [%s]: ContainerStatus %q from runtime service failed: %v", client.id, in.ContainerId, err)
-		return nil, client.wrapError(err)
+		return nil, client.handleError(err, false)
 	}
 
 	if resp.GetStatus() != nil {
@@ -696,7 +727,7 @@ func (r *RuntimeProxy) ExecSync(ctx context.Context, in *runtimeapi.ExecSyncRequ
 	resp, err := client.ExecSync(ctx, in)
 	if err != nil {
 		glog.Errorf("FAIL: ExecSync() [%s]: ExecSync %q from runtime service failed: %v", client.id, in.ContainerId, err)
-		return nil, client.wrapError(err)
+		return nil, client.handleError(err, false)
 	}
 
 	glog.Infof("LEAVE: ExecSync() [%s]: %s", client.id, spew.Sdump(resp))
@@ -716,7 +747,7 @@ func (r *RuntimeProxy) Exec(ctx context.Context, in *runtimeapi.ExecRequest) (*r
 	resp, err := client.Exec(ctx, in)
 	if err != nil {
 		glog.Errorf("FAIL: Exec() [%s]: Exec %q from runtime service failed: %v", client.id, in.ContainerId, err)
-		return nil, client.wrapError(err)
+		return nil, client.handleError(err, false)
 	}
 
 	glog.Infof("LEAVE: Exec() [%s]: %s", client.id, spew.Sdump(resp))
@@ -736,7 +767,7 @@ func (r *RuntimeProxy) Attach(ctx context.Context, in *runtimeapi.AttachRequest)
 	resp, err := client.Attach(ctx, in)
 	if err != nil {
 		glog.Errorf("FAIL: Attach() [%s]: Attach %q from runtime service failed: %v", client.id, in.ContainerId, err)
-		return nil, client.wrapError(err)
+		return nil, client.handleError(err, false)
 	}
 
 	glog.Infof("LEAVE: Attach() [%s]: %s", client.id, spew.Sdump(resp))
@@ -756,7 +787,7 @@ func (r *RuntimeProxy) PortForward(ctx context.Context, in *runtimeapi.PortForwa
 	resp, err := client.PortForward(ctx, in)
 	if err != nil {
 		glog.Errorf("FAIL: PortForward() [%s]: PortForward %q from runtime service failed: %v", client.id, in.PodSandboxId, err)
-		return nil, client.wrapError(err)
+		return nil, client.handleError(err, false)
 	}
 
 	glog.Infof("LEAVE: PortForward() [%s]: %s", client.id, spew.Sdump(resp))
@@ -780,7 +811,7 @@ func (r *RuntimeProxy) UpdateRuntimeConfig(ctx context.Context, in *runtimeapi.U
 		_, err := client.UpdateRuntimeConfig(ctx, in)
 		if err != nil {
 			glog.Errorf("FAIL: UpdateRuntimeConfig() [%s]: UpdateRuntimeConfig from runtime service failed: %v", client.id, err)
-			errs = append(errs, client.wrapError(err).Error())
+			errs = append(errs, client.handleError(err, false).Error())
 		}
 	}
 
@@ -818,7 +849,11 @@ func (r *RuntimeProxy) ListImages(ctx context.Context, in *runtimeapi.ListImages
 	clients := r.clients
 	clientStr := "all clients"
 	if in.GetFilter() != nil && in.GetFilter().GetImage() != nil {
-		client, unprefixed, err := r.clientForImage(in.GetFilter().GetImage())
+		client, unprefixed, err := r.clientForImage(in.GetFilter().GetImage(), true)
+		if client == nil {
+			// the client is offline
+			return &runtimeapi.ListImagesResponse{}, nil
+		}
 		if err != nil {
 			glog.Errorf("FAIL: ListImages(): %v", err)
 			return nil, err
@@ -840,9 +875,12 @@ func (r *RuntimeProxy) ListImages(ctx context.Context, in *runtimeapi.ListImages
 
 		resp, err := client.ListImages(ctx, in)
 		if err != nil {
-			err = client.wrapError(err)
-			glog.Errorf("FAIL: ListImages() [%s]: ListImages with filter %q from image service failed: %v", clientStr, in.GetFilter(), err)
-			return nil, err
+			err = client.handleError(err, true)
+			// if the image server is gone, let's just skip it
+			if err != nil {
+				glog.Errorf("FAIL: ListImages() [%s]: ListImages with filter %q from image service failed: %v", clientStr, in.GetFilter(), err)
+				return nil, err
+			}
 		}
 		images = append(images, client.prefixImages(resp.GetImages())...)
 	}
@@ -854,7 +892,12 @@ func (r *RuntimeProxy) ListImages(ctx context.Context, in *runtimeapi.ListImages
 
 // ImageStatus returns the status of the image.
 func (r *RuntimeProxy) ImageStatus(ctx context.Context, in *runtimeapi.ImageStatusRequest) (*runtimeapi.ImageStatusResponse, error) {
-	client, unprefixed, err := r.clientForImage(in.GetImage())
+	client, unprefixed, err := r.clientForImage(in.GetImage(), true)
+	if client == nil {
+		// the client is offline
+		return &runtimeapi.ImageStatusResponse{}, nil
+	}
+
 	if err != nil {
 		glog.Errorf("FAIL: ImageStatus(): %v", err)
 		return nil, err
@@ -864,8 +907,13 @@ func (r *RuntimeProxy) ImageStatus(ctx context.Context, in *runtimeapi.ImageStat
 	in.Image.Image = unprefixed
 	resp, err := client.ImageStatus(ctx, in)
 	if err != nil {
+		err = client.handleError(err, true)
+		if err == nil {
+			// image runtime is gone, let's consider this image nonexistent
+			return nil, nil
+		}
 		glog.Errorf("FAIL: ImageStatus() [%s]: ImageStatus %q from image service failed: %v", client.id, in.GetImage().Image, err)
-		return nil, client.wrapError(err)
+		return nil, err
 	}
 
 	glog.Infof("LEAVE: ImageStatus() [%s]: %s", client.id, spew.Sdump(resp))
@@ -877,7 +925,7 @@ func (r *RuntimeProxy) ImageStatus(ctx context.Context, in *runtimeapi.ImageStat
 
 // PullImage pulls an image with authentication config.
 func (r *RuntimeProxy) PullImage(ctx context.Context, in *runtimeapi.PullImageRequest) (*runtimeapi.PullImageResponse, error) {
-	client, unprefixed, err := r.clientForImage(in.GetImage())
+	client, unprefixed, err := r.clientForImage(in.GetImage(), false)
 	if err != nil {
 		glog.Errorf("FAIL: PullImage(): %v", err)
 		return nil, err
@@ -888,7 +936,7 @@ func (r *RuntimeProxy) PullImage(ctx context.Context, in *runtimeapi.PullImageRe
 	resp, err := client.PullImage(ctx, in)
 	if err != nil {
 		glog.Errorf("FAIL: PullImage() [%s]: PullImage %q from image service failed: %v", client.id, in.GetImage().Image, err)
-		return nil, client.wrapError(err)
+		return nil, client.handleError(err, false)
 	}
 
 	resp.ImageRef = client.imageName(resp.ImageRef)
@@ -898,7 +946,7 @@ func (r *RuntimeProxy) PullImage(ctx context.Context, in *runtimeapi.PullImageRe
 
 // RemoveImage removes the image.
 func (r *RuntimeProxy) RemoveImage(ctx context.Context, in *runtimeapi.RemoveImageRequest) (*runtimeapi.RemoveImageResponse, error) {
-	client, unprefixed, err := r.clientForImage(in.GetImage())
+	client, unprefixed, err := r.clientForImage(in.GetImage(), false)
 	if err != nil {
 		glog.Errorf("FAIL: RemoveImage(): %v", err)
 		return nil, err
@@ -909,7 +957,7 @@ func (r *RuntimeProxy) RemoveImage(ctx context.Context, in *runtimeapi.RemoveIma
 	resp, err := client.RemoveImage(ctx, in)
 	if err != nil {
 		glog.Errorf("FAIL: RemoveImage() [%s]: RemoveImage %q from image service failed: %v", client.id, in.GetImage().Image, err)
-		return nil, client.wrapError(err)
+		return nil, client.handleError(err, false)
 	}
 
 	glog.Infof("LEAVE: RemoveImage() [%s]: %s", client.id, spew.Sdump(resp))
@@ -940,8 +988,9 @@ func (r *RuntimeProxy) clientForId(id string) (*apiClient, string, error) {
 	unprefixed := id
 	for _, c := range r.clients[1:] {
 		if ok, unpref := c.idPrefixMatches(id); ok {
-			if err := <-c.connect(); err != nil {
-				return nil, "", err
+			c.connect()
+			if c.currentState() != clientStateConnected {
+				return nil, "", fmt.Errorf("CRI proxy: target runtime is not available")
 			}
 			client = c
 			unprefixed = unpref
@@ -954,13 +1003,18 @@ func (r *RuntimeProxy) clientForId(id string) (*apiClient, string, error) {
 	return client, unprefixed, nil
 }
 
-func (r *RuntimeProxy) clientForImage(image *runtimeapi.ImageSpec) (*apiClient, string, error) {
+func (r *RuntimeProxy) clientForImage(image *runtimeapi.ImageSpec, noErrorIfNotConnected bool) (*apiClient, string, error) {
 	client := r.clients[0]
 	unprefixed := image.Image
 	for _, c := range r.clients[1:] {
 		if ok, unpref := c.imageMatches(image.Image); ok {
-			if err := <-c.connect(); err != nil {
-				return nil, "", err
+			c.connect()
+			// don't wait for additional runtimes
+			if c.currentState() != clientStateConnected {
+				if noErrorIfNotConnected {
+					return nil, "", nil
+				}
+				return nil, "", fmt.Errorf("CRI proxy: target runtime is not available")
 			}
 			client = c
 			unprefixed = unpref
@@ -975,3 +1029,9 @@ func (r *RuntimeProxy) clientForImage(image *runtimeapi.ImageSpec) (*apiClient, 
 
 // TODO: for primary client, show [primary] not [] in the logs
 // (add apiClient.Name() or something)
+
+// TODO: tolerate runtime disconnection & enable the 'race' test on travis
+// dbox.go:185] ListPodSandbox failed: rpc error: code = 2 desc = "/run/virtlet.sock": rpc error: code = 14 desc = grpc: the connection is unavailable
+// GenericPLEG: Unable to retrieve pods: rpc error: code = 2 desc = "/run/virtlet.sock": rpc error: code = 14 desc = grpc: the connection is unavailable
+
+// https://github.com/grpc/grpc-go/blob/master/codes/codes.go

--- a/pkg/criproxy/proxy_test.go
+++ b/pkg/criproxy/proxy_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -1135,16 +1134,7 @@ func TestCriProxy(t *testing.T) {
 	}
 }
 
-func inTravis() bool {
-	// https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
-	return os.Getenv("TRAVIS") == "true"
-}
-
 func TestCriProxyInactiveServers(t *testing.T) {
-	if inTravis() {
-		t.Skip("apparently there's still a startup race in CRI proxy, but it only manifests itself on slower machines")
-	}
-
 	tester := newProxyTester(t)
 	defer tester.stop()
 	tester.startServers(t, 0)


### PR DESCRIPTION
- Fix CRI Proxy's handling of runtime disconnection (primary reason for the problems described in #229)
- Document Virtlet removal
- Reenable TestCriProxyInactiveServers (formely TestCriProxyNoStartupRace) on Travis. The issue with this test failing on Travis should be fixed now because of the new gRPC disconnection handling

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/275)
<!-- Reviewable:end -->
