### PR TITLE
Mention OSv unikernel project in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ At this stage (pre-alpha), it's possible to run Virtlet by following the instruc
 
 You can join
 [#virtlet](https://kubernetes.slack.com/messages/virtlet/) channel on
-[Kubernetes Slack](https://kubernetes.slack.com/messages). Both the
+[Kubernetes Slack](https://kubernetes.slack.com/messages)
+(register at [slack.k8s.io](http://slack.k8s.io) if you're not in k8s group already). Both the
 users and developers are welcome!
 
 ## Getting started with Virtlet
@@ -48,6 +49,15 @@ The demo script will check for KVM support on the host and will make Virtlet use
 The demo is based on [kubeadm-dind-cluster](https://github.com/Mirantis/kubeadm-dind-cluster) project. **Docker btrfs storage driver is currently unsupported.** Please refer to `kubeadm-dind-cluster` documentation for more info.
 
 You can remove the test cluster with `./dind-cluster-v1.6.sh clean` when you no longer need it.
+
+## External projects using Virtlet
+Even if Virtlet is in pre-alpha stage at this point, we have some external projects using it already.
+One interesting usecase is that of [MIKELANGELO project](https://www.mikelangelo-project.eu/) that
+runs [OSv unikernels](http://osv.io) on Kubernetes using Virtlet. Unikernels are special case of VMs
+that are extremely small in size (20MB or so) and can only run a single process each. Nevertheless,
+Virtlet has no problems handling them on Kubernetes as demonstrated in this
+[video](https://www.youtube.com/watch?v=L-QrxDJSZBA). Microservice Demo is available
+[here](https://github.com/mikelangelo-project/osv-microservice-demo#deploying-unikernels-on-kubernetes).
 
 ## Need any help with Virtlet?
 


### PR DESCRIPTION
Since unikernel experiment with Virtlet is a success, we dare to mention it in Virtlet's README (also suggested by @pigmej on Slack channel).

While having README open, we add a link to register page for k8s Slack as well, since we had quite some problem getting in the channel.

/cc @gberginc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/296)
<!-- Reviewable:end -->
