### PR TITLE
Better CNI handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The demo will start a test cluster, deploy Virtlet on it and then boot a [CirrOS
 examples/vmssh.sh cirros@cirros-vm [command...]
 ```
 
-By default, CNI bridge plugin is used for cluster networking. Another option is using [flannel](https://github.com/coreos/flannel). To do so, run demo script like this:
+By default, CNI bridge plugin is used for cluster networking. It's also possible to override this with `flannel` or `weave` plugin, e.g.:
 ```
 CNI_PLUGIN=flannel ./demo.sh
 ```

--- a/pkg/bolttools/sandbox.go
+++ b/pkg/bolttools/sandbox.go
@@ -578,3 +578,14 @@ func (b *BoltClient) GetPodNetworkConfigurationAsBytes(podId string) ([]byte, er
 	})
 	return config, err
 }
+
+func (b *BoltClient) GetPodSandboxNameAndNamespace(podId string) (string, string, error) {
+	podSandbox, _, err := b.getPodSandbox([]byte(podId), nil)
+	if err != nil {
+		return "", "", err
+	}
+	if podSandbox.Metadata == nil {
+		return "", "", fmt.Errorf("storage: malformed pod metadata detected for pod %q", podId)
+	}
+	return podSandbox.Metadata.Name, podSandbox.Metadata.Namespace, nil
+}

--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -51,6 +51,7 @@ type SandboxMetadataStore interface {
 	GetPodSandboxStatus(podId string) (*kubeapi.PodSandboxStatus, error)
 	ListPodSandbox(filter *kubeapi.PodSandboxFilter) ([]*kubeapi.PodSandbox, error)
 	GetPodNetworkConfigurationAsBytes(podId string) ([]byte, error)
+	GetPodSandboxNameAndNamespace(podId string) (string, string, error)
 }
 
 // ContainerMetadataStore contains methods to operate on containers (VMs)

--- a/pkg/nettools/nettools.go
+++ b/pkg/nettools/nettools.go
@@ -376,7 +376,10 @@ func SetupContainerSideNetwork(info *types.Result) (*ContainerSideNetwork, error
 	if err != nil {
 		return nil, err
 	}
-	if info == nil {
+	// If there are no routes provided, we consider it a broken
+	// config and extract interface config instead. That's the
+	// case with Weave CNI plugin.
+	if info == nil || info.IP4 == nil || len(info.IP4.Routes) == 0 {
 		info, err = ExtractLinkInfo(contVeth)
 		if err != nil {
 			return nil, err

--- a/pkg/nettools/nettools.go
+++ b/pkg/nettools/nettools.go
@@ -334,6 +334,33 @@ func updateEbTables(interfaceName, command string) error {
 	return nil
 }
 
+func setHardwareAddr(link netlink.Link, hwaddr net.HardwareAddr) error {
+	if err := netlink.LinkSetDown(link); err != nil {
+		return fmt.Errorf("can't bring down the link: %v", err)
+	}
+	if err := netlink.LinkSetHardwareAddr(link, hwaddr); err != nil {
+		return fmt.Errorf("can't set hardware address for the link: %v", err)
+	}
+	if err := netlink.LinkSetUp(link); err != nil {
+		return fmt.Errorf("can't bring up the link: %v", err)
+	}
+
+	return nil
+}
+
+// ContainerSideNetwork struct describes the container (VM) network
+// namespace properties
+type ContainerSideNetwork struct {
+	// Result contains CNI result object describing the network settings
+	Result *types.Result
+	// TapFile contains an open File object pointing to Tap device inside
+	// the network namespace
+	TapFile *os.File
+	// HardwareAddr stores the original hardware address of the
+	// CNI veth interface
+	HardwareAddr net.HardwareAddr
+}
+
 // SetupContainerSideNetwork sets up networking in container
 // namespace.  It does so by calling ExtractLinkInfo() first unless
 // non-nil info argument is provided and then preparing the following
@@ -343,20 +370,29 @@ func updateEbTables(interfaceName, command string) error {
 // The bridge (br0) gets assigned a link-local address to be used
 // for dhcp server.
 // The function should be called from within container namespace.
-// Returns container network info (CNI Result) and error, if any
-func SetupContainerSideNetwork(info *types.Result) (*types.Result, *os.File, error) {
+// Returns container network struct and an error, if any
+func SetupContainerSideNetwork(info *types.Result) (*ContainerSideNetwork, error) {
 	contVeth, err := FindVeth()
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	if info == nil {
 		info, err = ExtractLinkInfo(contVeth)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 	}
-	if err := StripLink(contVeth); err != nil {
-		return nil, nil, err
+
+	hwAddr := contVeth.Attrs().HardwareAddr
+	newHwAddr, err := GenerateMacAddress()
+	if err == nil {
+		err = setHardwareAddr(contVeth, newHwAddr)
+	}
+	if err == nil {
+		err = StripLink(contVeth)
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	tap := &netlink.Tuntap{
@@ -368,37 +404,37 @@ func SetupContainerSideNetwork(info *types.Result) (*types.Result, *os.File, err
 		Mode: netlink.TUNTAP_MODE_TAP,
 	}
 	if err := netlink.LinkAdd(tap); err != nil {
-		return nil, nil, fmt.Errorf("failed to create tap interface: %v", err)
+		return nil, fmt.Errorf("failed to create tap interface: %v", err)
 	}
 
 	if err := netlink.LinkSetUp(tap); err != nil {
-		return nil, nil, fmt.Errorf("failed to set %q up: %v", tapInterfaceName, err)
+		return nil, fmt.Errorf("failed to set %q up: %v", tapInterfaceName, err)
 	}
 
 	br, err := SetupBridge(containerBridgeName, []netlink.Link{contVeth, tap})
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create bridge: %v", err)
+		return nil, fmt.Errorf("failed to create bridge: %v", err)
 	}
 
 	if err := netlink.AddrAdd(br, mustParseAddr(internalDhcpAddr)); err != nil {
-		return nil, nil, fmt.Errorf("failed to set address for the bridge: %v", err)
+		return nil, fmt.Errorf("failed to set address for the bridge: %v", err)
 	}
 
 	// Add ebtables DHCP blocking rules
 	if err := updateEbTables(contVeth.Attrs().Name, "-A"); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	if err := bringUpLoopback(); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	tapFile, err := OpenTAP(tapInterfaceName)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to open tap: %v", err)
+		return nil, fmt.Errorf("failed to open tap: %v", err)
 	}
 
-	return info, tapFile, nil
+	return &ContainerSideNetwork{info, tapFile, hwAddr}, nil
 }
 
 // TeardownBridge removes links from bridge and sets it down
@@ -433,12 +469,12 @@ func ConfigureLink(link netlink.Link, info *types.Result) error {
 	return nil
 }
 
-// TeardownContainerSideNetwork cleans up container network configuration.
+// Teardown cleans up container network configuration.
 // It does so by invoking teardown sequence which removes ebtables rules, links
 // and addresses in an order opposite to that of their creation in SetupContainerSideNetwork.
 // The end result is the same network configuration in the container network namespace
 // as it was before SetupContainerSideNetwork() call.
-func TeardownContainerSideNetwork(info *types.Result) error {
+func (csn *ContainerSideNetwork) Teardown() error {
 	contVeth, err := FindVeth()
 	if err != nil {
 		return err
@@ -479,7 +515,11 @@ func TeardownContainerSideNetwork(info *types.Result) error {
 		return err
 	}
 
-	return ConfigureLink(contVeth, info)
+	if err := setHardwareAddr(contVeth, csn.HardwareAddr); err != nil {
+		return err
+	}
+
+	return ConfigureLink(contVeth, csn.Result)
 }
 
 // copied from:

--- a/tests/network/vm_network_test.go
+++ b/tests/network/vm_network_test.go
@@ -102,7 +102,7 @@ func TestVmNetwork(t *testing.T) {
 	}
 
 	if contNS.Do(func(ns.NetNS) error {
-		_, _, err = nettools.SetupContainerSideNetwork(info)
+		_, err = nettools.SetupContainerSideNetwork(info)
 		if err != nil {
 			return fmt.Errorf("failed to set up container side network: %v", err)
 		}


### PR DESCRIPTION
- Mimic the kubelet behavior in passing extra CNI args
- Move hwaddr from CNI veth to the VM
- Ignore CNI-provided json config if it has no routes (i.e. no default gw) and extract it from netns instead. This makes Virtlet support Weave.

Fixes #284

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/291)
<!-- Reviewable:end -->
