### PR TITLE
Xml refactoring

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,7 +26,11 @@ TESTS = $(check_SCRIPTS)
 .PHONY: all vendor
 
 all:
-	if [ ! -d vendor ]; then $(MAKE) install-vendor; fi
+	if [ ! -d vendor ]; then \
+		$(MAKE) install-vendor; \
+		cp ./vendor/github.com/libvirt/libvirt-go-xml/domain.go ./vendor/github.com/libvirt/libvirt-go-xml/domain.orig; \
+	fi
+	patch ./vendor/github.com/libvirt/libvirt-go-xml/domain.orig -i ./libvirt-xml-go.patch -o ./vendor/github.com/libvirt/libvirt-go-xml/domain.go
 	mkdir -p $(builddir)/_output $(builddir)/contrib/images/libvirt/_output
 	go build -o $(builddir)/_output/virtlet ./cmd/virtlet
 	go build -o $(builddir)/_output/vmwrapper ./cmd/vmwrapper

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 9f5c3fc2a95e67236dfaa31d352b76f9d762d6c5871b61092b863bc83ed10b56
-updated: 2017-05-15T13:36:43.9414608Z
+updated: 2017-05-15T19:39:56.7455294Z
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -165,7 +165,7 @@ imports:
   - protoc-gen-gogo/descriptor
   - sortkeys
 - name: github.com/golang/glog
-  version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
+  version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/groupcache
   version: 02826c3e79038b59d737d3b1c0a1d937f71a4433
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: caa8317655422f51d63f54f4696fd4fa8e0d65ce684e99a12ff4dd54967ab80d
-updated: 2017-04-17T19:16:44.449399415+03:00
+hash: 9f5c3fc2a95e67236dfaa31d352b76f9d762d6c5871b61092b863bc83ed10b56
+updated: 2017-05-15T13:36:43.9414608Z
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -58,7 +58,7 @@ imports:
 - name: github.com/blang/semver
   version: 31b736133b98f26d5e078ec9eb591666edfd091f
 - name: github.com/boltdb/bolt
-  version: dfb21201d9270c1082d5fb0f07f500311ff72f18
+  version: e9cf4fae01b5a8ff89d0ec6b32f0d9c9f79aefdd
 - name: github.com/containernetworking/cni
   version: 9d5e6e60e79491207834ae8439e80c943db65a69
   subpackages:
@@ -165,7 +165,7 @@ imports:
   - protoc-gen-gogo/descriptor
   - sortkeys
 - name: github.com/golang/glog
-  version: 44145f04b68cf362d9c4df2182967c2275eaefed
+  version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
 - name: github.com/golang/groupcache
   version: 02826c3e79038b59d737d3b1c0a1d937f71a4433
   subpackages:
@@ -226,7 +226,9 @@ imports:
 - name: github.com/kr/pty
   version: f7ee69f31298ecbe5d2b349c711e2547a617d398
 - name: github.com/libvirt/libvirt-go
-  version: ea3aa1162f01b9a41d4ab1c183f3a4dc59f57273
+  version: c3209e4ba8b8dda65c85ca0ac04302e55895caf7
+- name: github.com/libvirt/libvirt-go-xml
+  version: e515652baed5eb4eb96b99a6dcc9acfcd4fc300f
 - name: github.com/mailru/easyjson
   version: d5b7844b561a7bc640052f1b935f7b800330d7e0
   subpackages:
@@ -310,7 +312,7 @@ imports:
 - name: github.com/vishvananda/netns
   version: 8ba1072b58e0c2a240eb5f6120165c7776c3e7b8
 - name: go.universe.tf/netboot
-  version: 7e671a0899a237c12a78d95cc849584ff31bd683
+  version: 9253ccdf97149d96019a62122555b37047168c1f
   subpackages:
   - dhcp4
 - name: golang.org/x/exp

--- a/glide.yaml
+++ b/glide.yaml
@@ -21,6 +21,7 @@ import:
   subpackages:
   - difflib
 - package: github.com/libvirt/libvirt-go
+- package: github.com/libvirt/libvirt-go-xml
 - package: k8s.io/kubernetes
   version: v1.6.1
 - package: k8s.io/apiserver

--- a/libvirt-xml-go.patch
+++ b/libvirt-xml-go.patch
@@ -96,7 +96,7 @@
 +}
 +
 +type DomainMemoryBacking struct {
-+	Locked *DomainMemoryBackingLocked `xml:locked`
++	Locked *DomainMemoryBackingLocked `xml:"locked"`
 +}
 +
  type Domain struct {

--- a/libvirt-xml-go.patch
+++ b/libvirt-xml-go.patch
@@ -1,5 +1,5 @@
---- domain_ref.go	2017-05-16 01:08:28.735308800 +0300
-+++ domain.go	2017-05-17 13:49:21.167776600 +0300
+--- domain_ref.go	2017-05-15 22:08:28.735308800 +0000
++++ domain.go	2017-05-17 20:25:02.298415800 +0000
 @@ -184,9 +184,8 @@
  }
  
@@ -28,7 +28,7 @@
  	Controllers []DomainController `xml:"controller"`
  	Disks       []DomainDisk       `xml:"disk"`
  	Filesystems []DomainFilesystem `xml:"filesystem"`
-@@ -431,24 +432,55 @@
+@@ -431,24 +432,67 @@
  	SMM        *DomainFeatureState  `xml:"smm"`
  }
  
@@ -46,10 +46,22 @@
 +	Envs []QemuEnv `xml:"env"`
 +}
 +
++type DomainCPUTuneShares struct {
++	Value uint `xml:",chardata"`
++}
++
++type DomainCPUTunePeriod struct {
++	Value uint64 `xml:",chardata"`
++}
++
++type DomainCPUTuneQuota struct {
++	Value int64 `xml:",chardata"`
++}
++
 +type DomainCPUTune struct {
-+	Shares uint    `xml:"shares,omitempty"`
-+	Period uint64  `xml:"period,omitempty"`
-+	Quota  int64   `xml:"quota,omitempty"`
++	Shares *DomainCPUTuneShares `xml:"shares"`
++	Period *DomainCPUTunePeriod `xml:"period"`
++	Quota  *DomainCPUTuneQuota  `xml:"quota"`
 +}
 +
 +type DomainMemoryBackingLocked struct {
@@ -57,7 +69,7 @@
 +}
 +
 +type DomainMemoryBacking struct {
-+	Locked    *DomainMemoryBackingLocked `xml:locked`
++	Locked *DomainMemoryBackingLocked `xml:locked`
 +}
 +
  type Domain struct {
@@ -78,26 +90,26 @@
 -	OnReboot      string             `xml:"on_reboot,omitempty"`
 -	OnCrash       string             `xml:"on_crash,omitempty"`
 -	Features      *DomainFeatureList `xml:"features"`
-+	XMLName       xml.Name              `xml:"domain"`
-+	Type          string                `xml:"type,attr,omitempty"`
-+	Name          string                `xml:"name"`
-+	UUID          string                `xml:"uuid,omitempty"`
-+	Memory        *DomainMemory         `xml:"memory"`
-+	CurrentMemory *DomainMemory         `xml:"currentMemory"`
-+	MaximumMemory *DomainMaxMemory      `xml:"maxMemory"`
-+	MemoryBacking *DomainMemoryBacking  `xml:"memoryBacking"`
-+	VCPU          *DomainVCPU           `xml:"vcpu"`
-+	CPU           *DomainCPU            `xml:"cpu"`
-+	CPUTune       *DomainCPUTune        `xml:"cputune"`
-+	Resource      *DomainResource       `xml:"resource"`
-+	Devices       *DomainDeviceList     `xml:"devices"`
-+	OS            *DomainOS             `xml:"os"`
-+	SysInfo       *DomainSysInfo        `xml:"sysinfo"`
-+	OnPoweroff    string                `xml:"on_poweroff,omitempty"`
-+	OnReboot      string                `xml:"on_reboot,omitempty"`
-+	OnCrash       string                `xml:"on_crash,omitempty"`
-+	Features      *DomainFeatureList    `xml:"features"`
-+	CMDLine       *DomainCMDLine        `xml:"http://libvirt.org/schemas/domain/qemu/1.0 commandline"`
++	XMLName       xml.Name             `xml:"domain"`
++	Type          string               `xml:"type,attr,omitempty"`
++	Name          string               `xml:"name"`
++	UUID          string               `xml:"uuid,omitempty"`
++	Memory        *DomainMemory        `xml:"memory"`
++	CurrentMemory *DomainMemory        `xml:"currentMemory"`
++	MaximumMemory *DomainMaxMemory     `xml:"maxMemory"`
++	MemoryBacking *DomainMemoryBacking `xml:"memoryBacking"`
++	VCPU          *DomainVCPU          `xml:"vcpu"`
++	CPU           *DomainCPU           `xml:"cpu"`
++	CPUTune       *DomainCPUTune       `xml:"cputune"`
++	Resource      *DomainResource      `xml:"resource"`
++	Devices       *DomainDeviceList    `xml:"devices"`
++	OS            *DomainOS            `xml:"os"`
++	SysInfo       *DomainSysInfo       `xml:"sysinfo"`
++	OnPoweroff    string               `xml:"on_poweroff,omitempty"`
++	OnReboot      string               `xml:"on_reboot,omitempty"`
++	OnCrash       string               `xml:"on_crash,omitempty"`
++	Features      *DomainFeatureList   `xml:"features"`
++	CMDLine       *DomainCMDLine       `xml:"http://libvirt.org/schemas/domain/qemu/1.0 commandline"`
  }
  
  func (d *Domain) Unmarshal(doc string) error {

--- a/libvirt-xml-go.patch
+++ b/libvirt-xml-go.patch
@@ -1,0 +1,59 @@
+--- ./domain_ref.go	2017-05-15 22:08:28.735308800 +0000
++++ ./domain.go	2017-05-15 22:22:50.304352700 +0000
+@@ -184,9 +184,8 @@
+ }
+ 
+ type DomainChardevTarget struct {
+-	Type  string `xml:"type,attr"`
+-	Name  string `xml:"name,attr"`
+-	State string `xml:"state,attr,omitempty"` // is guest agent connected?
++	Type string `xml:"type,attr,omitempty"`
++	Port string `xml:"name,attr,omitempty"`
+ }
+ 
+ type DomainAlias struct {
+@@ -202,6 +201,7 @@
+ 
+ type DomainChardev struct {
+ 	Type    string               `xml:"type,attr"`
++	TTY     string               `xml:"tty,attr,omitempty"`
+ 	Source  *DomainChardevSource `xml:"source"`
+ 	Target  *DomainChardevTarget `xml:"target"`
+ 	Alias   *DomainAlias         `xml:"alias"`
+@@ -251,6 +251,7 @@
+ }
+ 
+ type DomainDeviceList struct {
++	Emulator    string             `xml:"emulator,omitempty"`
+ 	Controllers []DomainController `xml:"controller"`
+ 	Disks       []DomainDisk       `xml:"disk"`
+ 	Filesystems []DomainFilesystem `xml:"filesystem"`
+@@ -431,6 +432,20 @@
+ 	SMM        *DomainFeatureState  `xml:"smm"`
+ }
+ 
++type QemuArg struct {
++	Value string `xml:"value,attr"`
++}
++
++type QemuEnv struct {
++	Name  string `xml:"name,attr"`
++	Value string `xml:"value,attr,omitempty"`
++}
++
++type DomainCMDLine struct {
++	Args []QemuArg `xml:"arg"`
++	Envs []QemuEnv `xml:"env"`
++}
++
+ type Domain struct {
+ 	XMLName       xml.Name           `xml:"domain"`
+ 	Type          string             `xml:"type,attr,omitempty"`
+@@ -449,6 +464,7 @@
+ 	OnReboot      string             `xml:"on_reboot,omitempty"`
+ 	OnCrash       string             `xml:"on_crash,omitempty"`
+ 	Features      *DomainFeatureList `xml:"features"`
++	CMDLine       *DomainCMDLine     `xml:"http://libvirt.org/schemas/domain/qemu/1.0 commandline"`
+ }
+ 
+ func (d *Domain) Unmarshal(doc string) error {

--- a/libvirt-xml-go.patch
+++ b/libvirt-xml-go.patch
@@ -1,6 +1,33 @@
 --- domain_ref.go	2017-05-15 22:08:28.735308800 +0000
-+++ domain.go	2017-05-17 20:25:02.298415800 +0000
-@@ -184,9 +184,8 @@
++++ domain.go	2017-05-18 19:18:59.300460500 +0000
+@@ -73,14 +73,19 @@
+ 	Bus string `xml:"bus,attr,omitempty"`
+ }
+ 
++type DomainDiskReadOnly struct {
++	//empty
++}
++
+ type DomainDisk struct {
+-	Type     string            `xml:"type,attr"`
+-	Device   string            `xml:"device,attr"`
+-	Snapshot string            `xml:"snapshot,attr,omitempty"`
+-	Driver   *DomainDiskDriver `xml:"driver"`
+-	Auth     *DomainDiskAuth   `xml:"auth"`
+-	Source   *DomainDiskSource `xml:"source"`
+-	Target   *DomainDiskTarget `xml:"target"`
++	Type     string              `xml:"type,attr"`
++	Device   string              `xml:"device,attr"`
++	Snapshot string              `xml:"snapshot,attr,omitempty"`
++	Driver   *DomainDiskDriver   `xml:"driver"`
++	Auth     *DomainDiskAuth     `xml:"auth"`
++	Source   *DomainDiskSource   `xml:"source"`
++	Target   *DomainDiskTarget   `xml:"target"`
++	ReadOnly *DomainDiskReadOnly `xml:"readonly"`
+ }
+ 
+ type DomainFilesystemDriver struct {
+@@ -184,9 +189,8 @@
  }
  
  type DomainChardevTarget struct {
@@ -12,7 +39,7 @@
  }
  
  type DomainAlias struct {
-@@ -202,6 +201,7 @@
+@@ -202,6 +206,7 @@
  
  type DomainChardev struct {
  	Type    string               `xml:"type,attr"`
@@ -20,7 +47,7 @@
  	Source  *DomainChardevSource `xml:"source"`
  	Target  *DomainChardevTarget `xml:"target"`
  	Alias   *DomainAlias         `xml:"alias"`
-@@ -251,6 +251,7 @@
+@@ -251,6 +256,7 @@
  }
  
  type DomainDeviceList struct {
@@ -28,7 +55,7 @@
  	Controllers []DomainController `xml:"controller"`
  	Disks       []DomainDisk       `xml:"disk"`
  	Filesystems []DomainFilesystem `xml:"filesystem"`
-@@ -431,24 +432,67 @@
+@@ -431,24 +437,67 @@
  	SMM        *DomainFeatureState  `xml:"smm"`
  }
  

--- a/libvirt-xml-go.patch
+++ b/libvirt-xml-go.patch
@@ -1,5 +1,5 @@
---- ./domain_ref.go	2017-05-15 22:08:28.735308800 +0000
-+++ ./domain.go	2017-05-15 22:22:50.304352700 +0000
+--- domain_ref.go	2017-05-16 01:08:28.735308800 +0300
++++ domain.go	2017-05-17 13:49:21.167776600 +0300
 @@ -184,9 +184,8 @@
  }
  
@@ -28,7 +28,7 @@
  	Controllers []DomainController `xml:"controller"`
  	Disks       []DomainDisk       `xml:"disk"`
  	Filesystems []DomainFilesystem `xml:"filesystem"`
-@@ -431,6 +432,20 @@
+@@ -431,24 +432,55 @@
  	SMM        *DomainFeatureState  `xml:"smm"`
  }
  
@@ -46,14 +46,58 @@
 +	Envs []QemuEnv `xml:"env"`
 +}
 +
++type DomainCPUTune struct {
++	Shares uint    `xml:"shares,omitempty"`
++	Period uint64  `xml:"period,omitempty"`
++	Quota  int64   `xml:"quota,omitempty"`
++}
++
++type DomainMemoryBackingLocked struct {
++	//empty
++}
++
++type DomainMemoryBacking struct {
++	Locked    *DomainMemoryBackingLocked `xml:locked`
++}
++
  type Domain struct {
- 	XMLName       xml.Name           `xml:"domain"`
- 	Type          string             `xml:"type,attr,omitempty"`
-@@ -449,6 +464,7 @@
- 	OnReboot      string             `xml:"on_reboot,omitempty"`
- 	OnCrash       string             `xml:"on_crash,omitempty"`
- 	Features      *DomainFeatureList `xml:"features"`
-+	CMDLine       *DomainCMDLine     `xml:"http://libvirt.org/schemas/domain/qemu/1.0 commandline"`
+-	XMLName       xml.Name           `xml:"domain"`
+-	Type          string             `xml:"type,attr,omitempty"`
+-	Name          string             `xml:"name"`
+-	UUID          string             `xml:"uuid,omitempty"`
+-	Memory        *DomainMemory      `xml:"memory"`
+-	CurrentMemory *DomainMemory      `xml:"currentMemory"`
+-	MaximumMemory *DomainMaxMemory   `xml:"maxMemory"`
+-	VCPU          *DomainVCPU        `xml:"vcpu"`
+-	CPU           *DomainCPU         `xml:"cpu"`
+-	Resource      *DomainResource    `xml:"resource"`
+-	Devices       *DomainDeviceList  `xml:"devices"`
+-	OS            *DomainOS          `xml:"os"`
+-	SysInfo       *DomainSysInfo     `xml:"sysinfo"`
+-	OnPoweroff    string             `xml:"on_poweroff,omitempty"`
+-	OnReboot      string             `xml:"on_reboot,omitempty"`
+-	OnCrash       string             `xml:"on_crash,omitempty"`
+-	Features      *DomainFeatureList `xml:"features"`
++	XMLName       xml.Name              `xml:"domain"`
++	Type          string                `xml:"type,attr,omitempty"`
++	Name          string                `xml:"name"`
++	UUID          string                `xml:"uuid,omitempty"`
++	Memory        *DomainMemory         `xml:"memory"`
++	CurrentMemory *DomainMemory         `xml:"currentMemory"`
++	MaximumMemory *DomainMaxMemory      `xml:"maxMemory"`
++	MemoryBacking *DomainMemoryBacking  `xml:"memoryBacking"`
++	VCPU          *DomainVCPU           `xml:"vcpu"`
++	CPU           *DomainCPU            `xml:"cpu"`
++	CPUTune       *DomainCPUTune        `xml:"cputune"`
++	Resource      *DomainResource       `xml:"resource"`
++	Devices       *DomainDeviceList     `xml:"devices"`
++	OS            *DomainOS             `xml:"os"`
++	SysInfo       *DomainSysInfo        `xml:"sysinfo"`
++	OnPoweroff    string                `xml:"on_poweroff,omitempty"`
++	OnReboot      string                `xml:"on_reboot,omitempty"`
++	OnCrash       string                `xml:"on_crash,omitempty"`
++	Features      *DomainFeatureList    `xml:"features"`
++	CMDLine       *DomainCMDLine        `xml:"http://libvirt.org/schemas/domain/qemu/1.0 commandline"`
  }
  
  func (d *Domain) Unmarshal(doc string) error {

--- a/pkg/diskimage/diskimage.go
+++ b/pkg/diskimage/diskimage.go
@@ -44,7 +44,7 @@ func FormatDisk(path string) error {
 	/* Attach the disk image to libguestfs. */
 	optargs := guestfs.OptargsAdd_drive{
 		Format_is_set:   true,
-		Format:          "raw",
+		Format:          "qcow2",
 		Readonly_is_set: true,
 		Readonly:        false,
 	}

--- a/pkg/flexvolume/ceph.go
+++ b/pkg/flexvolume/ceph.go
@@ -63,7 +63,7 @@ func cephVolumeHandler(uuidGen UuidGen, targetDir string, opts volumeOpts) (map[
 		Ephemeral: "no",
 		Private:   "no",
 		UUID:      uuid,
-		Usage:     &libvirtxml.SecretUsage{Name: opts.User},
+		Usage:     &libvirtxml.SecretUsage{Name: opts.User, Type: "ceph"},
 	}
 	secretXML, err := secret.Marshal()
 	if err != nil {

--- a/pkg/libvirttools/storage_pool.go
+++ b/pkg/libvirttools/storage_pool.go
@@ -187,6 +187,7 @@ func (s *StorageTool) CreateQCOW2Volume(name string, capacity uint64, capacityUn
 		Name:       name,
 		Allocation: &libvirtxml.StorageVolumeSize{Value: 0},
 		Capacity:   &libvirtxml.StorageVolumeSize{Unit: capacityUnit, Value: capacity},
+		Target:     &libvirtxml.StorageVolumeTarget{Format: &libvirtxml.StorageVolumeTargetFormat{Type: "qcow2"}},
 	}
 	volumeXML, err := volume.Marshal()
 	if err != nil {
@@ -286,6 +287,7 @@ func (s *StorageTool) PrepareVolumesToBeAttached(volumes []*VirtletVolume, conta
 				return nil, err
 			}
 			disk.Type = "block"
+			disk.Driver.Type = "raw"
 			disk.Source.Device = virtletVol.Path
 		}
 

--- a/pkg/libvirttools/storage_pool.go
+++ b/pkg/libvirttools/storage_pool.go
@@ -25,16 +25,11 @@ import (
 	"github.com/Mirantis/virtlet/pkg/diskimage"
 	"github.com/golang/glog"
 	libvirt "github.com/libvirt/libvirt-go"
+	libvirtxml "github.com/libvirt/libvirt-go-xml"
 )
 
 const (
-	poolTypeDir     = "dir"
-	diskXMLTemplate = `
-<disk type='file' device='disk'>
-    <driver name='qemu' type='raw'/>
-    <source file='%s'/>
-    <target dev='%s' bus='virtio'/>
-</disk>`
+	poolTypeDir = "dir"
 )
 
 type Volume struct {
@@ -83,19 +78,17 @@ var DefaultPools PoolSet = PoolSet{
 	"volumes": &Pool{volumesDir: "/var/lib/virtlet", poolType: poolTypeDir},
 }
 
-func generatePoolXML(name string, path string, poolType string) string {
-	poolXML := `
-<pool type="%s">
-    <name>%s</name>
-    <target>
-	<path>%s</path>
-    </target>
-</pool>`
-	return fmt.Sprintf(poolXML, poolType, name, path)
-}
-
 func createPool(tool StorageOperations, name string, path string, poolType string) (*Pool, error) {
-	poolXML := generatePoolXML(name, path, poolType)
+	storagePool := libvirtxml.StoragePool{
+		Type:   poolType,
+		Name:   name,
+		Target: &libvirtxml.StoragePoolTarget{Path: path},
+	}
+
+	poolXML, err := storagePool.Marshal()
+	if err != nil {
+		return nil, err
+	}
 
 	glog.V(2).Infof("Creating storage pool (name: %s, path: %s)", name, path)
 	pool, err := tool.CreateFromXML(poolXML)
@@ -189,40 +182,32 @@ func NewStorageTool(conn *libvirt.Connect, poolName, rawDevices string) (*Storag
 	return &StorageTool{name: poolName, tool: tool, pool: pool, rawDevices: strings.Split(rawDevices, ",")}, nil
 }
 
-func (s *StorageTool) GenerateVolumeXML(shortName string, capacity uint64, capacityUnit string, path string) string {
-	volXML := `
-<volume>
-    <name>%s</name>
-    <allocation>0</allocation>
-    <capacity unit="%s">%d</capacity>
-    <target>
-        <path>%s</path>
-    </target>
-</volume>`
-	return fmt.Sprintf(volXML, shortName, capacityUnit, capacity, path)
-}
-
 func (s *StorageTool) CreateQCOW2Volume(name string, capacity uint64, capacityUnit string) (*Volume, error) {
-	volumeXML := `
-<volume>
-    <name>%s</name>
-    <allocation>0</allocation>
-    <capacity unit="%s">%d</capacity>
-</volume>`
-	volumeXML = fmt.Sprintf(volumeXML, name, capacityUnit, capacity)
+	volume := libvirtxml.StorageVolume{
+		Name:       name,
+		Allocation: &libvirtxml.StorageVolumeSize{Value: 0},
+		Capacity:   &libvirtxml.StorageVolumeSize{Unit: capacityUnit, Value: capacity},
+	}
+	volumeXML, err := volume.Marshal()
+	if err != nil {
+		return nil, err
+	}
+
 	glog.V(2).Infof("Create volume using XML description: %s", volumeXML)
 	return s.pool.CreateVolume(name, volumeXML)
 }
 
 func (s *StorageTool) CloneVolume(name string, from *Volume) (*Volume, error) {
-	cloneXMLtemplate := `
-<volume type='file'>
-    <name>%s</name>
-    <target>
-         <format type='qcow2'/>
-    </target>
-</volume>`
-	cloneXML := fmt.Sprintf(cloneXMLtemplate, name)
+	volume := libvirtxml.StorageVolume{
+		Name:   name,
+		Type:   "file",
+		Target: &libvirtxml.StorageVolumeTarget{Format: &libvirtxml.StorageVolumeTargetFormat{Type: "qcow2"}},
+	}
+	cloneXML, err := volume.Marshal()
+	if err != nil {
+		return nil, err
+	}
+
 	glog.V(2).Infof("Creating volume clone with name '%s' from volume '%s'.", name, from.Name)
 	return s.pool.CloneVolume(name, cloneXML, from)
 }
@@ -255,8 +240,8 @@ func (s *StorageTool) CleanAttachedQCOW2Volumes(volumes []*VirtletVolume, contai
 
 // PrepareVolumesToBeAttached returns a list of xml definitions for dom xml of created or raw disks
 // letterInd contains the number of drive letters already used by flexvolumes
-func (s *StorageTool) PrepareVolumesToBeAttached(volumes []*VirtletVolume, containerId string, letterInd int) ([]string, error) {
-	var disksXMLs []string
+func (s *StorageTool) PrepareVolumesToBeAttached(volumes []*VirtletVolume, containerId string, letterInd int) ([]libvirtxml.DomainDisk, error) {
+	var disks []libvirtxml.DomainDisk
 
 	for i, virtletVol := range volumes {
 		if letterInd+i == len(diskLetters) {
@@ -265,7 +250,13 @@ func (s *StorageTool) PrepareVolumesToBeAttached(volumes []*VirtletVolume, conta
 
 		volName := containerId + "-" + virtletVol.Name
 		virtDev := "vd" + diskLetters[letterInd+i]
-		var diskXML string
+		disk := libvirtxml.DomainDisk{
+			Device: "disk",
+			Source: &libvirtxml.DomainDiskSource{},
+			Driver: &libvirtxml.DomainDiskDriver{Name: "qemu"},
+			Target: &libvirtxml.DomainDiskTarget{Dev: virtDev, Bus: "virtio"},
+		}
+
 		switch virtletVol.Format {
 		case "qcow2":
 			vol, err := s.CreateQCOW2Volume(volName, uint64(virtletVol.Capacity), virtletVol.CapacityUnit)
@@ -283,7 +274,9 @@ func (s *StorageTool) PrepareVolumesToBeAttached(volumes []*VirtletVolume, conta
 				return nil, err
 			}
 
-			diskXML = fmt.Sprintf(diskXMLTemplate, path, virtDev)
+			disk.Type = "file"
+			disk.Driver.Type = "qcow2"
+			disk.Source.File = path
 
 		case "rawDevice":
 			if err := s.isRawDeviceOnWhitelist(virtletVol.Path); err != nil {
@@ -292,13 +285,14 @@ func (s *StorageTool) PrepareVolumesToBeAttached(volumes []*VirtletVolume, conta
 			if err := verifyRawDeviceAccess(virtletVol.Path); err != nil {
 				return nil, err
 			}
-			diskXML = generateRawDeviceXML(virtletVol.Path, virtDev)
+			disk.Type = "block"
+			disk.Source.Device = virtletVol.Path
 		}
 
-		disksXMLs = append(disksXMLs, diskXML)
+		disks = append(disks, disk)
 	}
 
-	return disksXMLs, nil
+	return disks, nil
 }
 
 func (s *StorageTool) isRawDeviceOnWhitelist(path string) error {
@@ -331,26 +325,23 @@ func verifyRawDeviceAccess(path string) error {
 	return fmt.Errorf("path '%s' points to something other than block device", path)
 }
 
-const (
-	rawDeviceTemplateXML = `<disk type='block' device='disk'>
-  <driver name='qemu' type='raw'/>
-  <source dev='%s'/>
-  <target dev='%s' bus='virtio'/>
-</disk>
-`
-)
-
-func generateRawDeviceXML(path, device string) string {
-	return fmt.Sprintf(rawDeviceTemplateXML, path, device)
-}
-
 func (s *StorageTool) PullFileToVolume(path, volumeName string) error {
 	imageSize, err := getFileSize(path)
 	if err != nil {
 		return err
 	}
 	libvirtFilePath := fmt.Sprintf("/var/lib/libvirt/images/%s", volumeName)
-	volXML := s.GenerateVolumeXML(volumeName, imageSize, "B", libvirtFilePath)
+
+	volume := libvirtxml.StorageVolume{
+		Name:       volumeName,
+		Allocation: &libvirtxml.StorageVolumeSize{Value: 0},
+		Capacity:   &libvirtxml.StorageVolumeSize{Unit: "B", Value: imageSize},
+		Target:     &libvirtxml.StorageVolumeTarget{Path: libvirtFilePath},
+	}
+	volXML, err := volume.Marshal()
+	if err != nil {
+		return err
+	}
 
 	return s.tool.PullImageToVolume(s.pool.pool, volumeName, path, volXML)
 }

--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -95,12 +95,6 @@ func (ds *VirtletDomainSettings) createDomain() *libvirtxml.Domain {
 		emulator = noKvmEmulator
 	}
 
-	var buf bytes.Buffer
-	if err := xml.EscapeText(&buf, []byte(ds.cniConfig)); err != nil {
-		glog.Errorf("EscapeText() failed: %v", err)
-	}
-	cniConfigEscaped := buf.String()
-
 	domain := &libvirtxml.Domain{
 
 		Devices: &libvirtxml.DomainDeviceList{
@@ -147,7 +141,7 @@ func (ds *VirtletDomainSettings) createDomain() *libvirtxml.Domain {
 			Envs: []libvirtxml.QemuEnv{
 				libvirtxml.QemuEnv{Name: "VIRTLET_EMULATOR", Value: emulator},
 				libvirtxml.QemuEnv{Name: "VIRTLET_NS", Value: ds.netNSPath},
-				libvirtxml.QemuEnv{Name: "VIRTLET_CNI_CONFIG", Value: cniConfigEscaped},
+				libvirtxml.QemuEnv{Name: "VIRTLET_CNI_CONFIG", Value: ds.cniConfig},
 			},
 		},
 	}

--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -64,6 +64,21 @@ type FlexVolumeInfo struct {
 	Key       string
 }
 
+type VirtletDomainSettings struct {
+	useKvm           bool
+	domainName       string
+	domainUUID       string
+	memory           int
+	memoryUnit       string
+	vcpuNum          int
+	cpuShares        uint
+	cpuPeriod        uint64
+	cpuQuota         int64
+	rootDiskFilepath string
+	netNSPath        string
+	cniConfig        string
+}
+
 func canUseKvm() bool {
 	if os.Getenv("VIRTLET_DISABLE_KVM") != "" {
 		glog.V(0).Infof("VIRTLET_DISABLE_KVM env var not empty, using plain qemu")
@@ -72,69 +87,68 @@ func canUseKvm() bool {
 	return true
 }
 
-func generateDomXML(useKvm bool, name string, memory int64, memoryUnit string, uuid string, cpuNum int, cpuShare int64, cpuPeriod int64, cpuQuota int64, rootDiskFilepath, netNSPath, cniConfig string) string {
+func getDomain() *libvirtxml.Domain {
+	var dom libvirtxml.Domain
+
+	dom.Devices = &libvirtxml.DomainDeviceList{Emulator: "/vmwrapper"}
+	dom.Devices.Inputs = []libvirtxml.DomainInput{libvirtxml.DomainInput{Type: "tablet", Bus: "usb"}}
+	dom.Devices.Graphics = []libvirtxml.DomainGraphic{libvirtxml.DomainGraphic{Type: "vnc", Port: -1}}
+	dom.Devices.Serials = []libvirtxml.DomainChardev{libvirtxml.DomainChardev{Type: "pty", Target: &libvirtxml.DomainChardevTarget{Port: "0"}}}
+	dom.Devices.Consoles = []libvirtxml.DomainChardev{libvirtxml.DomainChardev{Type: "pty", Target: &libvirtxml.DomainChardevTarget{Type: "serial", Port: "0"}}}
+	dom.Devices.Videos = []libvirtxml.DomainVideo{libvirtxml.DomainVideo{Model: libvirtxml.DomainVideoModel{Type: "cirrus"}}}
+
+	dom.OS = &libvirtxml.DomainOS{
+		Type:        &libvirtxml.DomainOSType{Type: "hvm"},
+		BootDevices: []libvirtxml.DomainBootDevice{libvirtxml.DomainBootDevice{Dev: "hd"}},
+	}
+
+	dom.Features = &libvirtxml.DomainFeatureList{ACPI: &libvirtxml.DomainFeature{}}
+
+	dom.OnPoweroff = "destroy"
+	dom.OnReboot = "restart"
+	dom.OnCrash = "restart"
+
+	return &dom
+}
+
+func (ds *VirtletDomainSettings) createDomain() *libvirtxml.Domain {
+	dom := getDomain()
+	dom.Name = ds.domainUUID + "-" + ds.domainName
+	dom.UUID = ds.domainUUID
+	dom.Memory = &libvirtxml.DomainMemory{Value: ds.memory, Unit: ds.memoryUnit}
+	dom.VCPU = &libvirtxml.DomainVCPU{Value: ds.vcpuNum}
+	dom.CPUTune = &libvirtxml.DomainCPUTune{Shares: ds.cpuShares, Period: ds.cpuPeriod, Quota: ds.cpuQuota}
+	dom.MemoryBacking = &libvirtxml.DomainMemoryBacking{Locked: &libvirtxml.DomainMemoryBackingLocked{}}
+
+	dom.Devices.Disks = []libvirtxml.DomainDisk{libvirtxml.DomainDisk{
+		Type:   "file",
+		Device: "disk",
+		Driver: &libvirtxml.DomainDiskDriver{Name: "qemu", Type: "qcow2"},
+		Source: &libvirtxml.DomainDiskSource{File: ds.rootDiskFilepath},
+		Target: &libvirtxml.DomainDiskTarget{Dev: "vda", Bus: "virtio"},
+	}}
+
 	domainType := defaultDomainType
 	emulator := defaultEmulator
-	if !useKvm {
+	if !ds.useKvm {
 		domainType = noKvmDomainType
 		emulator = noKvmEmulator
 	}
+	dom.Type = domainType
+
 	var buf bytes.Buffer
-	if err := xml.EscapeText(&buf, []byte(cniConfig)); err != nil {
+	if err := xml.EscapeText(&buf, []byte(ds.cniConfig)); err != nil {
 		glog.Errorf("EscapeText() failed: %v", err)
 	}
 	cniConfigEscaped := buf.String()
-	domXML := `
-<domain type='%s'>
-    <name>%s-%s</name>
-    <uuid>%s</uuid>
-    <memory unit='%s'>%d</memory>
-    <memoryBacking>
-      <locked/>
-    </memoryBacking>
-    <vcpu>%d</vcpu>
-    <cputune>
-        <shares>%d</shares>
-        <period>%d</period>
-        <quota>%d</quota>
-    </cputune>
-    <os>
-        <type>hvm</type>
-        <boot dev='hd'/>
-    </os>
-    <features>
-        <acpi/><apic/>
-    </features>
-    <on_poweroff>destroy</on_poweroff>
-    <on_reboot>restart</on_reboot>
-    <on_crash>restart</on_crash>
-    <devices>
-        <emulator>/vmwrapper</emulator>
-        <disk type='file' device='disk'>
-            <driver name='qemu' type='qcow2'/>
-            <source file='%s'/>
-            <target dev='vda' bus='virtio'/>
-        </disk>
-        <input type='tablet' bus='usb'/>
-        <graphics type='vnc' port='-1'/>
-        <serial type='pty'>
-            <target port='0'/>
-        </serial>
-        <console type='pty'>
-            <target type='serial' port='0'/>
-        </console>
-        <sound model='ac97'/>
-        <video>
-            <model type='cirrus'/>
-        </video>
-    </devices>
-    <commandline xmlns='http://libvirt.org/schemas/domain/qemu/1.0'>
-      <env name='VIRTLET_EMULATOR' value='%s'/>
-      <env name='VIRTLET_NS' value='%s'/>
-      <env name='VIRTLET_CNI_CONFIG' value='%s'/>
-    </commandline>
-</domain>`
-	return fmt.Sprintf(domXML, domainType, uuid, name, uuid, memoryUnit, memory, cpuNum, cpuShare, cpuPeriod, cpuQuota, rootDiskFilepath, emulator, netNSPath, cniConfigEscaped)
+
+	dom.CMDLine = &libvirtxml.DomainCMDLine{Envs: []libvirtxml.QemuEnv{
+		libvirtxml.QemuEnv{Name: "VIRTLET_EMULATOR", Value: emulator},
+		libvirtxml.QemuEnv{Name: "VIRTLET_NS", Value: ds.netNSPath},
+		libvirtxml.QemuEnv{Name: "VIRTLET_CNI_CONFIG", Value: cniConfigEscaped},
+	}}
+
+	return dom
 }
 
 func (v *VirtualizationTool) createBootImageClone(cloneName, imageName string) (string, error) {
@@ -245,20 +259,14 @@ func marshalToXML(domain *libvirtxml.Domain) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return string(outArr[:]), nil
+	domXML := strings.Replace(string(outArr[:]), "\"", "'", -1)
+	return domXML, nil
 }
 
-func (v *VirtualizationTool) addAttachedVolumesXML(podID, podName, uuid, domXML string, volumes []*VirtletVolume) (string, error) {
-	glog.V(3).Infof("INPUT domain:\n%s\n\n", domXML)
-	domain := &libvirtxml.Domain{}
-	err := xml.Unmarshal([]byte(domXML), domain)
-	if err != nil {
-		return "", err
-	}
-
+func (v *VirtualizationTool) addVolumesToDomain(podID, podName string, domain *libvirtxml.Domain, volumes []*VirtletVolume) error {
 	flexVolumeInfos, err := gatherFlexvolumeDriverVolumeDefinitions(podID, podName, 0)
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	glog.V(2).Infof("FlexVolumes set to process: %v", flexVolumeInfos)
@@ -266,31 +274,31 @@ func (v *VirtualizationTool) addAttachedVolumesXML(podID, podName, uuid, domXML 
 		if flexVolumeInfo.SecretXML != "" {
 			secret, err := v.tool.DefineSecretFromXML(flexVolumeInfo.SecretXML)
 			if err != nil {
-				return "", err
+				return err
 			}
 			key, err := base64.StdEncoding.DecodeString(flexVolumeInfo.Key)
 			if err != nil {
-				return "", err
+				return err
 			}
 			secret.SetValue(key, 0)
 		}
 		if err = addDiskToDomainDefinition(domain, flexVolumeInfo.DiskXML); err != nil {
-			return "", err
+			return err
 		}
 	}
 
-	volumesXML, err := v.volumeStorage.PrepareVolumesToBeAttached(volumes, uuid, len(flexVolumeInfos))
+	volumesXML, err := v.volumeStorage.PrepareVolumesToBeAttached(volumes, domain.UUID, len(flexVolumeInfos))
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	for _, volXML := range volumesXML {
 		if err = addDiskToDomainDefinition(domain, volXML); err != nil {
-			return "", err
+			return err
 		}
 	}
 
-	return marshalToXML(domain)
+	return nil
 }
 
 type VirtualizationTool struct {
@@ -316,7 +324,11 @@ func NewVirtualizationTool(conn *libvirt.Connect, volumesPoolName string, images
 }
 
 func (v *VirtualizationTool) CreateContainer(in *kubeapi.CreateContainerRequest, imageName string, netNSPath, cniConfig string) (string, error) {
-	uuid, err := utils.NewUuid()
+	var err error
+	var domSettings VirtletDomainSettings
+	domSettings.netNSPath = netNSPath
+	domSettings.cniConfig = cniConfig
+	domSettings.domainUUID, err = utils.NewUuid()
 	if err != nil {
 		return "", err
 	}
@@ -326,17 +338,17 @@ func (v *VirtualizationTool) CreateContainer(in *kubeapi.CreateContainerRequest,
 	}
 
 	config := in.Config
-	name := config.Metadata.Name
+	domSettings.domainName = config.Metadata.Name
 	sandboxAnnotations, err := v.metadataStore.GetPodSandboxAnnotations(in.PodSandboxId)
 	if err != nil {
 		return "", err
 	}
 
-	if name == "" {
-		name = uuid
+	if domSettings.domainName == "" {
+		domSettings.domainName = domSettings.domainUUID
 	} else {
 		// check whether the domain with such name already exists, if so - return it's uuid
-		domainName := in.PodSandboxId + "-" + name
+		domainName := in.PodSandboxId + "-" + domSettings.domainName
 		domain, _ := v.tool.LookupByName(domainName)
 		if domain != nil {
 			if domainID, err := v.tool.GetUUIDString(domain); err == nil {
@@ -349,25 +361,24 @@ func (v *VirtualizationTool) CreateContainer(in *kubeapi.CreateContainerRequest,
 		}
 	}
 
-	cloneName := "root_" + uuid
-	cloneImage, err := v.createBootImageClone(cloneName, imageName)
+	cloneName := "root_" + domSettings.domainUUID
+	domSettings.rootDiskFilepath, err = v.createBootImageClone(cloneName, imageName)
 	if err != nil {
 		return "", err
 	}
 
-	v.metadataStore.SetContainer(name, uuid, in.PodSandboxId, config.Image.Image, cloneName, config.Labels, config.Annotations)
+	v.metadataStore.SetContainer(domSettings.domainName, domSettings.domainUUID, in.PodSandboxId, config.Image.Image, cloneName, config.Labels, config.Annotations)
 
-	var memory, cpuShares, cpuPeriod, cpuQuota int64
 	if config.Linux != nil && config.Linux.Resources != nil {
-		memory = config.Linux.Resources.MemoryLimitInBytes
-		cpuShares = config.Linux.Resources.CpuShares
-		cpuPeriod = config.Linux.Resources.CpuPeriod
-		cpuQuota = config.Linux.Resources.CpuQuota
+		domSettings.memory = int(config.Linux.Resources.MemoryLimitInBytes)
+		domSettings.cpuShares = uint(config.Linux.Resources.CpuShares)
+		domSettings.cpuPeriod = uint64(config.Linux.Resources.CpuPeriod)
+		domSettings.cpuQuota = config.Linux.Resources.CpuQuota
 	}
-	memoryUnit := "b"
-	if memory == 0 {
-		memory = defaultMemory
-		memoryUnit = defaultMemoryUnit
+	domSettings.memoryUnit = "b"
+	if domSettings.memory == 0 {
+		domSettings.memory = defaultMemory
+		domSettings.memoryUnit = defaultMemoryUnit
 	}
 
 	annotations, err := LoadAnnotations(sandboxAnnotations)
@@ -375,19 +386,24 @@ func (v *VirtualizationTool) CreateContainer(in *kubeapi.CreateContainerRequest,
 		return "", err
 	}
 
-	domXML := generateDomXML(canUseKvm(), name, memory, memoryUnit, uuid, annotations.VCPUCount, cpuShares, cpuPeriod, cpuQuota, cloneImage, netNSPath, cniConfig)
-	domXML, err = v.addAttachedVolumesXML(in.PodSandboxId, in.SandboxConfig.Metadata.Name, uuid, domXML, annotations.Volumes)
+	domSettings.useKvm = canUseKvm()
+	dom := domSettings.createDomain()
+
+	if err = v.addVolumesToDomain(in.PodSandboxId, in.SandboxConfig.Metadata.Name, dom, annotations.Volumes); err != nil {
+		return "", err
+	}
+
+	domXML, err := marshalToXML(dom)
 	if err != nil {
 		return "", err
 	}
 
-	domXML = strings.Replace(domXML, "\"", "'", -1)
 	glog.V(2).Infof("Creating domain:\n%s", domXML)
 	if _, err := v.tool.DefineFromXML(domXML); err != nil {
 		return "", err
 	}
 
-	domain, err := v.tool.LookupByUUIDString(uuid)
+	domain, err := v.tool.LookupByUUIDString(domSettings.domainUUID)
 	if err != nil {
 		return "", err
 	}
@@ -396,7 +412,7 @@ func (v *VirtualizationTool) CreateContainer(in *kubeapi.CreateContainerRequest,
 		return "", err
 	}
 
-	return uuid, nil
+	return domSettings.domainName, nil
 }
 
 func (v *VirtualizationTool) StartContainer(containerId string) error {

--- a/tests/e2e/e2e.sh
+++ b/tests/e2e/e2e.sh
@@ -78,7 +78,7 @@ fi
 # wait for login prompt to appear
 "${SCRIPT_DIR}/vmchat-short.exp" @cirros-vm-rbd
 
-"${vmssh}" cirros@cirros-vm-rbd 'sudo /usr/sbin/mkfs.ext2 /dev/vdb && sudo mount /dev/vdb /mnt && ls -l /mnt | grep lost+found'
+"${vmssh}" cirros@cirros-vm-rbd 'sudo /usr/sbin/mkfs.ext2 /dev/vdc && sudo mount /dev/vdc /mnt && ls -l /mnt | grep lost+found'
 
 # check vnc consoles are available for both domains
 if ! kubectl exec "${virtlet_pod_name}" --namespace=kube-system -- /bin/sh -c "apt-get install -y vncsnapshot"; then


### PR DESCRIPTION
- [x] moved to libvirt-go-xml package usage and get rid of internally defined domain structures
- [x] fixed bugs found in generated domain's xml definition during testing and added ability to specify cmdline env vars. Currently done by applying patch, it will be removed later after changes will be merged to upstream repo.
- [x] get rid of raw strings usage during forming domain's definition

Fixes #132 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/279)
<!-- Reviewable:end -->
