### PR TITLE
Demo.sh script now uses ssh instead virsh console

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ chmod +x demo.sh
 ./demo.sh
 ```
 
-The demo will start a test cluster, deploy Virtlet on it and then boot a [CirrOS](https://launchpad.net/cirros) VM there. You may access sample nginx server via `curl http://nginx.default.svc.cluster.local` from inside the VM. To detach from VM console, press `Ctrl-]`. After the VM has booted, you can also use a helper script to connect to its SSH server:
+The demo will start a test cluster, deploy Virtlet on it and then boot a [CirrOS](https://launchpad.net/cirros) VM there. You may access sample nginx server via `curl http://nginx.default.svc.cluster.local` from inside the VM. To disconnect from VM, press `Ctrl-D`. After the VM has booted, you can also use a helper script to connect to its SSH server:
 ```
 examples/vmssh.sh cirros@cirros-vm [command...]
 ```

--- a/deploy/demo.sh
+++ b/deploy/demo.sh
@@ -14,6 +14,7 @@ BASE_LOCATION="${BASE_LOCATION:-https://raw.githubusercontent.com/Mirantis/virtl
 # Convenience setting for local testing:
 # BASE_LOCATION="${HOME}/work/kubernetes/src/github.com/Mirantis/virtlet"
 DEPLOY_LOG_CONTAINER=${DEPLOY_LOG_CONTAINER:-deploy} # '' = don't deploy, 'deploy' = deploy, 'inject' = inject local log image and deploy
+cirros_key="demo-cirros-private-key"
 
 function demo::step {
   local OPTS=""
@@ -47,10 +48,19 @@ function demo::get-dind-cluster {
   chmod +x "${dind_script}"
 }
 
+function demo::get-cirros-ssh-keys {
+  if [[ -f ${cirros_key} ]]; then
+    return 0
+  fi
+  demo::step "Will download ${cirros_key} into current directory"
+  wget -O ${cirros_key} "https://raw.githubusercontent.com/Mirantis/virtlet/master/examples/vmkey"
+  chmod 600 ${cirros_key}
+}
+
 function demo::start-dind-cluster {
   demo::step "Will now clear any kubeadm-dind-cluster data on the current Docker"
   if [[ ! ${NONINTERACTIVE} ]]; then
-    echo "VM console will be attached after Virtlet setup is complete, press Ctrl-] to detach." >&2
+    echo "Cirros ssh connection will be open after Virtlet setup is complete, press Ctrl-D to disconnect." >&2
   fi
   echo "To clean up the cluster, use './dind-cluster-v1.6.sh clean'" >&2
   demo::ask-before-continuing
@@ -115,6 +125,48 @@ function demo::virsh {
   "${kubectl}" exec ${opts} -n kube-system "${virtlet_pod}" -c virtlet -- virsh "$@"
 }
 
+function demo::ssh {
+  local cirros_ip=
+
+  demo::get-cirros-ssh-keys
+
+  if [[ ! ${virtlet_pod} ]]; then
+    virtlet_pod=$("${kubectl}" get pods -n kube-system -l runtime=virtlet -o name|head -1|sed 's@.*/@@')
+  fi
+
+  if [[ ! ${cirros_ip} ]]; then
+    while true; do
+      cirros_ip=$(kubectl get pod cirros-vm -o jsonpath="{.status.podIP}")
+      if [[ ! ${cirros_ip} ]]; then
+        echo "Waiting for cirros IP..."
+        sleep 1
+        continue
+      fi
+      echo "Cirros IP is ${cirros_ip}."
+      break
+    done
+  fi
+
+  echo "Trying to establish ssh connection to cirros-vm..."
+  while ! internal::ssh ${virtlet_pod} ${cirros_ip} "echo Hello" | grep -q "Hello"; do
+    sleep 1
+    echo "Trying to establish ssh connection to cirros-vm..."
+  done
+
+  echo "Successfully established ssh connection. Press Ctrl-D to disconnect."
+  internal::ssh ${virtlet_pod} ${cirros_ip}
+}
+
+function internal::ssh {
+  virtlet_pod=${1}
+  cirros_ip=${2}
+  shift 2
+
+  ssh -oProxyCommand="kubectl exec -i -n kube-system ${virtlet_pod} -c virtlet -- nc -q0 ${cirros_ip} 22" \
+    -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -q \
+    -i ${cirros_key} cirros@cirros-vm "$@"
+}
+
 function demo::vm-ready {
   local name="$1"
   # note that the following is not a bulletproof check
@@ -162,8 +214,8 @@ function demo::start-vm {
   "${kubectl}" create -f "${BASE_LOCATION}/examples/cirros-vm.yaml"
   demo::wait-for "CirrOS VM" demo::vm-ready cirros-vm
   if [[ ! "${NO_VM_CONSOLE:-}" ]]; then
-    demo::step "Entering the VM, press Enter if you don't see the prompt or OS boot messages"
-    demo::virsh console $(demo::virsh list --name)
+    demo::step "Establishing ssh connection to the VM. Use Ctrl-D to disconnect"
+    demo::ssh
   fi
 }
 
@@ -172,8 +224,8 @@ if [[ ${1:-} = "--help" || ${1:-} = "-h" ]]; then
 Usage: ./demo.sh
 
 This script runs a simple demo of Virtlet[1] using kubeadm-dind-cluster[2]
-VM console will be attached after Virtlet setup is complete, Ctrl-]
-can be used to detach from it.
+ssh connection will be established after Virtlet setup is complete, Ctrl-D
+can be used to disconnect from it.
 Use 'curl http://nginx.default.svc.cluster.local' from VM console to test
 cluster networking.
 


### PR DESCRIPTION
Since we have disabled virsh console in favor of VM logging, demo.sh script was unable to connect to the cirros VM at the very end of the deployment process. Therefore we update script so that it connects to the VM with `ssh` instead of `virsh console`.

There are two workarounds used in this patch:

1. password authentication is used
2. infinite while loop is used

The former is required since we need demo.sh script to be self-contained so we are unable to ship it with ssh keys. The latter is required since ssh server in cirros is started with some delay after cirros is already running. 

*The easiest way to wait for ssh server to start was to simply retry in while loop until it blocks. This brings some minor issue that once user cancels ssh connection with `CTRL + D`, script attempts to ssh again. But IMO this is not an issue, since user can simply hit `CTRL + C` if she doesn't want to connect again and the script will finally exit.*

Fixes https://github.com/Mirantis/virtlet/issues/304

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/315)
<!-- Reviewable:end -->
