### PR TITLE
Support mounting virtlet flexvolumes using volumeMounts

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,9 +28,10 @@ TESTS = $(check_SCRIPTS)
 all:
 	if [ ! -d vendor ]; then \
 		$(MAKE) install-vendor; \
-		cp ./vendor/github.com/libvirt/libvirt-go-xml/domain.go ./vendor/github.com/libvirt/libvirt-go-xml/domain.orig; \
 	fi
-	patch ./vendor/github.com/libvirt/libvirt-go-xml/domain.orig -i ./libvirt-xml-go.patch -o ./vendor/github.com/libvirt/libvirt-go-xml/domain.go
+	if [ ! -f ./vendor/github.com/libvirt/libvirt-go-xml/domain.go.orig ]; then \
+		patch -d vendor/github.com/libvirt/libvirt-go-xml -p1 -b -i $(CURDIR)/libvirt-xml-go.patch; \
+	fi
 	mkdir -p $(builddir)/_output $(builddir)/contrib/images/libvirt/_output
 	go build -o $(builddir)/_output/virtlet ./cmd/virtlet
 	go build -o $(builddir)/_output/vmwrapper ./cmd/vmwrapper

--- a/cmd/flexvolume_driver/flexvolume_driver.go
+++ b/cmd/flexvolume_driver/flexvolume_driver.go
@@ -20,9 +20,10 @@ import (
 	"os"
 
 	"github.com/Mirantis/virtlet/pkg/flexvolume"
+	"github.com/Mirantis/virtlet/pkg/utils"
 )
 
 func main() {
-	driver := flexvolume.NewFlexVolumeDriver(flexvolume.NewLinuxMounter())
+	driver := flexvolume.NewFlexVolumeDriver(utils.NewUuid, flexvolume.NewLinuxMounter())
 	os.Stdout.WriteString(driver.Run(os.Args[1:]))
 }

--- a/docs/volumes.md
+++ b/docs/volumes.md
@@ -78,6 +78,12 @@ well enough yet.
    devices `/dev/sdb`, `/dev/sdc` and so on (`/dev/vdb`, `/dev/vdc`
    and so on in case of `virtio-blk`). As said above there is no fixed
    behavior for device names and their order on the PCI bus.
+4. As with the majority of other guest OS functionality, Virtlet
+   doesn't give any guarantee about the possibility of mounting
+   flexvolumes into the VM. This depends on the cloud-init
+   functionality supported by the image used. Also note that Virtlet
+   doesn't perform any checks on the guest OS side to ensure that
+   volume mounting succeeded.
 
 ## Flexvolume driver
 

--- a/docs/volumes.md
+++ b/docs/volumes.md
@@ -1,12 +1,42 @@
 # Volume Handling
 
+Virtlet volumes can use either `virtio-blk` or `virtio-scsi` storage
+backends for the volumes. `virtio-scsi` is the default, but it can be
+overridden using `VirtletDiskDriver` annotation, which can have one of
+two values: `virtio` meaning `virtio-blk` and `scsi` meaning
+`virtio-scsi` (the default). Below is an example of switching a pod
+to `virtio-blk` driver:
+
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cirros-vm
+  annotations:
+    kubernetes.io/target-runtime: virtlet
+    VirtletDiskDriver: virtio
+```
+
+The values of the `VirtletDiskDriver` annotation correspond to values
+of `bus` attribute of libvirt disk target specification.
+
+The selected mechanism is used for the rootfs, nocloud cloud-init
+CD-ROM and all the flexvolume types that Virtlet supports.
+
 ## Caveats and Limitations
 
-1. Virtlet uses virtio block device driver.
-1. The overal allowed number of volumes can be attached to single VM is up to 20 regardless of ephemeral, persistent and/or raw devices.
-1. Virtlet sets name for disks in a form ```vd + <disk-letter>```, where disk letter for disk is set in alphabet order from 'b' to 'u' (20 in overall) while forms domain's xml definition. The first one - 'vda' - is used for boot image.
+1. The overall allowed number of volumes that can be attached to a
+   single VM (including implicit volumes for the boot disk and nocloud
+   cloud-init CD-ROM) is 20 in case of `virtio-blk` and 26 in case of
+   `virtio-scsi` driver. The limits can be exteneded in future.
+1. When generating libvirt domain definition, Virtlet constructs disk
+   names as ```sd + <disk-char>``` in case of `virtio-scsi` and as
+   ```vd + <disk-char>``` in case of `virtio-blk`, where `disk-char`
+   is a lowercase latin letter starting with 'a'. The first block
+   device, `sda` or `vda`, is used for the boot disk.
 
-```
+```xml
 <domain type='qemu' id='2' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
   <name>de0ae972-4154-4f8f-70ff-48335987b5ce-cirros-vm-rbd</name>
 ....
@@ -15,17 +45,17 @@
     <emulator>/vmwrapper</emulator>
     <disk type='file' device='disk'>
       ...
-      <target dev='vda' bus='virtio'/>
+      <target dev='sda' bus='scsi/'>
       ...
     </disk>
     <disk type='file' device='disk'>
       ...
-      <target dev='vdb' bus='virtio'/>
+      <target dev='sdb' bus='scsi'/>
       ...
     </disk>
     <disk type='network' device='disk'>
       ...
-      <target dev='vdc' bus='virtio'/>
+      <target dev='sdc' bus='scsi'/>
       ...
     </disk>
 
@@ -35,19 +65,27 @@
 ...
 </domain>
 ```
-Despite of this you must not expect correspondence between the name of device within OS and the one which was set in domain definition, as this part is up to the guest OS.
 
-From [Libvirt spec](http://libvirt.org/formatdomain.html#elementsDisks):
+Virtlet tries to do its best so as to make the disk names specified in
+the domain definition to match the devices inside VM in case of Linux
+system.  This will be the case with most Linux images when using
+`virtio-scsi` driver, but in case of `virtio-blk` it depends on
+whether the device naming/numbering in the VM follows the numbering of
+PCI slots used for `virtio-blk` devices. We didn't study this part
+well enough yet.
 
-> **target**
-> The target element controls the bus / device under which the disk is exposed to the guest OS. The dev attribute indicates the "logical" device name. The actual device name specified is not guaranteed to map to the device name in the guest OS. Treat it as a device ordering hint
-
-4. Attached disks are visible by the OS inside VM as hard disk devices `/dev/vdb`, `/dev/vdc` and so on. As said above there is no fixed behaviour for device names and their order on the PCI bus.
+3. The attached disks are visible by the OS inside VM as hard disk
+   devices `/dev/sdb`, `/dev/sdc` and so on (`/dev/vdb`, `/dev/vdc`
+   and so on in case of `virtio-blk`). As said above there is no fixed
+   behavior for device names and their order on the PCI bus.
 
 ## Flexvolume driver
 
-Virtlet uses custom [FlexVolume](https://github.com/kubernetes/community/blob/master/contributors/devel/flexvolume.md) driver (`virtlet/flexvolume_driver`) to specify block devices for the VMs.
-Flexvolume options must include `type` field with one of the following values:
+Virtlet uses custom
+[FlexVolume](https://github.com/kubernetes/community/blob/master/contributors/devel/flexvolume.md)
+driver (`virtlet/flexvolume_driver`) to specify block devices for the
+VMs. Flexvolume options must include `type` field with one of the
+following values:
 * `qcow2` - ephemeral volume
 * `raw` - raw device
 * `ceph` - Ceph RBD
@@ -105,11 +143,19 @@ spec:
         type: qcow2
 ```
 
-According to this definition will be created VM-POD with VM with 2 equal volumes, attached, which can be found in "volumes" pool under `<domain-uuid>-vol1` and `<domain-uuid>-vol2`
-A clone of boot image is exposed as **vda** device to the guest OS.
-On a typical linux system the additional volume disks are assigned to /dev/vdX devices in an alphabetical order, so vol1 will be /dev/vdb and vol2 will be /dev/vdc, but please refer to caveat #3 at the beginning of this document.
+According to this definition will be created VM-POD with VM with 2
+equal volumes, attached, which can be found in "volumes" pool under
+`<domain-uuid>-vol1` and `<domain-uuid>-vol2`. A clone of boot image is
+exposed as `sda` device to the guest OS.
+On a typical Linux system the additional volume disks are assigned to
+`/dev/sdX` (`/dev/vdX` in case of `virtio-blk`) devices in an
+alphabetical order, so vol1 will be `/dev/sdb` (`/dev/vdb`) and vol2
+will be `/dev/sdc` (`/dev/vdc`), but please refer to the caveat #3 at
+the beginning of this document.
 
-When a pod is removed, all the volumes related to it are removed too. This includes the root disk (a clone of the boot image) and any additional volumes.
+When a pod is removed, all the volumes related to it are removed
+too. This includes the root disk (a clone of the boot image) and any
+additional volumes.
 
 ## Persistent Storage
 
@@ -130,11 +176,11 @@ As of now, there's no need to mount volumes into the container, it's enough to d
 - pool: <pool-name>
 ```
 
-## Flexvolume driver implemetation details
+## Flexvolume driver implementation details
 1. It's expected that the driver's binary resides at `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/virtlet~flexvolume_driver/flexvolume_driver` before kubelet is started. Note that if you're using DaemonSet for virtlet deployment, you don't need to bother about that because in that case it's done automatically.
 1. Kubelet calls the virtlet flexvolume driver and passes volume info to it
-1. Virtlet flexvolume driver uses standard kubelet's dir `/var/lib/kubelet/pods/<pod-id>/volumes/virtlet~flexvolume_driver/<volume-name>` to store a json file with flexvolume configuration.
-4. Virtlet checks whether there are dirs with volume info under `/var/lib/kubelet/pods/<pod-id>/volumes/virtlet~flexvolume_driver`. If yes, virtlet parses the json configuration file and updates the domain definition accordingly.
+1. Virtlet flexvolume driver uses standard kubelet dir `/var/lib/kubelet/pods/<pod-id>/volumes/virtlet~flexvolume_driver/<volume-name>` to store a JSON file with flexvolume configuration.
+4. Virtlet checks whether there are dirs with volume info under `/var/lib/kubelet/pods/<pod-id>/volumes/virtlet~flexvolume_driver`. If yes, virtlet parses the JSON configuration file and updates the domain definition accordingly.
 
 #### Example of VM-pod definition with a ceph volume:
 ```yaml
@@ -176,8 +222,8 @@ spec:
 # virsh domblklist 2
 Target     Source
 ------------------------------------------------
-vda        /var/lib/virtlet/root_de0ae972-4154-4f8f-70ff-48335987b5ce
-vdb        libvirt-pool/rbd-test-image
+sda        /var/lib/virtlet/root_de0ae972-4154-4f8f-70ff-48335987b5ce
+sdb        libvirt-pool/rbd-test-image
 ```
 
 ### Raw devices
@@ -216,18 +262,19 @@ spec:
         path: /dev/loop0
 ```
 
-As always, the boot image is exposed to the guest OS under **vda** device.
+As always, the boot disk is exposed to the guest OS as `sda` device.
 This pod definition exposes a single raw device to the VM (/dev/loop0).
-As devices/volumes are exposed in the alphabet order starting from `b`, `vol1` will be visible on typical linux VM as `vdb`, but please reffer to third caveats of listed at the top of this document.
+As devices/volumes are exposed in the alphabet order starting from `b`, `vol1` will be visible on typical Linux VM as `sdb`, but please refer to the caveat #3 at the beginning of this document.
 
 #### Raw device whitelist
 
-Virtlet allows to expose to VM only whitelisted raw devices. This list is controlled by `-raw-devices` parameter for `virtlet` binary. It's value is passed to `virtlet` daemonset using `VIRTLET_RAW_DEVICES` environment variable.
-This `-raw-devices` parameter should contain comma separated patterns of paths relative to `/dev` directory, which are used to [glob](https://en.wikipedia.org/wiki/Glob_(programming)) paths of devices, allowed to use by virtual machines.
+Virtlet only allows exposing to VM only those raw devices that are whitelisted. This list is controlled by `-raw-devices` parameter for `virtlet` binary. Its value is passed to `virtlet` daemonset using `VIRTLET_RAW_DEVICES` environment variable.
+This `-raw-devices` parameter should contain comma separated patterns of paths relative to `/dev` directory, which are [globbed](https://en.wikipedia.org/wiki/Glob_(programming)) to get the list of paths of raw devices that can be used by virtual machines.
 When not set, it defaults to `loop*`.
 
-The easiest method of passing this parameter to `virtlet` is to use [configmap](https://kubernetes.io/docs/tasks/configure-pod-container/configmap) to contain a key/value pair (e.x. `devices.raw=loop*,mapper/vm_pool-*`), which then can be used in `deploy/virtlet_ds.yaml` after setting:
+One way to pass this parameter to `virtlet` is to use [configmap](https://kubernetes.io/docs/tasks/configure-pod-container/configmap) to contain a key/value pair (e.x. `devices.raw=loop*,mapper/vm_pool-*`), which then can be used by modifying `deploy/virtlet-ds.yaml` in the following manner:
 ```yaml
+...
 spec:
   ...
   containers:
@@ -240,4 +287,51 @@ spec:
           configMapKeyRef:
             name: name-of-configmap-for-this-node
             key: devices.raw
+```
+
+### Mounting the volumes into the VMs
+
+In case if the guest OS supports proper `#cloud-config` format of
+cloud-init userdata which includes supporting `mounts` module,
+it's possible to mount the flexvolumes into the VM using usual
+pod `volumeMounts` notation:
+
+```yaml
+...
+spec:
+...
+  containers:
+  - name: ubuntu-vm
+    image: virtlet/cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
+    volumeMounts:
+    - name: docker
+      mountPath: /var/lib/docker
+  volumes:
+  - name: docker
+    flexVolume:
+      driver: "virtlet/flexvolume_driver"
+      options:
+        type: qcow2
+        capacity: 2048MB
+```
+
+The example above adds an ephemeral volume to the VM and mounts it
+under `/var/lib/docker` in the guest OS filesystem.
+
+When mounting a device, Virtlet defaults to mounting its 1st
+partition. This can be changed by specifying `part` option in the
+flexvolume definition, which may make sense in case of e.g. raw
+devices. `part` value of `0` denotes mounting the device itself and
+not looking for partitions on it, and `part` values above 0 denote the
+corresponding partition numbers. Below is an example:
+
+```yaml
+  volumes:
+  - name: raw
+    flexVolume:
+      driver: "virtlet/flexvolume_driver"
+      options:
+        type: raw
+        path: /dev/sdc
+        part: 2
 ```

--- a/examples/cirros-vm-rbd-volume.yaml.tmpl
+++ b/examples/cirros-vm-rbd-volume.yaml.tmpl
@@ -4,6 +4,8 @@ metadata:
   name: cirros-vm-rbd
   annotations:
     kubernetes.io/target-runtime: virtlet
+    # CirrOS doesn't load nocloud data from SCSI CD-ROM for some reason
+    VirtletDiskDriver: virtio
     VirtletSSHKeys: |
       ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaJEcFDXEK2ZbX0ZLS1EIYFZRbDAcRfuVjpstSc0De8+sV1aiu+dePxdkuDRwqFtCyk6dEZkssjOkBXtri00MECLkir6FcH3kKOJtbJ6vy3uaJc9w1ERo+wyl6SkAh/+JTJkp7QRXj8oylW5E20LsbnA/dIwWzAF51PPwF7A7FtNg9DnwPqMkxFo1Th/buOMKbP5ZA1mmNNtmzbMpMfJATvVyiv3ccsSJKOiyQr6UG+j7sc/7jMVz5Xk34Vd0l8GwcB0334MchHckmqDB142h/NCWTr8oLakDNvkfC1YneAfAO41hDkUbxPtVBG5M/o7P4fxoqiHEX+ZLfRxDtHB53 me@localhost
 spec:

--- a/examples/cirros-vm.yaml
+++ b/examples/cirros-vm.yaml
@@ -10,6 +10,8 @@ metadata:
     # thus numeric values need to be quoted.
     # Defaults to "1".
     VirtletVCPUCount: "1"
+    # CirrOS doesn't load nocloud data from SCSI CD-ROM for some reason
+    VirtletDiskDriver: virtio
     # inject ssh keys via cloud-init
     VirtletSSHKeys: |
       ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaJEcFDXEK2ZbX0ZLS1EIYFZRbDAcRfuVjpstSc0De8+sV1aiu+dePxdkuDRwqFtCyk6dEZkssjOkBXtri00MECLkir6FcH3kKOJtbJ6vy3uaJc9w1ERo+wyl6SkAh/+JTJkp7QRXj8oylW5E20LsbnA/dIwWzAF51PPwF7A7FtNg9DnwPqMkxFo1Th/buOMKbP5ZA1mmNNtmzbMpMfJATvVyiv3ccsSJKOiyQr6UG+j7sc/7jMVz5Xk34Vd0l8GwcB0334MchHckmqDB142h/NCWTr8oLakDNvkfC1YneAfAO41hDkUbxPtVBG5M/o7P4fxoqiHEX+ZLfRxDtHB53 me@localhost

--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -27,8 +27,6 @@ spec:
       annotations:
         kubernetes.io/target-runtime: virtlet
         VirtletCloudInitUserData: |
-          mounts:
-          - [ /dev/vdc1, /var/lib/docker ]
           write_files:
           - path: /etc/systemd/system/docker.service.d/env.conf
             permissions: "0644"
@@ -103,6 +101,9 @@ spec:
           tcpSocket:
             port: 22
           initialDelaySeconds: 5
+        volumeMounts:
+        - name: docker
+          mountPath: /var/lib/docker
       volumes:
       - name: docker
         flexVolume:

--- a/examples/ubuntu-vm.yaml
+++ b/examples/ubuntu-vm.yaml
@@ -21,3 +21,13 @@ spec:
   containers:
   - name: ubuntu-vm
     image: virtlet/cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
+    volumeMounts:
+    - name: docker
+      mountPath: /var/lib/docker
+  volumes:
+  - name: docker
+    flexVolume:
+      driver: "virtlet/flexvolume_driver"
+      options:
+        type: qcow2
+        capacity: 2048MB

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 9f5c3fc2a95e67236dfaa31d352b76f9d762d6c5871b61092b863bc83ed10b56
-updated: 2017-05-15T19:39:56.7455294Z
+hash: c3e8bb2d74e1ee4ba62edccda9945b80238226e5236c91456a23a945446a080c
+updated: 2017-06-10T18:28:53.78884615+03:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -235,7 +235,7 @@ imports:
 - name: github.com/libvirt/libvirt-go
   version: c3209e4ba8b8dda65c85ca0ac04302e55895caf7
 - name: github.com/libvirt/libvirt-go-xml
-  version: e515652baed5eb4eb96b99a6dcc9acfcd4fc300f
+  version: cc4025ea01eee7c73a7c75b4211b07125a8119ae
 - name: github.com/mailru/easyjson
   version: d5b7844b561a7bc640052f1b935f7b800330d7e0
   subpackages:
@@ -371,7 +371,7 @@ imports:
   - peer
   - transport
 - name: gopkg.in/fsnotify.v1
-  version: 629574ca2a5df945712d3079857300b5e4da0236
+  version: 96c060f6a6b7e0d6f75fddd10efeaca3e5d1bcb0
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/tomb.v1

--- a/glide.yaml
+++ b/glide.yaml
@@ -21,7 +21,9 @@ import:
   subpackages:
   - difflib
 - package: github.com/libvirt/libvirt-go
+  version: c3209e4ba8b8dda65c85ca0ac04302e55895caf7
 - package: github.com/libvirt/libvirt-go-xml
+  version: cc4025ea01eee7c73a7c75b4211b07125a8119ae
 - package: k8s.io/kubernetes
   version: v1.6.1
 - package: k8s.io/apiserver

--- a/libvirt-xml-go.patch
+++ b/libvirt-xml-go.patch
@@ -1,61 +1,8 @@
---- domain_ref.go	2017-05-15 22:08:28.735308800 +0000
-+++ domain.go	2017-05-18 19:18:59.300460500 +0000
-@@ -73,14 +73,19 @@
- 	Bus string `xml:"bus,attr,omitempty"`
- }
- 
-+type DomainDiskReadOnly struct {
-+	//empty
-+}
-+
- type DomainDisk struct {
--	Type     string            `xml:"type,attr"`
--	Device   string            `xml:"device,attr"`
--	Snapshot string            `xml:"snapshot,attr,omitempty"`
--	Driver   *DomainDiskDriver `xml:"driver"`
--	Auth     *DomainDiskAuth   `xml:"auth"`
--	Source   *DomainDiskSource `xml:"source"`
--	Target   *DomainDiskTarget `xml:"target"`
-+	Type     string              `xml:"type,attr"`
-+	Device   string              `xml:"device,attr"`
-+	Snapshot string              `xml:"snapshot,attr,omitempty"`
-+	Driver   *DomainDiskDriver   `xml:"driver"`
-+	Auth     *DomainDiskAuth     `xml:"auth"`
-+	Source   *DomainDiskSource   `xml:"source"`
-+	Target   *DomainDiskTarget   `xml:"target"`
-+	ReadOnly *DomainDiskReadOnly `xml:"readonly"`
- }
- 
- type DomainFilesystemDriver struct {
-@@ -184,9 +189,8 @@
- }
- 
- type DomainChardevTarget struct {
--	Type  string `xml:"type,attr"`
--	Name  string `xml:"name,attr"`
--	State string `xml:"state,attr,omitempty"` // is guest agent connected?
-+	Type string `xml:"type,attr,omitempty"`
-+	Port string `xml:"name,attr,omitempty"`
- }
- 
- type DomainAlias struct {
-@@ -202,6 +206,7 @@
- 
- type DomainChardev struct {
- 	Type    string               `xml:"type,attr"`
-+	TTY     string               `xml:"tty,attr,omitempty"`
- 	Source  *DomainChardevSource `xml:"source"`
- 	Target  *DomainChardevTarget `xml:"target"`
- 	Alias   *DomainAlias         `xml:"alias"`
-@@ -251,6 +256,7 @@
- }
- 
- type DomainDeviceList struct {
-+	Emulator    string             `xml:"emulator,omitempty"`
- 	Controllers []DomainController `xml:"controller"`
- 	Disks       []DomainDisk       `xml:"disk"`
- 	Filesystems []DomainFilesystem `xml:"filesystem"`
-@@ -431,24 +437,67 @@
+diff --git a/domain.go b/domain.go
+index eb7ff9e..46cd806 100644
+--- a/domain.go
++++ b/domain.go
+@@ -522,27 +522,70 @@ type DomainFeatureList struct {
  	SMM        *DomainFeatureState  `xml:"smm"`
  }
  
@@ -99,6 +46,9 @@
 +	Locked *DomainMemoryBackingLocked `xml:"locked"`
 +}
 +
+ // NB, try to keep the order of fields in this struct
+ // matching the order of XML elements that libvirt
+ // will generate when dumping XML.
  type Domain struct {
 -	XMLName       xml.Name           `xml:"domain"`
 -	Type          string             `xml:"type,attr,omitempty"`
@@ -108,15 +58,15 @@
 -	CurrentMemory *DomainMemory      `xml:"currentMemory"`
 -	MaximumMemory *DomainMaxMemory   `xml:"maxMemory"`
 -	VCPU          *DomainVCPU        `xml:"vcpu"`
--	CPU           *DomainCPU         `xml:"cpu"`
 -	Resource      *DomainResource    `xml:"resource"`
--	Devices       *DomainDeviceList  `xml:"devices"`
--	OS            *DomainOS          `xml:"os"`
 -	SysInfo       *DomainSysInfo     `xml:"sysinfo"`
+-	OS            *DomainOS          `xml:"os"`
+-	Features      *DomainFeatureList `xml:"features"`
+-	CPU           *DomainCPU         `xml:"cpu"`
 -	OnPoweroff    string             `xml:"on_poweroff,omitempty"`
 -	OnReboot      string             `xml:"on_reboot,omitempty"`
 -	OnCrash       string             `xml:"on_crash,omitempty"`
--	Features      *DomainFeatureList `xml:"features"`
+-	Devices       *DomainDeviceList  `xml:"devices"`
 +	XMLName       xml.Name             `xml:"domain"`
 +	Type          string               `xml:"type,attr,omitempty"`
 +	Name          string               `xml:"name"`
@@ -126,16 +76,16 @@
 +	MaximumMemory *DomainMaxMemory     `xml:"maxMemory"`
 +	MemoryBacking *DomainMemoryBacking `xml:"memoryBacking"`
 +	VCPU          *DomainVCPU          `xml:"vcpu"`
-+	CPU           *DomainCPU           `xml:"cpu"`
 +	CPUTune       *DomainCPUTune       `xml:"cputune"`
 +	Resource      *DomainResource      `xml:"resource"`
-+	Devices       *DomainDeviceList    `xml:"devices"`
-+	OS            *DomainOS            `xml:"os"`
 +	SysInfo       *DomainSysInfo       `xml:"sysinfo"`
++	OS            *DomainOS            `xml:"os"`
++	Features      *DomainFeatureList   `xml:"features"`
++	CPU           *DomainCPU           `xml:"cpu"`
 +	OnPoweroff    string               `xml:"on_poweroff,omitempty"`
 +	OnReboot      string               `xml:"on_reboot,omitempty"`
 +	OnCrash       string               `xml:"on_crash,omitempty"`
-+	Features      *DomainFeatureList   `xml:"features"`
++	Devices       *DomainDeviceList    `xml:"devices"`
 +	CMDLine       *DomainCMDLine       `xml:"http://libvirt.org/schemas/domain/qemu/1.0 commandline"`
  }
  

--- a/pkg/flexvolume/flexvolume_test.go
+++ b/pkg/flexvolume/flexvolume_test.go
@@ -31,6 +31,10 @@ import (
 	testutils "github.com/Mirantis/virtlet/pkg/utils/testing"
 )
 
+const (
+	fakeUuid = "abb67e3c-71b3-4ddd-5505-8c4215d5c4eb"
+)
+
 type fakeMounter struct {
 	t       *testing.T
 	tmpDir  string
@@ -115,6 +119,12 @@ func TestFlexVolume(t *testing.T) {
 		"secret":  "foobar",
 		"user":    "libvirt",
 	}
+	cephJsonVolumeInfo := map[string]interface{}{
+		"uuid": fakeUuid,
+	}
+	for k, v := range cephJsonOpts {
+		cephJsonVolumeInfo[k] = v
+	}
 	cephDir := path.Join(tmpDir, "ceph")
 	for _, step := range []struct {
 		name         string
@@ -170,9 +180,9 @@ func TestFlexVolume(t *testing.T) {
 			status: "Success",
 			subdir: "ceph",
 			files: map[string]interface{}{
-				"virtlet-flexvolume.json": utils.MapToJsonUnindented(cephJsonOpts),
+				"virtlet-flexvolume.json": utils.MapToJsonUnindented(cephJsonVolumeInfo),
 				".shadowed": map[string]interface{}{
-					"virtlet-flexvolume.json": utils.MapToJsonUnindented(cephJsonOpts),
+					"virtlet-flexvolume.json": utils.MapToJsonUnindented(cephJsonVolumeInfo),
 				},
 			},
 			mountJournal: []string{
@@ -194,9 +204,9 @@ func TestFlexVolume(t *testing.T) {
 			status: "Success",
 			subdir: "ceph",
 			files: map[string]interface{}{
-				"virtlet-flexvolume.json": utils.MapToJsonUnindented(cephJsonOpts),
+				"virtlet-flexvolume.json": utils.MapToJsonUnindented(cephJsonVolumeInfo),
 				".shadowed": map[string]interface{}{
-					"virtlet-flexvolume.json": utils.MapToJsonUnindented(cephJsonOpts),
+					"virtlet-flexvolume.json": utils.MapToJsonUnindented(cephJsonVolumeInfo),
 				},
 			},
 			mountJournal: []string{
@@ -247,7 +257,9 @@ func TestFlexVolume(t *testing.T) {
 			var subdir string
 			args := step.args
 			mounter := newFakeMounter(t, tmpDir)
-			d := NewFlexVolumeDriver(mounter)
+			d := NewFlexVolumeDriver(func() string {
+				return fakeUuid
+			}, mounter)
 			result := d.Run(args)
 			var m map[string]interface{}
 			if err := json.Unmarshal([]byte(result), &m); err != nil {

--- a/pkg/libvirttools/TestContainerLifecycle.json
+++ b/pkg/libvirttools/TestContainerLifecycle.json
@@ -142,7 +142,6 @@
         "Current": "",
         "Value": 1
       },
-      "CPU": null,
       "CPUTune": {
         "Shares": {
           "Value": 0
@@ -155,17 +154,77 @@
         }
       },
       "Resource": null,
+      "SysInfo": null,
+      "OS": {
+        "Type": {
+          "Arch": "",
+          "Machine": "",
+          "Type": "hvm"
+        },
+        "Loader": null,
+        "NVRam": null,
+        "Kernel": "",
+        "Initrd": "",
+        "KernelArgs": "",
+        "BootDevices": [
+          {
+            "Dev": "hd"
+          }
+        ],
+        "BootMenu": null,
+        "SMBios": null,
+        "BIOS": null,
+        "Init": "",
+        "InitArgs": null
+      },
+      "Features": {
+        "PAE": null,
+        "ACPI": {},
+        "APIC": null,
+        "HAP": null,
+        "Viridian": null,
+        "PrivNet": null,
+        "HyperV": null,
+        "KVM": null,
+        "PVSpinlock": null,
+        "PMU": null,
+        "VMPort": null,
+        "GIC": null,
+        "SMM": null
+      },
+      "CPU": null,
+      "OnPoweroff": "destroy",
+      "OnReboot": "restart",
+      "OnCrash": "restart",
       "Devices": {
         "Emulator": "/vmwrapper",
-        "Controllers": null,
+        "Controllers": [
+          {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
+            "Type": "scsi",
+            "Index": 0,
+            "Model": "virtio-scsi",
+            "Address": null
+          }
+        ],
         "Disks": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "file",
             "Device": "disk",
             "Snapshot": "",
             "Driver": {
               "Name": "qemu",
-              "Type": "qcow2"
+              "Type": "qcow2",
+              "Cache": "",
+              "IO": "",
+              "ErrorPolicy": ""
             },
             "Auth": null,
             "Source": {
@@ -179,18 +238,39 @@
               "StartupPolicy": ""
             },
             "Target": {
-              "Dev": "vda",
-              "Bus": "virtio"
+              "Dev": "sda",
+              "Bus": "scsi"
             },
-            "ReadOnly": null
+            "Serial": "",
+            "ReadOnly": null,
+            "Shareable": null,
+            "Address": {
+              "Type": "drive",
+              "Controller": 0,
+              "Domain": null,
+              "Bus": 0,
+              "Port": null,
+              "Slot": null,
+              "Function": null,
+              "Target": 0,
+              "Unit": 0
+            },
+            "Boot": null
           },
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "file",
-            "Device": "disk",
+            "Device": "cdrom",
             "Snapshot": "",
             "Driver": {
               "Name": "qemu",
-              "Type": "raw"
+              "Type": "raw",
+              "Cache": "",
+              "IO": "",
+              "ErrorPolicy": ""
             },
             "Auth": null,
             "Source": {
@@ -204,22 +284,39 @@
               "StartupPolicy": ""
             },
             "Target": {
-              "Dev": "vdb",
-              "Bus": "virtio"
+              "Dev": "sdb",
+              "Bus": "scsi"
             },
-            "ReadOnly": {}
+            "Serial": "",
+            "ReadOnly": {},
+            "Shareable": null,
+            "Address": {
+              "Type": "drive",
+              "Controller": 0,
+              "Domain": null,
+              "Bus": 0,
+              "Port": null,
+              "Slot": null,
+              "Function": null,
+              "Target": 0,
+              "Unit": 1
+            },
+            "Boot": null
           }
         ],
         "Filesystems": null,
         "Interfaces": null,
         "Serials": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "pty",
-            "TTY": "",
             "Source": null,
             "Target": {
               "Type": "",
-              "Port": "0"
+              "Port": 0
             },
             "Alias": null,
             "Address": null
@@ -227,12 +324,15 @@
         ],
         "Consoles": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "pty",
-            "TTY": "",
             "Source": null,
             "Target": {
               "Type": "serial",
-              "Port": "0"
+              "Port": 0
             },
             "Alias": null,
             "Address": null
@@ -240,8 +340,13 @@
         ],
         "Inputs": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "tablet",
-            "Bus": "usb"
+            "Bus": "usb",
+            "Address": null
           }
         ],
         "Graphics": [
@@ -269,53 +374,23 @@
         ],
         "Videos": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Model": {
-              "Type": "cirrus"
-            }
+              "Type": "cirrus",
+              "Heads": 0,
+              "Ram": 0,
+              "VRam": 0,
+              "VGAMem": 0
+            },
+            "Address": null
           }
         ],
-        "Channels": null
-      },
-      "OS": {
-        "Type": {
-          "Arch": "",
-          "Machine": "",
-          "Type": "hvm"
-        },
-        "Loader": null,
-        "NVRam": null,
-        "Kernel": "",
-        "Initrd": "",
-        "KernelArgs": "",
-        "BootDevices": [
-          {
-            "Dev": "hd"
-          }
-        ],
-        "BootMenu": null,
-        "SMBios": null,
-        "BIOS": null,
-        "Init": "",
-        "InitArgs": null
-      },
-      "SysInfo": null,
-      "OnPoweroff": "destroy",
-      "OnReboot": "restart",
-      "OnCrash": "restart",
-      "Features": {
-        "PAE": null,
-        "ACPI": {},
-        "APIC": null,
-        "HAP": null,
-        "Viridian": null,
-        "PrivNet": null,
-        "HyperV": null,
-        "KVM": null,
-        "PVSpinlock": null,
-        "PMU": null,
-        "VMPort": null,
-        "GIC": null,
-        "SMM": null
+        "Channels": null,
+        "MemBalloon": null,
+        "Sounds": null
       },
       "CMDLine": {
         "Args": null,

--- a/pkg/libvirttools/TestDomainDefinitions__ceph_flexvolume.json
+++ b/pkg/libvirttools/TestDomainDefinitions__ceph_flexvolume.json
@@ -161,7 +161,6 @@
         "Current": "",
         "Value": 1
       },
-      "CPU": null,
       "CPUTune": {
         "Shares": {
           "Value": 0
@@ -174,17 +173,77 @@
         }
       },
       "Resource": null,
+      "SysInfo": null,
+      "OS": {
+        "Type": {
+          "Arch": "",
+          "Machine": "",
+          "Type": "hvm"
+        },
+        "Loader": null,
+        "NVRam": null,
+        "Kernel": "",
+        "Initrd": "",
+        "KernelArgs": "",
+        "BootDevices": [
+          {
+            "Dev": "hd"
+          }
+        ],
+        "BootMenu": null,
+        "SMBios": null,
+        "BIOS": null,
+        "Init": "",
+        "InitArgs": null
+      },
+      "Features": {
+        "PAE": null,
+        "ACPI": {},
+        "APIC": null,
+        "HAP": null,
+        "Viridian": null,
+        "PrivNet": null,
+        "HyperV": null,
+        "KVM": null,
+        "PVSpinlock": null,
+        "PMU": null,
+        "VMPort": null,
+        "GIC": null,
+        "SMM": null
+      },
+      "CPU": null,
+      "OnPoweroff": "destroy",
+      "OnReboot": "restart",
+      "OnCrash": "restart",
       "Devices": {
         "Emulator": "/vmwrapper",
-        "Controllers": null,
+        "Controllers": [
+          {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
+            "Type": "scsi",
+            "Index": 0,
+            "Model": "virtio-scsi",
+            "Address": null
+          }
+        ],
         "Disks": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "file",
             "Device": "disk",
             "Snapshot": "",
             "Driver": {
               "Name": "qemu",
-              "Type": "qcow2"
+              "Type": "qcow2",
+              "Cache": "",
+              "IO": "",
+              "ErrorPolicy": ""
             },
             "Auth": null,
             "Source": {
@@ -198,18 +257,39 @@
               "StartupPolicy": ""
             },
             "Target": {
-              "Dev": "vda",
-              "Bus": "virtio"
+              "Dev": "sda",
+              "Bus": "scsi"
             },
-            "ReadOnly": null
+            "Serial": "",
+            "ReadOnly": null,
+            "Shareable": null,
+            "Address": {
+              "Type": "drive",
+              "Controller": 0,
+              "Domain": null,
+              "Bus": 0,
+              "Port": null,
+              "Slot": null,
+              "Function": null,
+              "Target": 0,
+              "Unit": 0
+            },
+            "Boot": null
           },
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "file",
-            "Device": "disk",
+            "Device": "cdrom",
             "Snapshot": "",
             "Driver": {
               "Name": "qemu",
-              "Type": "raw"
+              "Type": "raw",
+              "Cache": "",
+              "IO": "",
+              "ErrorPolicy": ""
             },
             "Auth": null,
             "Source": {
@@ -223,18 +303,39 @@
               "StartupPolicy": ""
             },
             "Target": {
-              "Dev": "vdb",
-              "Bus": "virtio"
+              "Dev": "sdb",
+              "Bus": "scsi"
             },
-            "ReadOnly": {}
+            "Serial": "",
+            "ReadOnly": {},
+            "Shareable": null,
+            "Address": {
+              "Type": "drive",
+              "Controller": 0,
+              "Domain": null,
+              "Bus": 0,
+              "Port": null,
+              "Slot": null,
+              "Function": null,
+              "Target": 0,
+              "Unit": 1
+            },
+            "Boot": null
           },
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "network",
             "Device": "disk",
             "Snapshot": "",
             "Driver": {
               "Name": "qemu",
-              "Type": "raw"
+              "Type": "raw",
+              "Cache": "",
+              "IO": "",
+              "ErrorPolicy": ""
             },
             "Auth": {
               "Username": "libvirt",
@@ -262,22 +363,39 @@
               "StartupPolicy": ""
             },
             "Target": {
-              "Dev": "vdc",
-              "Bus": "virtio"
+              "Dev": "sdc",
+              "Bus": "scsi"
             },
-            "ReadOnly": null
+            "Serial": "",
+            "ReadOnly": null,
+            "Shareable": null,
+            "Address": {
+              "Type": "drive",
+              "Controller": 0,
+              "Domain": null,
+              "Bus": 0,
+              "Port": null,
+              "Slot": null,
+              "Function": null,
+              "Target": 0,
+              "Unit": 2
+            },
+            "Boot": null
           }
         ],
         "Filesystems": null,
         "Interfaces": null,
         "Serials": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "pty",
-            "TTY": "",
             "Source": null,
             "Target": {
               "Type": "",
-              "Port": "0"
+              "Port": 0
             },
             "Alias": null,
             "Address": null
@@ -285,12 +403,15 @@
         ],
         "Consoles": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "pty",
-            "TTY": "",
             "Source": null,
             "Target": {
               "Type": "serial",
-              "Port": "0"
+              "Port": 0
             },
             "Alias": null,
             "Address": null
@@ -298,8 +419,13 @@
         ],
         "Inputs": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "tablet",
-            "Bus": "usb"
+            "Bus": "usb",
+            "Address": null
           }
         ],
         "Graphics": [
@@ -327,53 +453,23 @@
         ],
         "Videos": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Model": {
-              "Type": "cirrus"
-            }
+              "Type": "cirrus",
+              "Heads": 0,
+              "Ram": 0,
+              "VRam": 0,
+              "VGAMem": 0
+            },
+            "Address": null
           }
         ],
-        "Channels": null
-      },
-      "OS": {
-        "Type": {
-          "Arch": "",
-          "Machine": "",
-          "Type": "hvm"
-        },
-        "Loader": null,
-        "NVRam": null,
-        "Kernel": "",
-        "Initrd": "",
-        "KernelArgs": "",
-        "BootDevices": [
-          {
-            "Dev": "hd"
-          }
-        ],
-        "BootMenu": null,
-        "SMBios": null,
-        "BIOS": null,
-        "Init": "",
-        "InitArgs": null
-      },
-      "SysInfo": null,
-      "OnPoweroff": "destroy",
-      "OnReboot": "restart",
-      "OnCrash": "restart",
-      "Features": {
-        "PAE": null,
-        "ACPI": {},
-        "APIC": null,
-        "HAP": null,
-        "Viridian": null,
-        "PrivNet": null,
-        "HyperV": null,
-        "KVM": null,
-        "PVSpinlock": null,
-        "PMU": null,
-        "VMPort": null,
-        "GIC": null,
-        "SMM": null
+        "Channels": null,
+        "MemBalloon": null,
+        "Sounds": null
       },
       "CMDLine": {
         "Args": null,

--- a/pkg/libvirttools/TestDomainDefinitions__ceph_flexvolume.json
+++ b/pkg/libvirttools/TestDomainDefinitions__ceph_flexvolume.json
@@ -133,7 +133,7 @@
     "name": "domain conn: iso image",
     "data": {
       "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\"}",
-      "user-data": "#cloud-config\n"
+      "user-data": "#cloud-config\nmounts:\n- - /dev/sdb1\n  - /var/lib/whatever\n"
     }
   },
   {
@@ -281,52 +281,6 @@
               "Space": "",
               "Local": ""
             },
-            "Type": "file",
-            "Device": "cdrom",
-            "Snapshot": "",
-            "Driver": {
-              "Name": "qemu",
-              "Type": "raw",
-              "Cache": "",
-              "IO": "",
-              "ErrorPolicy": ""
-            },
-            "Auth": null,
-            "Source": {
-              "File": "--volatile-path-replaced-by-FakeDomainConnection--",
-              "Device": "",
-              "Protocol": "",
-              "Name": "",
-              "Pool": "",
-              "Volume": "",
-              "Hosts": null,
-              "StartupPolicy": ""
-            },
-            "Target": {
-              "Dev": "sdb",
-              "Bus": "scsi"
-            },
-            "Serial": "",
-            "ReadOnly": {},
-            "Shareable": null,
-            "Address": {
-              "Type": "drive",
-              "Controller": 0,
-              "Domain": null,
-              "Bus": 0,
-              "Port": null,
-              "Slot": null,
-              "Function": null,
-              "Target": 0,
-              "Unit": 1
-            },
-            "Boot": null
-          },
-          {
-            "XMLName": {
-              "Space": "",
-              "Local": ""
-            },
             "Type": "network",
             "Device": "disk",
             "Snapshot": "",
@@ -363,11 +317,57 @@
               "StartupPolicy": ""
             },
             "Target": {
-              "Dev": "sdc",
+              "Dev": "sdb",
               "Bus": "scsi"
             },
             "Serial": "",
             "ReadOnly": null,
+            "Shareable": null,
+            "Address": {
+              "Type": "drive",
+              "Controller": 0,
+              "Domain": null,
+              "Bus": 0,
+              "Port": null,
+              "Slot": null,
+              "Function": null,
+              "Target": 0,
+              "Unit": 1
+            },
+            "Boot": null
+          },
+          {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
+            "Type": "file",
+            "Device": "cdrom",
+            "Snapshot": "",
+            "Driver": {
+              "Name": "qemu",
+              "Type": "raw",
+              "Cache": "",
+              "IO": "",
+              "ErrorPolicy": ""
+            },
+            "Auth": null,
+            "Source": {
+              "File": "--volatile-path-replaced-by-FakeDomainConnection--",
+              "Device": "",
+              "Protocol": "",
+              "Name": "",
+              "Pool": "",
+              "Volume": "",
+              "Hosts": null,
+              "StartupPolicy": ""
+            },
+            "Target": {
+              "Dev": "sdc",
+              "Bus": "scsi"
+            },
+            "Serial": "",
+            "ReadOnly": {},
             "Shareable": null,
             "Address": {
               "Type": "drive",

--- a/pkg/libvirttools/TestDomainDefinitions__cloud-init.json
+++ b/pkg/libvirttools/TestDomainDefinitions__cloud-init.json
@@ -138,7 +138,6 @@
         "Current": "",
         "Value": 1
       },
-      "CPU": null,
       "CPUTune": {
         "Shares": {
           "Value": 0
@@ -151,17 +150,77 @@
         }
       },
       "Resource": null,
+      "SysInfo": null,
+      "OS": {
+        "Type": {
+          "Arch": "",
+          "Machine": "",
+          "Type": "hvm"
+        },
+        "Loader": null,
+        "NVRam": null,
+        "Kernel": "",
+        "Initrd": "",
+        "KernelArgs": "",
+        "BootDevices": [
+          {
+            "Dev": "hd"
+          }
+        ],
+        "BootMenu": null,
+        "SMBios": null,
+        "BIOS": null,
+        "Init": "",
+        "InitArgs": null
+      },
+      "Features": {
+        "PAE": null,
+        "ACPI": {},
+        "APIC": null,
+        "HAP": null,
+        "Viridian": null,
+        "PrivNet": null,
+        "HyperV": null,
+        "KVM": null,
+        "PVSpinlock": null,
+        "PMU": null,
+        "VMPort": null,
+        "GIC": null,
+        "SMM": null
+      },
+      "CPU": null,
+      "OnPoweroff": "destroy",
+      "OnReboot": "restart",
+      "OnCrash": "restart",
       "Devices": {
         "Emulator": "/vmwrapper",
-        "Controllers": null,
+        "Controllers": [
+          {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
+            "Type": "scsi",
+            "Index": 0,
+            "Model": "virtio-scsi",
+            "Address": null
+          }
+        ],
         "Disks": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "file",
             "Device": "disk",
             "Snapshot": "",
             "Driver": {
               "Name": "qemu",
-              "Type": "qcow2"
+              "Type": "qcow2",
+              "Cache": "",
+              "IO": "",
+              "ErrorPolicy": ""
             },
             "Auth": null,
             "Source": {
@@ -175,18 +234,39 @@
               "StartupPolicy": ""
             },
             "Target": {
-              "Dev": "vda",
-              "Bus": "virtio"
+              "Dev": "sda",
+              "Bus": "scsi"
             },
-            "ReadOnly": null
+            "Serial": "",
+            "ReadOnly": null,
+            "Shareable": null,
+            "Address": {
+              "Type": "drive",
+              "Controller": 0,
+              "Domain": null,
+              "Bus": 0,
+              "Port": null,
+              "Slot": null,
+              "Function": null,
+              "Target": 0,
+              "Unit": 0
+            },
+            "Boot": null
           },
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "file",
-            "Device": "disk",
+            "Device": "cdrom",
             "Snapshot": "",
             "Driver": {
               "Name": "qemu",
-              "Type": "raw"
+              "Type": "raw",
+              "Cache": "",
+              "IO": "",
+              "ErrorPolicy": ""
             },
             "Auth": null,
             "Source": {
@@ -200,22 +280,39 @@
               "StartupPolicy": ""
             },
             "Target": {
-              "Dev": "vdb",
-              "Bus": "virtio"
+              "Dev": "sdb",
+              "Bus": "scsi"
             },
-            "ReadOnly": {}
+            "Serial": "",
+            "ReadOnly": {},
+            "Shareable": null,
+            "Address": {
+              "Type": "drive",
+              "Controller": 0,
+              "Domain": null,
+              "Bus": 0,
+              "Port": null,
+              "Slot": null,
+              "Function": null,
+              "Target": 0,
+              "Unit": 1
+            },
+            "Boot": null
           }
         ],
         "Filesystems": null,
         "Interfaces": null,
         "Serials": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "pty",
-            "TTY": "",
             "Source": null,
             "Target": {
               "Type": "",
-              "Port": "0"
+              "Port": 0
             },
             "Alias": null,
             "Address": null
@@ -223,12 +320,15 @@
         ],
         "Consoles": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "pty",
-            "TTY": "",
             "Source": null,
             "Target": {
               "Type": "serial",
-              "Port": "0"
+              "Port": 0
             },
             "Alias": null,
             "Address": null
@@ -236,8 +336,13 @@
         ],
         "Inputs": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "tablet",
-            "Bus": "usb"
+            "Bus": "usb",
+            "Address": null
           }
         ],
         "Graphics": [
@@ -265,53 +370,23 @@
         ],
         "Videos": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Model": {
-              "Type": "cirrus"
-            }
+              "Type": "cirrus",
+              "Heads": 0,
+              "Ram": 0,
+              "VRam": 0,
+              "VGAMem": 0
+            },
+            "Address": null
           }
         ],
-        "Channels": null
-      },
-      "OS": {
-        "Type": {
-          "Arch": "",
-          "Machine": "",
-          "Type": "hvm"
-        },
-        "Loader": null,
-        "NVRam": null,
-        "Kernel": "",
-        "Initrd": "",
-        "KernelArgs": "",
-        "BootDevices": [
-          {
-            "Dev": "hd"
-          }
-        ],
-        "BootMenu": null,
-        "SMBios": null,
-        "BIOS": null,
-        "Init": "",
-        "InitArgs": null
-      },
-      "SysInfo": null,
-      "OnPoweroff": "destroy",
-      "OnReboot": "restart",
-      "OnCrash": "restart",
-      "Features": {
-        "PAE": null,
-        "ACPI": {},
-        "APIC": null,
-        "HAP": null,
-        "Viridian": null,
-        "PrivNet": null,
-        "HyperV": null,
-        "KVM": null,
-        "PVSpinlock": null,
-        "PMU": null,
-        "VMPort": null,
-        "GIC": null,
-        "SMM": null
+        "Channels": null,
+        "MemBalloon": null,
+        "Sounds": null
       },
       "CMDLine": {
         "Args": null,

--- a/pkg/libvirttools/TestDomainDefinitions__plain_domain.json
+++ b/pkg/libvirttools/TestDomainDefinitions__plain_domain.json
@@ -138,7 +138,6 @@
         "Current": "",
         "Value": 1
       },
-      "CPU": null,
       "CPUTune": {
         "Shares": {
           "Value": 0
@@ -151,17 +150,77 @@
         }
       },
       "Resource": null,
+      "SysInfo": null,
+      "OS": {
+        "Type": {
+          "Arch": "",
+          "Machine": "",
+          "Type": "hvm"
+        },
+        "Loader": null,
+        "NVRam": null,
+        "Kernel": "",
+        "Initrd": "",
+        "KernelArgs": "",
+        "BootDevices": [
+          {
+            "Dev": "hd"
+          }
+        ],
+        "BootMenu": null,
+        "SMBios": null,
+        "BIOS": null,
+        "Init": "",
+        "InitArgs": null
+      },
+      "Features": {
+        "PAE": null,
+        "ACPI": {},
+        "APIC": null,
+        "HAP": null,
+        "Viridian": null,
+        "PrivNet": null,
+        "HyperV": null,
+        "KVM": null,
+        "PVSpinlock": null,
+        "PMU": null,
+        "VMPort": null,
+        "GIC": null,
+        "SMM": null
+      },
+      "CPU": null,
+      "OnPoweroff": "destroy",
+      "OnReboot": "restart",
+      "OnCrash": "restart",
       "Devices": {
         "Emulator": "/vmwrapper",
-        "Controllers": null,
+        "Controllers": [
+          {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
+            "Type": "scsi",
+            "Index": 0,
+            "Model": "virtio-scsi",
+            "Address": null
+          }
+        ],
         "Disks": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "file",
             "Device": "disk",
             "Snapshot": "",
             "Driver": {
               "Name": "qemu",
-              "Type": "qcow2"
+              "Type": "qcow2",
+              "Cache": "",
+              "IO": "",
+              "ErrorPolicy": ""
             },
             "Auth": null,
             "Source": {
@@ -175,18 +234,39 @@
               "StartupPolicy": ""
             },
             "Target": {
-              "Dev": "vda",
-              "Bus": "virtio"
+              "Dev": "sda",
+              "Bus": "scsi"
             },
-            "ReadOnly": null
+            "Serial": "",
+            "ReadOnly": null,
+            "Shareable": null,
+            "Address": {
+              "Type": "drive",
+              "Controller": 0,
+              "Domain": null,
+              "Bus": 0,
+              "Port": null,
+              "Slot": null,
+              "Function": null,
+              "Target": 0,
+              "Unit": 0
+            },
+            "Boot": null
           },
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "file",
-            "Device": "disk",
+            "Device": "cdrom",
             "Snapshot": "",
             "Driver": {
               "Name": "qemu",
-              "Type": "raw"
+              "Type": "raw",
+              "Cache": "",
+              "IO": "",
+              "ErrorPolicy": ""
             },
             "Auth": null,
             "Source": {
@@ -200,22 +280,39 @@
               "StartupPolicy": ""
             },
             "Target": {
-              "Dev": "vdb",
-              "Bus": "virtio"
+              "Dev": "sdb",
+              "Bus": "scsi"
             },
-            "ReadOnly": {}
+            "Serial": "",
+            "ReadOnly": {},
+            "Shareable": null,
+            "Address": {
+              "Type": "drive",
+              "Controller": 0,
+              "Domain": null,
+              "Bus": 0,
+              "Port": null,
+              "Slot": null,
+              "Function": null,
+              "Target": 0,
+              "Unit": 1
+            },
+            "Boot": null
           }
         ],
         "Filesystems": null,
         "Interfaces": null,
         "Serials": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "pty",
-            "TTY": "",
             "Source": null,
             "Target": {
               "Type": "",
-              "Port": "0"
+              "Port": 0
             },
             "Alias": null,
             "Address": null
@@ -223,12 +320,15 @@
         ],
         "Consoles": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "pty",
-            "TTY": "",
             "Source": null,
             "Target": {
               "Type": "serial",
-              "Port": "0"
+              "Port": 0
             },
             "Alias": null,
             "Address": null
@@ -236,8 +336,13 @@
         ],
         "Inputs": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "tablet",
-            "Bus": "usb"
+            "Bus": "usb",
+            "Address": null
           }
         ],
         "Graphics": [
@@ -265,53 +370,23 @@
         ],
         "Videos": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Model": {
-              "Type": "cirrus"
-            }
+              "Type": "cirrus",
+              "Heads": 0,
+              "Ram": 0,
+              "VRam": 0,
+              "VGAMem": 0
+            },
+            "Address": null
           }
         ],
-        "Channels": null
-      },
-      "OS": {
-        "Type": {
-          "Arch": "",
-          "Machine": "",
-          "Type": "hvm"
-        },
-        "Loader": null,
-        "NVRam": null,
-        "Kernel": "",
-        "Initrd": "",
-        "KernelArgs": "",
-        "BootDevices": [
-          {
-            "Dev": "hd"
-          }
-        ],
-        "BootMenu": null,
-        "SMBios": null,
-        "BIOS": null,
-        "Init": "",
-        "InitArgs": null
-      },
-      "SysInfo": null,
-      "OnPoweroff": "destroy",
-      "OnReboot": "restart",
-      "OnCrash": "restart",
-      "Features": {
-        "PAE": null,
-        "ACPI": {},
-        "APIC": null,
-        "HAP": null,
-        "Viridian": null,
-        "PrivNet": null,
-        "HyperV": null,
-        "KVM": null,
-        "PVSpinlock": null,
-        "PMU": null,
-        "VMPort": null,
-        "GIC": null,
-        "SMM": null
+        "Channels": null,
+        "MemBalloon": null,
+        "Sounds": null
       },
       "CMDLine": {
         "Args": null,

--- a/pkg/libvirttools/TestDomainDefinitions__raw_devices.json
+++ b/pkg/libvirttools/TestDomainDefinitions__raw_devices.json
@@ -138,7 +138,6 @@
         "Current": "",
         "Value": 1
       },
-      "CPU": null,
       "CPUTune": {
         "Shares": {
           "Value": 0
@@ -151,17 +150,77 @@
         }
       },
       "Resource": null,
+      "SysInfo": null,
+      "OS": {
+        "Type": {
+          "Arch": "",
+          "Machine": "",
+          "Type": "hvm"
+        },
+        "Loader": null,
+        "NVRam": null,
+        "Kernel": "",
+        "Initrd": "",
+        "KernelArgs": "",
+        "BootDevices": [
+          {
+            "Dev": "hd"
+          }
+        ],
+        "BootMenu": null,
+        "SMBios": null,
+        "BIOS": null,
+        "Init": "",
+        "InitArgs": null
+      },
+      "Features": {
+        "PAE": null,
+        "ACPI": {},
+        "APIC": null,
+        "HAP": null,
+        "Viridian": null,
+        "PrivNet": null,
+        "HyperV": null,
+        "KVM": null,
+        "PVSpinlock": null,
+        "PMU": null,
+        "VMPort": null,
+        "GIC": null,
+        "SMM": null
+      },
+      "CPU": null,
+      "OnPoweroff": "destroy",
+      "OnReboot": "restart",
+      "OnCrash": "restart",
       "Devices": {
         "Emulator": "/vmwrapper",
-        "Controllers": null,
+        "Controllers": [
+          {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
+            "Type": "scsi",
+            "Index": 0,
+            "Model": "virtio-scsi",
+            "Address": null
+          }
+        ],
         "Disks": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "file",
             "Device": "disk",
             "Snapshot": "",
             "Driver": {
               "Name": "qemu",
-              "Type": "qcow2"
+              "Type": "qcow2",
+              "Cache": "",
+              "IO": "",
+              "ErrorPolicy": ""
             },
             "Auth": null,
             "Source": {
@@ -175,18 +234,39 @@
               "StartupPolicy": ""
             },
             "Target": {
-              "Dev": "vda",
-              "Bus": "virtio"
+              "Dev": "sda",
+              "Bus": "scsi"
             },
-            "ReadOnly": null
+            "Serial": "",
+            "ReadOnly": null,
+            "Shareable": null,
+            "Address": {
+              "Type": "drive",
+              "Controller": 0,
+              "Domain": null,
+              "Bus": 0,
+              "Port": null,
+              "Slot": null,
+              "Function": null,
+              "Target": 0,
+              "Unit": 0
+            },
+            "Boot": null
           },
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "file",
-            "Device": "disk",
+            "Device": "cdrom",
             "Snapshot": "",
             "Driver": {
               "Name": "qemu",
-              "Type": "raw"
+              "Type": "raw",
+              "Cache": "",
+              "IO": "",
+              "ErrorPolicy": ""
             },
             "Auth": null,
             "Source": {
@@ -200,18 +280,39 @@
               "StartupPolicy": ""
             },
             "Target": {
-              "Dev": "vdb",
-              "Bus": "virtio"
+              "Dev": "sdb",
+              "Bus": "scsi"
             },
-            "ReadOnly": {}
+            "Serial": "",
+            "ReadOnly": {},
+            "Shareable": null,
+            "Address": {
+              "Type": "drive",
+              "Controller": 0,
+              "Domain": null,
+              "Bus": 0,
+              "Port": null,
+              "Slot": null,
+              "Function": null,
+              "Target": 0,
+              "Unit": 1
+            },
+            "Boot": null
           },
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "block",
             "Device": "disk",
             "Snapshot": "",
             "Driver": {
               "Name": "qemu",
-              "Type": "raw"
+              "Type": "raw",
+              "Cache": "",
+              "IO": "",
+              "ErrorPolicy": ""
             },
             "Auth": null,
             "Source": {
@@ -225,22 +326,39 @@
               "StartupPolicy": ""
             },
             "Target": {
-              "Dev": "vdc",
-              "Bus": "virtio"
+              "Dev": "sdc",
+              "Bus": "scsi"
             },
-            "ReadOnly": null
+            "Serial": "",
+            "ReadOnly": null,
+            "Shareable": null,
+            "Address": {
+              "Type": "drive",
+              "Controller": 0,
+              "Domain": null,
+              "Bus": 0,
+              "Port": null,
+              "Slot": null,
+              "Function": null,
+              "Target": 0,
+              "Unit": 2
+            },
+            "Boot": null
           }
         ],
         "Filesystems": null,
         "Interfaces": null,
         "Serials": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "pty",
-            "TTY": "",
             "Source": null,
             "Target": {
               "Type": "",
-              "Port": "0"
+              "Port": 0
             },
             "Alias": null,
             "Address": null
@@ -248,12 +366,15 @@
         ],
         "Consoles": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "pty",
-            "TTY": "",
             "Source": null,
             "Target": {
               "Type": "serial",
-              "Port": "0"
+              "Port": 0
             },
             "Alias": null,
             "Address": null
@@ -261,8 +382,13 @@
         ],
         "Inputs": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "tablet",
-            "Bus": "usb"
+            "Bus": "usb",
+            "Address": null
           }
         ],
         "Graphics": [
@@ -290,53 +416,23 @@
         ],
         "Videos": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Model": {
-              "Type": "cirrus"
-            }
+              "Type": "cirrus",
+              "Heads": 0,
+              "Ram": 0,
+              "VRam": 0,
+              "VGAMem": 0
+            },
+            "Address": null
           }
         ],
-        "Channels": null
-      },
-      "OS": {
-        "Type": {
-          "Arch": "",
-          "Machine": "",
-          "Type": "hvm"
-        },
-        "Loader": null,
-        "NVRam": null,
-        "Kernel": "",
-        "Initrd": "",
-        "KernelArgs": "",
-        "BootDevices": [
-          {
-            "Dev": "hd"
-          }
-        ],
-        "BootMenu": null,
-        "SMBios": null,
-        "BIOS": null,
-        "Init": "",
-        "InitArgs": null
-      },
-      "SysInfo": null,
-      "OnPoweroff": "destroy",
-      "OnReboot": "restart",
-      "OnCrash": "restart",
-      "Features": {
-        "PAE": null,
-        "ACPI": {},
-        "APIC": null,
-        "HAP": null,
-        "Viridian": null,
-        "PrivNet": null,
-        "HyperV": null,
-        "KVM": null,
-        "PVSpinlock": null,
-        "PMU": null,
-        "VMPort": null,
-        "GIC": null,
-        "SMM": null
+        "Channels": null,
+        "MemBalloon": null,
+        "Sounds": null
       },
       "CMDLine": {
         "Args": null,

--- a/pkg/libvirttools/TestDomainDefinitions__raw_devices.json
+++ b/pkg/libvirttools/TestDomainDefinitions__raw_devices.json
@@ -258,52 +258,6 @@
               "Space": "",
               "Local": ""
             },
-            "Type": "file",
-            "Device": "cdrom",
-            "Snapshot": "",
-            "Driver": {
-              "Name": "qemu",
-              "Type": "raw",
-              "Cache": "",
-              "IO": "",
-              "ErrorPolicy": ""
-            },
-            "Auth": null,
-            "Source": {
-              "File": "--volatile-path-replaced-by-FakeDomainConnection--",
-              "Device": "",
-              "Protocol": "",
-              "Name": "",
-              "Pool": "",
-              "Volume": "",
-              "Hosts": null,
-              "StartupPolicy": ""
-            },
-            "Target": {
-              "Dev": "sdb",
-              "Bus": "scsi"
-            },
-            "Serial": "",
-            "ReadOnly": {},
-            "Shareable": null,
-            "Address": {
-              "Type": "drive",
-              "Controller": 0,
-              "Domain": null,
-              "Bus": 0,
-              "Port": null,
-              "Slot": null,
-              "Function": null,
-              "Target": 0,
-              "Unit": 1
-            },
-            "Boot": null
-          },
-          {
-            "XMLName": {
-              "Space": "",
-              "Local": ""
-            },
             "Type": "block",
             "Device": "disk",
             "Snapshot": "",
@@ -326,11 +280,57 @@
               "StartupPolicy": ""
             },
             "Target": {
-              "Dev": "sdc",
+              "Dev": "sdb",
               "Bus": "scsi"
             },
             "Serial": "",
             "ReadOnly": null,
+            "Shareable": null,
+            "Address": {
+              "Type": "drive",
+              "Controller": 0,
+              "Domain": null,
+              "Bus": 0,
+              "Port": null,
+              "Slot": null,
+              "Function": null,
+              "Target": 0,
+              "Unit": 1
+            },
+            "Boot": null
+          },
+          {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
+            "Type": "file",
+            "Device": "cdrom",
+            "Snapshot": "",
+            "Driver": {
+              "Name": "qemu",
+              "Type": "raw",
+              "Cache": "",
+              "IO": "",
+              "ErrorPolicy": ""
+            },
+            "Auth": null,
+            "Source": {
+              "File": "--volatile-path-replaced-by-FakeDomainConnection--",
+              "Device": "",
+              "Protocol": "",
+              "Name": "",
+              "Pool": "",
+              "Volume": "",
+              "Hosts": null,
+              "StartupPolicy": ""
+            },
+            "Target": {
+              "Dev": "sdc",
+              "Bus": "scsi"
+            },
+            "Serial": "",
+            "ReadOnly": {},
             "Shareable": null,
             "Address": {
               "Type": "drive",

--- a/pkg/libvirttools/TestDomainDefinitions__vcpu_count.json
+++ b/pkg/libvirttools/TestDomainDefinitions__vcpu_count.json
@@ -138,7 +138,6 @@
         "Current": "",
         "Value": 4
       },
-      "CPU": null,
       "CPUTune": {
         "Shares": {
           "Value": 0
@@ -151,17 +150,77 @@
         }
       },
       "Resource": null,
+      "SysInfo": null,
+      "OS": {
+        "Type": {
+          "Arch": "",
+          "Machine": "",
+          "Type": "hvm"
+        },
+        "Loader": null,
+        "NVRam": null,
+        "Kernel": "",
+        "Initrd": "",
+        "KernelArgs": "",
+        "BootDevices": [
+          {
+            "Dev": "hd"
+          }
+        ],
+        "BootMenu": null,
+        "SMBios": null,
+        "BIOS": null,
+        "Init": "",
+        "InitArgs": null
+      },
+      "Features": {
+        "PAE": null,
+        "ACPI": {},
+        "APIC": null,
+        "HAP": null,
+        "Viridian": null,
+        "PrivNet": null,
+        "HyperV": null,
+        "KVM": null,
+        "PVSpinlock": null,
+        "PMU": null,
+        "VMPort": null,
+        "GIC": null,
+        "SMM": null
+      },
+      "CPU": null,
+      "OnPoweroff": "destroy",
+      "OnReboot": "restart",
+      "OnCrash": "restart",
       "Devices": {
         "Emulator": "/vmwrapper",
-        "Controllers": null,
+        "Controllers": [
+          {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
+            "Type": "scsi",
+            "Index": 0,
+            "Model": "virtio-scsi",
+            "Address": null
+          }
+        ],
         "Disks": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "file",
             "Device": "disk",
             "Snapshot": "",
             "Driver": {
               "Name": "qemu",
-              "Type": "qcow2"
+              "Type": "qcow2",
+              "Cache": "",
+              "IO": "",
+              "ErrorPolicy": ""
             },
             "Auth": null,
             "Source": {
@@ -175,18 +234,39 @@
               "StartupPolicy": ""
             },
             "Target": {
-              "Dev": "vda",
-              "Bus": "virtio"
+              "Dev": "sda",
+              "Bus": "scsi"
             },
-            "ReadOnly": null
+            "Serial": "",
+            "ReadOnly": null,
+            "Shareable": null,
+            "Address": {
+              "Type": "drive",
+              "Controller": 0,
+              "Domain": null,
+              "Bus": 0,
+              "Port": null,
+              "Slot": null,
+              "Function": null,
+              "Target": 0,
+              "Unit": 0
+            },
+            "Boot": null
           },
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "file",
-            "Device": "disk",
+            "Device": "cdrom",
             "Snapshot": "",
             "Driver": {
               "Name": "qemu",
-              "Type": "raw"
+              "Type": "raw",
+              "Cache": "",
+              "IO": "",
+              "ErrorPolicy": ""
             },
             "Auth": null,
             "Source": {
@@ -200,22 +280,39 @@
               "StartupPolicy": ""
             },
             "Target": {
-              "Dev": "vdb",
-              "Bus": "virtio"
+              "Dev": "sdb",
+              "Bus": "scsi"
             },
-            "ReadOnly": {}
+            "Serial": "",
+            "ReadOnly": {},
+            "Shareable": null,
+            "Address": {
+              "Type": "drive",
+              "Controller": 0,
+              "Domain": null,
+              "Bus": 0,
+              "Port": null,
+              "Slot": null,
+              "Function": null,
+              "Target": 0,
+              "Unit": 1
+            },
+            "Boot": null
           }
         ],
         "Filesystems": null,
         "Interfaces": null,
         "Serials": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "pty",
-            "TTY": "",
             "Source": null,
             "Target": {
               "Type": "",
-              "Port": "0"
+              "Port": 0
             },
             "Alias": null,
             "Address": null
@@ -223,12 +320,15 @@
         ],
         "Consoles": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "pty",
-            "TTY": "",
             "Source": null,
             "Target": {
               "Type": "serial",
-              "Port": "0"
+              "Port": 0
             },
             "Alias": null,
             "Address": null
@@ -236,8 +336,13 @@
         ],
         "Inputs": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "tablet",
-            "Bus": "usb"
+            "Bus": "usb",
+            "Address": null
           }
         ],
         "Graphics": [
@@ -265,53 +370,23 @@
         ],
         "Videos": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Model": {
-              "Type": "cirrus"
-            }
+              "Type": "cirrus",
+              "Heads": 0,
+              "Ram": 0,
+              "VRam": 0,
+              "VGAMem": 0
+            },
+            "Address": null
           }
         ],
-        "Channels": null
-      },
-      "OS": {
-        "Type": {
-          "Arch": "",
-          "Machine": "",
-          "Type": "hvm"
-        },
-        "Loader": null,
-        "NVRam": null,
-        "Kernel": "",
-        "Initrd": "",
-        "KernelArgs": "",
-        "BootDevices": [
-          {
-            "Dev": "hd"
-          }
-        ],
-        "BootMenu": null,
-        "SMBios": null,
-        "BIOS": null,
-        "Init": "",
-        "InitArgs": null
-      },
-      "SysInfo": null,
-      "OnPoweroff": "destroy",
-      "OnReboot": "restart",
-      "OnCrash": "restart",
-      "Features": {
-        "PAE": null,
-        "ACPI": {},
-        "APIC": null,
-        "HAP": null,
-        "Viridian": null,
-        "PrivNet": null,
-        "HyperV": null,
-        "KVM": null,
-        "PVSpinlock": null,
-        "PMU": null,
-        "VMPort": null,
-        "GIC": null,
-        "SMM": null
+        "Channels": null,
+        "MemBalloon": null,
+        "Sounds": null
       },
       "CMDLine": {
         "Args": null,

--- a/pkg/libvirttools/TestDomainDefinitions__virtio_disk_driver.json
+++ b/pkg/libvirttools/TestDomainDefinitions__virtio_disk_driver.json
@@ -109,8 +109,8 @@
   {
     "name": "domain conn: iso image",
     "data": {
-      "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\",\"public-keys\":[\"key1\",\"key2\"]}",
-      "user-data": "#cloud-config\nusers:\n- name: cloudy\n"
+      "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\"}",
+      "user-data": "#cloud-config\n"
     }
   },
   {
@@ -234,22 +234,22 @@
               "StartupPolicy": ""
             },
             "Target": {
-              "Dev": "sda",
-              "Bus": "scsi"
+              "Dev": "vda",
+              "Bus": "virtio"
             },
             "Serial": "",
             "ReadOnly": null,
             "Shareable": null,
             "Address": {
-              "Type": "drive",
-              "Controller": 0,
-              "Domain": null,
-              "Bus": 0,
+              "Type": "pci",
+              "Controller": null,
+              "Domain": 0,
+              "Bus": 1,
               "Port": null,
-              "Slot": null,
-              "Function": null,
-              "Target": 0,
-              "Unit": 0
+              "Slot": 1,
+              "Function": 0,
+              "Target": null,
+              "Unit": null
             },
             "Boot": null
           },
@@ -280,22 +280,22 @@
               "StartupPolicy": ""
             },
             "Target": {
-              "Dev": "sdb",
-              "Bus": "scsi"
+              "Dev": "vdb",
+              "Bus": "virtio"
             },
             "Serial": "",
             "ReadOnly": {},
             "Shareable": null,
             "Address": {
-              "Type": "drive",
-              "Controller": 0,
-              "Domain": null,
-              "Bus": 0,
+              "Type": "pci",
+              "Controller": null,
+              "Domain": 0,
+              "Bus": 1,
               "Port": null,
-              "Slot": null,
-              "Function": null,
-              "Target": 0,
-              "Unit": 1
+              "Slot": 2,
+              "Function": 0,
+              "Target": null,
+              "Unit": null
             },
             "Boot": null
           }

--- a/pkg/libvirttools/TestDomainDefinitions__volumes.json
+++ b/pkg/libvirttools/TestDomainDefinitions__volumes.json
@@ -249,7 +249,6 @@
         "Current": "",
         "Value": 1
       },
-      "CPU": null,
       "CPUTune": {
         "Shares": {
           "Value": 0
@@ -262,17 +261,77 @@
         }
       },
       "Resource": null,
+      "SysInfo": null,
+      "OS": {
+        "Type": {
+          "Arch": "",
+          "Machine": "",
+          "Type": "hvm"
+        },
+        "Loader": null,
+        "NVRam": null,
+        "Kernel": "",
+        "Initrd": "",
+        "KernelArgs": "",
+        "BootDevices": [
+          {
+            "Dev": "hd"
+          }
+        ],
+        "BootMenu": null,
+        "SMBios": null,
+        "BIOS": null,
+        "Init": "",
+        "InitArgs": null
+      },
+      "Features": {
+        "PAE": null,
+        "ACPI": {},
+        "APIC": null,
+        "HAP": null,
+        "Viridian": null,
+        "PrivNet": null,
+        "HyperV": null,
+        "KVM": null,
+        "PVSpinlock": null,
+        "PMU": null,
+        "VMPort": null,
+        "GIC": null,
+        "SMM": null
+      },
+      "CPU": null,
+      "OnPoweroff": "destroy",
+      "OnReboot": "restart",
+      "OnCrash": "restart",
       "Devices": {
         "Emulator": "/vmwrapper",
-        "Controllers": null,
+        "Controllers": [
+          {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
+            "Type": "scsi",
+            "Index": 0,
+            "Model": "virtio-scsi",
+            "Address": null
+          }
+        ],
         "Disks": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "file",
             "Device": "disk",
             "Snapshot": "",
             "Driver": {
               "Name": "qemu",
-              "Type": "qcow2"
+              "Type": "qcow2",
+              "Cache": "",
+              "IO": "",
+              "ErrorPolicy": ""
             },
             "Auth": null,
             "Source": {
@@ -286,18 +345,39 @@
               "StartupPolicy": ""
             },
             "Target": {
-              "Dev": "vda",
-              "Bus": "virtio"
+              "Dev": "sda",
+              "Bus": "scsi"
             },
-            "ReadOnly": null
+            "Serial": "",
+            "ReadOnly": null,
+            "Shareable": null,
+            "Address": {
+              "Type": "drive",
+              "Controller": 0,
+              "Domain": null,
+              "Bus": 0,
+              "Port": null,
+              "Slot": null,
+              "Function": null,
+              "Target": 0,
+              "Unit": 0
+            },
+            "Boot": null
           },
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "file",
-            "Device": "disk",
+            "Device": "cdrom",
             "Snapshot": "",
             "Driver": {
               "Name": "qemu",
-              "Type": "raw"
+              "Type": "raw",
+              "Cache": "",
+              "IO": "",
+              "ErrorPolicy": ""
             },
             "Auth": null,
             "Source": {
@@ -311,18 +391,39 @@
               "StartupPolicy": ""
             },
             "Target": {
-              "Dev": "vdb",
-              "Bus": "virtio"
+              "Dev": "sdb",
+              "Bus": "scsi"
             },
-            "ReadOnly": {}
+            "Serial": "",
+            "ReadOnly": {},
+            "Shareable": null,
+            "Address": {
+              "Type": "drive",
+              "Controller": 0,
+              "Domain": null,
+              "Bus": 0,
+              "Port": null,
+              "Slot": null,
+              "Function": null,
+              "Target": 0,
+              "Unit": 1
+            },
+            "Boot": null
           },
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "file",
             "Device": "disk",
             "Snapshot": "",
             "Driver": {
               "Name": "qemu",
-              "Type": "qcow2"
+              "Type": "qcow2",
+              "Cache": "",
+              "IO": "",
+              "ErrorPolicy": ""
             },
             "Auth": null,
             "Source": {
@@ -336,18 +437,39 @@
               "StartupPolicy": ""
             },
             "Target": {
-              "Dev": "vdc",
-              "Bus": "virtio"
+              "Dev": "sdc",
+              "Bus": "scsi"
             },
-            "ReadOnly": null
+            "Serial": "",
+            "ReadOnly": null,
+            "Shareable": null,
+            "Address": {
+              "Type": "drive",
+              "Controller": 0,
+              "Domain": null,
+              "Bus": 0,
+              "Port": null,
+              "Slot": null,
+              "Function": null,
+              "Target": 0,
+              "Unit": 2
+            },
+            "Boot": null
           },
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "file",
             "Device": "disk",
             "Snapshot": "",
             "Driver": {
               "Name": "qemu",
-              "Type": "qcow2"
+              "Type": "qcow2",
+              "Cache": "",
+              "IO": "",
+              "ErrorPolicy": ""
             },
             "Auth": null,
             "Source": {
@@ -361,18 +483,39 @@
               "StartupPolicy": ""
             },
             "Target": {
-              "Dev": "vdd",
-              "Bus": "virtio"
+              "Dev": "sdd",
+              "Bus": "scsi"
             },
-            "ReadOnly": null
+            "Serial": "",
+            "ReadOnly": null,
+            "Shareable": null,
+            "Address": {
+              "Type": "drive",
+              "Controller": 0,
+              "Domain": null,
+              "Bus": 0,
+              "Port": null,
+              "Slot": null,
+              "Function": null,
+              "Target": 0,
+              "Unit": 3
+            },
+            "Boot": null
           },
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "file",
             "Device": "disk",
             "Snapshot": "",
             "Driver": {
               "Name": "qemu",
-              "Type": "qcow2"
+              "Type": "qcow2",
+              "Cache": "",
+              "IO": "",
+              "ErrorPolicy": ""
             },
             "Auth": null,
             "Source": {
@@ -386,22 +529,39 @@
               "StartupPolicy": ""
             },
             "Target": {
-              "Dev": "vde",
-              "Bus": "virtio"
+              "Dev": "sde",
+              "Bus": "scsi"
             },
-            "ReadOnly": null
+            "Serial": "",
+            "ReadOnly": null,
+            "Shareable": null,
+            "Address": {
+              "Type": "drive",
+              "Controller": 0,
+              "Domain": null,
+              "Bus": 0,
+              "Port": null,
+              "Slot": null,
+              "Function": null,
+              "Target": 0,
+              "Unit": 4
+            },
+            "Boot": null
           }
         ],
         "Filesystems": null,
         "Interfaces": null,
         "Serials": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "pty",
-            "TTY": "",
             "Source": null,
             "Target": {
               "Type": "",
-              "Port": "0"
+              "Port": 0
             },
             "Alias": null,
             "Address": null
@@ -409,12 +569,15 @@
         ],
         "Consoles": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "pty",
-            "TTY": "",
             "Source": null,
             "Target": {
               "Type": "serial",
-              "Port": "0"
+              "Port": 0
             },
             "Alias": null,
             "Address": null
@@ -422,8 +585,13 @@
         ],
         "Inputs": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "tablet",
-            "Bus": "usb"
+            "Bus": "usb",
+            "Address": null
           }
         ],
         "Graphics": [
@@ -451,53 +619,23 @@
         ],
         "Videos": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Model": {
-              "Type": "cirrus"
-            }
+              "Type": "cirrus",
+              "Heads": 0,
+              "Ram": 0,
+              "VRam": 0,
+              "VGAMem": 0
+            },
+            "Address": null
           }
         ],
-        "Channels": null
-      },
-      "OS": {
-        "Type": {
-          "Arch": "",
-          "Machine": "",
-          "Type": "hvm"
-        },
-        "Loader": null,
-        "NVRam": null,
-        "Kernel": "",
-        "Initrd": "",
-        "KernelArgs": "",
-        "BootDevices": [
-          {
-            "Dev": "hd"
-          }
-        ],
-        "BootMenu": null,
-        "SMBios": null,
-        "BIOS": null,
-        "Init": "",
-        "InitArgs": null
-      },
-      "SysInfo": null,
-      "OnPoweroff": "destroy",
-      "OnReboot": "restart",
-      "OnCrash": "restart",
-      "Features": {
-        "PAE": null,
-        "ACPI": {},
-        "APIC": null,
-        "HAP": null,
-        "Viridian": null,
-        "PrivNet": null,
-        "HyperV": null,
-        "KVM": null,
-        "PVSpinlock": null,
-        "PMU": null,
-        "VMPort": null,
-        "GIC": null,
-        "SMM": null
+        "Channels": null,
+        "MemBalloon": null,
+        "Sounds": null
       },
       "CMDLine": {
         "Args": null,

--- a/pkg/libvirttools/TestDomainDefinitions__volumes.json
+++ b/pkg/libvirttools/TestDomainDefinitions__volumes.json
@@ -370,11 +370,11 @@
               "Local": ""
             },
             "Type": "file",
-            "Device": "cdrom",
+            "Device": "disk",
             "Snapshot": "",
             "Driver": {
               "Name": "qemu",
-              "Type": "raw",
+              "Type": "qcow2",
               "Cache": "",
               "IO": "",
               "ErrorPolicy": ""
@@ -395,7 +395,7 @@
               "Bus": "scsi"
             },
             "Serial": "",
-            "ReadOnly": {},
+            "ReadOnly": null,
             "Shareable": null,
             "Address": {
               "Type": "drive",
@@ -508,11 +508,11 @@
               "Local": ""
             },
             "Type": "file",
-            "Device": "disk",
+            "Device": "cdrom",
             "Snapshot": "",
             "Driver": {
               "Name": "qemu",
-              "Type": "qcow2",
+              "Type": "raw",
               "Cache": "",
               "IO": "",
               "ErrorPolicy": ""
@@ -533,7 +533,7 @@
               "Bus": "scsi"
             },
             "Serial": "",
-            "ReadOnly": null,
+            "ReadOnly": {},
             "Shareable": null,
             "Address": {
               "Type": "drive",

--- a/pkg/libvirttools/annotations_test.go
+++ b/pkg/libvirttools/annotations_test.go
@@ -31,27 +31,42 @@ func TestVirtletAnnotations(t *testing.T) {
 		{
 			name:        "nil annotations",
 			annotations: nil,
-			va:          &VirtletAnnotations{VCPUCount: 1},
+			va: &VirtletAnnotations{
+				VCPUCount:  1,
+				DiskDriver: "scsi",
+			},
 		},
 		{
 			name:        "empty annotations",
 			annotations: map[string]string{},
-			va:          &VirtletAnnotations{VCPUCount: 1},
+			va: &VirtletAnnotations{
+				VCPUCount:  1,
+				DiskDriver: "scsi",
+			},
 		},
 		{
 			name:        "negative vcpu count (default)",
 			annotations: map[string]string{"VirtletVCPUCount": "-1"},
-			va:          &VirtletAnnotations{VCPUCount: 1},
+			va: &VirtletAnnotations{
+				VCPUCount:  1,
+				DiskDriver: "scsi",
+			},
 		},
 		{
 			name:        "zero vcpu count (default)",
 			annotations: map[string]string{"VirtletVCPUCount": "0"},
-			va:          &VirtletAnnotations{VCPUCount: 1},
+			va: &VirtletAnnotations{
+				VCPUCount:  1,
+				DiskDriver: "scsi",
+			},
 		},
 		{
 			name:        "vcpu count specified",
 			annotations: map[string]string{"VirtletVCPUCount": "4"},
-			va:          &VirtletAnnotations{VCPUCount: 4},
+			va: &VirtletAnnotations{
+				VCPUCount:  4,
+				DiskDriver: "scsi",
+			},
 		},
 		{
 			name: "cloud-init yaml and ssh keys",
@@ -76,7 +91,8 @@ func TestVirtletAnnotations(t *testing.T) {
 						},
 					},
 				},
-				SSHKeys: []string{"key1", "key2"},
+				SSHKeys:    []string{"key1", "key2"},
+				DiskDriver: "scsi",
 			},
 		},
 		{
@@ -87,6 +103,7 @@ func TestVirtletAnnotations(t *testing.T) {
 			va: &VirtletAnnotations{
 				VCPUCount:         1,
 				UserDataOverwrite: true,
+				DiskDriver:        "scsi",
 			},
 		},
 		{
@@ -97,12 +114,17 @@ func TestVirtletAnnotations(t *testing.T) {
 			va: &VirtletAnnotations{
 				VCPUCount:      1,
 				UserDataScript: "#!/bin/sh\necho hi\n",
+				DiskDriver:     "scsi",
 			},
 		},
 		// bad metadata items follow
 		{
 			name:        "bad vcpu count",
 			annotations: map[string]string{"VirtletVCPUCount": "256"},
+		},
+		{
+			name:        "bad disk driver",
+			annotations: map[string]string{"VirtletDiskDriver": "ducttape"},
 		},
 		{
 			name: "bad cloud-init meta-data",

--- a/pkg/libvirttools/ceph_flexvolume.go
+++ b/pkg/libvirttools/ceph_flexvolume.go
@@ -76,7 +76,7 @@ func (v *cephVolume) secretDef() *libvirtxml.Secret {
 	}
 }
 
-func (v *cephVolume) Setup(virtDev string) (*libvirtxml.DomainDisk, error) {
+func (v *cephVolume) Setup() (*libvirtxml.DomainDisk, error) {
 	secretUuid := v.secretUuid()
 	secret, err := v.owner.DomainConnection().LookupSecretByUUIDString(secretUuid)
 	ipPortPair := strings.Split(v.opts.Monitor, ":")
@@ -121,7 +121,6 @@ func (v *cephVolume) Setup(virtDev string) (*libvirtxml.DomainDisk, error) {
 				},
 			},
 		},
-		Target: &libvirtxml.DomainDiskTarget{Dev: virtDev, Bus: "virtio"},
 	}, nil
 }
 

--- a/pkg/libvirttools/ceph_flexvolume.go
+++ b/pkg/libvirttools/ceph_flexvolume.go
@@ -37,6 +37,7 @@ type cephFlexvolumeOptions struct {
 	Secret   string `json:"secret"`
 	User     string `json:"user"`
 	Protocol string `json:"protocol"`
+	Uuid     string `json:"uuid"`
 }
 
 // cephVolume denotes a Ceph RBD volume
@@ -76,7 +77,11 @@ func (v *cephVolume) secretDef() *libvirtxml.Secret {
 	}
 }
 
-func (v *cephVolume) Setup() (*libvirtxml.DomainDisk, error) {
+func (v *cephVolume) Uuid() string {
+	return v.opts.Uuid
+}
+
+func (v *cephVolume) Setup(volumeMap map[string]string) (*libvirtxml.DomainDisk, error) {
 	secretUuid := v.secretUuid()
 	secret, err := v.owner.DomainConnection().LookupSecretByUUIDString(secretUuid)
 	ipPortPair := strings.Split(v.opts.Monitor, ":")

--- a/pkg/libvirttools/cloudinit.go
+++ b/pkg/libvirttools/cloudinit.go
@@ -126,10 +126,9 @@ func (g *CloudInitGenerator) GenerateDisk() (string, *libvirtxml.DomainDisk, err
 
 	diskDef := &libvirtxml.DomainDisk{
 		Type:     "file",
-		Device:   "disk",
+		Device:   "cdrom",
 		Driver:   &libvirtxml.DomainDiskDriver{Name: "qemu", Type: "raw"},
 		Source:   &libvirtxml.DomainDiskSource{File: isoFile.Name()},
-		Target:   &libvirtxml.DomainDiskTarget{Bus: "virtio"},
 		ReadOnly: &libvirtxml.DomainDiskReadOnly{},
 	}
 	return isoFile.Name(), diskDef, nil

--- a/pkg/libvirttools/cloudinit_test.go
+++ b/pkg/libvirttools/cloudinit_test.go
@@ -19,32 +19,74 @@ package libvirttools
 import (
 	"bytes"
 	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/ghodss/yaml"
 
+	"github.com/Mirantis/virtlet/pkg/utils"
 	testutils "github.com/Mirantis/virtlet/pkg/utils/testing"
 	libvirtxml "github.com/libvirt/libvirt-go-xml"
 )
 
+type fakeFlexvolume struct {
+	uuid string
+	part int
+	path string
+}
+
+func newFakeFlexvolume(t *testing.T, parentDir string, uuid string, part int) *fakeFlexvolume {
+	info := map[string]string{"uuid": uuid}
+	if part >= 0 {
+		info["part"] = strconv.Itoa(part)
+	}
+	volDir := filepath.Join(parentDir, uuid)
+	if err := os.MkdirAll(volDir, 0777); err != nil {
+		t.Fatalf("MkdirAll(): %q: %v", volDir, err)
+	}
+	infoPath := filepath.Join(volDir, "virtlet-flexvolume.json")
+	if err := utils.WriteJson(infoPath, info, 0777); err != nil {
+		t.Fatalf("WriteJson(): %q: %v", infoPath, err)
+	}
+	return &fakeFlexvolume{
+		uuid: uuid,
+		part: part,
+		path: volDir,
+	}
+}
+
 func TestCloudInitGenerator(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "fake-flexvol")
+	if err != nil {
+		t.Fatalf("TempDir(): %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	vols := []*fakeFlexvolume{
+		newFakeFlexvolume(t, tmpDir, "77f29a0e-46af-4188-a6af-9ff8b8a65224", -1),
+		newFakeFlexvolume(t, tmpDir, "82b7a880-dc04-48a3-8f2d-0c6249bb53fe", 0),
+		newFakeFlexvolume(t, tmpDir, "94ae25c7-62e1-4854-9f9b-9e285c3a5ed9", 2),
+	}
+
 	for _, tc := range []struct {
 		name                string
-		podName             string
-		podNs               string
-		annotations         *VirtletAnnotations
-		environment         []*VMKeyValue
+		config              *VMConfig
+		volumeMap           map[string]string
 		expectedMetaData    map[string]interface{}
 		expectedUserData    map[string]interface{}
 		expectedUserDataStr string
 	}{
 		{
-			name:        "plain pod",
-			podName:     "foo",
-			podNs:       "default",
-			annotations: &VirtletAnnotations{},
+			name: "plain pod",
+			config: &VMConfig{
+				PodName:           "foo",
+				PodNamespace:      "default",
+				ParsedAnnotations: &VirtletAnnotations{},
+			},
 			expectedMetaData: map[string]interface{}{
 				"instance-id":    "foo.default",
 				"local-hostname": "foo",
@@ -52,11 +94,13 @@ func TestCloudInitGenerator(t *testing.T) {
 			expectedUserData: nil,
 		},
 		{
-			name:    "pod with ssh keys",
-			podName: "foo",
-			podNs:   "default",
-			annotations: &VirtletAnnotations{
-				SSHKeys: []string{"key1", "key2"},
+			name: "pod with ssh keys",
+			config: &VMConfig{
+				PodName:      "foo",
+				PodNamespace: "default",
+				ParsedAnnotations: &VirtletAnnotations{
+					SSHKeys: []string{"key1", "key2"},
+				},
 			},
 			expectedMetaData: map[string]interface{}{
 				"instance-id":    "foo.default",
@@ -66,13 +110,15 @@ func TestCloudInitGenerator(t *testing.T) {
 			expectedUserData: nil,
 		},
 		{
-			name:    "pod with ssh keys and meta-data override",
-			podName: "foo",
-			podNs:   "default",
-			annotations: &VirtletAnnotations{
-				SSHKeys: []string{"key1", "key2"},
-				MetaData: map[string]interface{}{
-					"instance-id": "foobar",
+			name: "pod with ssh keys and meta-data override",
+			config: &VMConfig{
+				PodName:      "foo",
+				PodNamespace: "default",
+				ParsedAnnotations: &VirtletAnnotations{
+					SSHKeys: []string{"key1", "key2"},
+					MetaData: map[string]interface{}{
+						"instance-id": "foobar",
+					},
 				},
 			},
 			expectedMetaData: map[string]interface{}{
@@ -83,18 +129,20 @@ func TestCloudInitGenerator(t *testing.T) {
 			expectedUserData: nil,
 		},
 		{
-			name:    "pod with user data",
-			podName: "foo",
-			podNs:   "default",
-			annotations: &VirtletAnnotations{
-				UserData: map[string]interface{}{
-					"users": []interface{}{
-						map[string]interface{}{
-							"name": "cloudy",
+			name: "pod with user data",
+			config: &VMConfig{
+				PodName:      "foo",
+				PodNamespace: "default",
+				ParsedAnnotations: &VirtletAnnotations{
+					UserData: map[string]interface{}{
+						"users": []interface{}{
+							map[string]interface{}{
+								"name": "cloudy",
+							},
 						},
 					},
+					SSHKeys: []string{"key1", "key2"},
 				},
-				SSHKeys: []string{"key1", "key2"},
 			},
 			expectedMetaData: map[string]interface{}{
 				"instance-id":    "foo.default",
@@ -110,13 +158,15 @@ func TestCloudInitGenerator(t *testing.T) {
 			},
 		},
 		{
-			name:        "pod with env variables",
-			podName:     "foo",
-			podNs:       "default",
-			annotations: &VirtletAnnotations{},
-			environment: []*VMKeyValue{
-				{"foo", "bar"},
-				{"baz", "abc"},
+			name: "pod with env variables",
+			config: &VMConfig{
+				PodName:           "foo",
+				PodNamespace:      "default",
+				ParsedAnnotations: &VirtletAnnotations{},
+				Environment: []*VMKeyValue{
+					{"foo", "bar"},
+					{"baz", "abc"},
+				},
 			},
 			expectedMetaData: map[string]interface{}{
 				"instance-id":    "foo.default",
@@ -132,27 +182,29 @@ func TestCloudInitGenerator(t *testing.T) {
 			},
 		},
 		{
-			name:    "pod with env variables and user data",
-			podName: "foo",
-			podNs:   "default",
-			annotations: &VirtletAnnotations{
-				UserData: map[string]interface{}{
-					"users": []interface{}{
-						map[string]interface{}{
-							"name": "cloudy",
+			name: "pod with env variables and user data",
+			config: &VMConfig{
+				PodName:      "foo",
+				PodNamespace: "default",
+				ParsedAnnotations: &VirtletAnnotations{
+					UserData: map[string]interface{}{
+						"users": []interface{}{
+							map[string]interface{}{
+								"name": "cloudy",
+							},
 						},
-					},
-					"write_files": []interface{}{
-						map[string]interface{}{
-							"path":    "/etc/foobar",
-							"content": "whatever",
+						"write_files": []interface{}{
+							map[string]interface{}{
+								"path":    "/etc/foobar",
+								"content": "whatever",
+							},
 						},
 					},
 				},
-			},
-			environment: []*VMKeyValue{
-				{"foo", "bar"},
-				{"baz", "abc"},
+				Environment: []*VMKeyValue{
+					{"foo", "bar"},
+					{"baz", "abc"},
+				},
 			},
 			expectedMetaData: map[string]interface{}{
 				"instance-id":    "foo.default",
@@ -177,12 +229,14 @@ func TestCloudInitGenerator(t *testing.T) {
 			},
 		},
 		{
-			name:    "pod with user data script",
-			podName: "foo",
-			podNs:   "default",
-			annotations: &VirtletAnnotations{
-				UserDataScript: "#!/bin/sh\necho hi\n",
-				SSHKeys:        []string{"key1", "key2"},
+			name: "pod with user data script",
+			config: &VMConfig{
+				PodName:      "foo",
+				PodNamespace: "default",
+				ParsedAnnotations: &VirtletAnnotations{
+					UserDataScript: "#!/bin/sh\necho hi\n",
+					SSHKeys:        []string{"key1", "key2"},
+				},
 			},
 			expectedMetaData: map[string]interface{}{
 				"instance-id":    "foo.default",
@@ -191,14 +245,47 @@ func TestCloudInitGenerator(t *testing.T) {
 			},
 			expectedUserDataStr: "#!/bin/sh\necho hi\n",
 		},
+		{
+			name: "pod with volumes to mount",
+			config: &VMConfig{
+				PodName:           "foo",
+				PodNamespace:      "default",
+				ParsedAnnotations: &VirtletAnnotations{},
+				Mounts: []*VMMount{
+					{
+						ContainerPath: "/opt",
+						HostPath:      vols[0].path,
+					},
+					{
+						ContainerPath: "/var/lib/whatever",
+						HostPath:      vols[1].path,
+					},
+					{
+						ContainerPath: "/var/lib/foobar",
+						HostPath:      vols[2].path,
+					},
+				},
+			},
+			volumeMap: map[string]string{
+				vols[0].uuid: "/dev/sdb",
+				vols[1].uuid: "/dev/sdc",
+				vols[2].uuid: "/dev/sdd",
+			},
+			expectedMetaData: map[string]interface{}{
+				"instance-id":    "foo.default",
+				"local-hostname": "foo",
+			},
+			expectedUserData: map[string]interface{}{
+				"mounts": []interface{}{
+					[]interface{}{"/dev/sdb1", "/opt"},
+					[]interface{}{"/dev/sdc", "/var/lib/whatever"},
+					[]interface{}{"/dev/sdd2", "/var/lib/foobar"},
+				},
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			g := NewCloudInitGenerator(&VMConfig{
-				PodName:           tc.podName,
-				PodNamespace:      tc.podNs,
-				ParsedAnnotations: tc.annotations,
-				Environment:       tc.environment,
-			})
+			g := NewCloudInitGenerator(tc.config, tc.volumeMap)
 
 			metaDataBytes, err := g.generateMetaData()
 			if err != nil {
@@ -242,7 +329,7 @@ func TestGenerateDisk(t *testing.T) {
 		PodName:           "foo",
 		PodNamespace:      "default",
 		ParsedAnnotations: &VirtletAnnotations{},
-	})
+	}, nil)
 	isoPath, diskDef, err := g.GenerateDisk()
 	if err != nil {
 		t.Fatalf("GenerateDisk(): %v", err)

--- a/pkg/libvirttools/cloudinit_test.go
+++ b/pkg/libvirttools/cloudinit_test.go
@@ -249,10 +249,9 @@ func TestGenerateDisk(t *testing.T) {
 	}
 	if !reflect.DeepEqual(diskDef, &libvirtxml.DomainDisk{
 		Type:     "file",
-		Device:   "disk",
+		Device:   "cdrom",
 		Driver:   &libvirtxml.DomainDiskDriver{Name: "qemu", Type: "raw"},
 		Source:   &libvirtxml.DomainDiskSource{File: isoPath},
-		Target:   &libvirtxml.DomainDiskTarget{Bus: "virtio"},
 		ReadOnly: &libvirtxml.DomainDiskReadOnly{},
 	}) {
 		t.Errorf("Bad disk definition:\n%s", spew.Sdump(diskDef))

--- a/pkg/libvirttools/diskdriver.go
+++ b/pkg/libvirttools/diskdriver.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2016-2017 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package libvirttools
+
+import (
+	"errors"
+	"fmt"
+
+	libvirtxml "github.com/libvirt/libvirt-go-xml"
+)
+
+const (
+	minBlockDevChar = 'a'
+	// https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/5/html/Virtualization/sect-Virtualization-Virtualization_limitations-KVM_limitations.html
+	// Actually there can be more than 21 block devices (including
+	// the root volume), but we want to be on the safe side here
+	maxVirtioBlockDevChar = 'u'
+	maxScsiBlockDevChar   = 'z'
+)
+
+type diskDriverFunc func(n int) (string, *libvirtxml.DomainDiskTarget, *libvirtxml.DomainAddress, error)
+
+var diskDriverMap = map[DiskDriver]diskDriverFunc{
+	DiskDriverVirtio: virtioBlkDriver,
+	DiskDriverScsi:   scsiDriver,
+}
+
+func virtioBlkDriver(n int) (string, *libvirtxml.DomainDiskTarget, *libvirtxml.DomainAddress, error) {
+	diskChar := minBlockDevChar + n
+	if diskChar > maxVirtioBlockDevChar {
+		return "", nil, nil, errors.New("too many virtio block devices")
+	}
+	virtDev := fmt.Sprintf("vd%c", diskChar)
+	diskTarget := &libvirtxml.DomainDiskTarget{
+		Dev: virtDev,
+		Bus: "virtio",
+	}
+	domain := uint(0)
+	// use bus1 to have more predictable addressing for virtio devs
+	bus := uint(1)
+	slot := uint(n + 1)
+	function := uint(0)
+	diskAddress := &libvirtxml.DomainAddress{
+		Type:     "pci",
+		Domain:   &domain,
+		Bus:      &bus,
+		Slot:     &slot,
+		Function: &function,
+	}
+	return "/dev/" + virtDev, diskTarget, diskAddress, nil
+}
+
+func scsiDriver(n int) (string, *libvirtxml.DomainDiskTarget, *libvirtxml.DomainAddress, error) {
+	diskChar := minBlockDevChar + n
+	if diskChar > maxScsiBlockDevChar {
+		return "", nil, nil, errors.New("too many scsi block devices")
+	}
+	virtDev := fmt.Sprintf("sd%c", diskChar)
+	diskTarget := &libvirtxml.DomainDiskTarget{
+		Dev: virtDev,
+		Bus: "scsi",
+	}
+	controller := uint(0)
+	bus := uint(0)
+	target := uint(0)
+	unit := uint(n)
+	diskAddress := &libvirtxml.DomainAddress{
+		Type:       "drive",
+		Controller: &controller,
+		Bus:        &bus,
+		Target:     &target,
+		Unit:       &unit,
+	}
+	// FIXME: in case of cdrom, that's actually sr0, but we're
+	// only using cdrom for nocloud drive currently
+	return "/dev/" + virtDev, diskTarget, diskAddress, nil
+}
+
+func getDiskDriverFunc(name DiskDriver) (diskDriverFunc, error) {
+	if f, found := diskDriverMap[name]; found {
+		return f, nil
+	}
+	return nil, fmt.Errorf("bad disk driver name: %q", name)
+}

--- a/pkg/libvirttools/kubeapi.go
+++ b/pkg/libvirttools/kubeapi.go
@@ -55,5 +55,12 @@ func GetVMConfig(in *kubeapi.CreateContainerRequest) (*VMConfig, error) {
 		r.Environment = append(r.Environment, &VMKeyValue{Key: entry.Key, Value: entry.Value})
 	}
 
+	for _, mount := range in.Config.Mounts {
+		r.Mounts = append(r.Mounts, &VMMount{
+			ContainerPath: mount.ContainerPath,
+			HostPath:      mount.HostPath,
+		})
+	}
+
 	return r, nil
 }

--- a/pkg/libvirttools/nocloud_volumesource.go
+++ b/pkg/libvirttools/nocloud_volumesource.go
@@ -37,8 +37,10 @@ func GetNocloudVolume(config *VMConfig, owner VolumeOwner) ([]VMVolume, error) {
 	}, nil
 }
 
-func (v *nocloudVolume) Setup() (*libvirtxml.DomainDisk, error) {
-	g := NewCloudInitGenerator(v.config)
+func (v *nocloudVolume) Uuid() string { return "" }
+
+func (v *nocloudVolume) Setup(volumeMap map[string]string) (*libvirtxml.DomainDisk, error) {
+	g := NewCloudInitGenerator(v.config, volumeMap)
 	isoPath, nocloudDiskDef, err := g.GenerateDisk()
 	if err != nil {
 		return nil, err

--- a/pkg/libvirttools/nocloud_volumesource.go
+++ b/pkg/libvirttools/nocloud_volumesource.go
@@ -37,14 +37,13 @@ func GetNocloudVolume(config *VMConfig, owner VolumeOwner) ([]VMVolume, error) {
 	}, nil
 }
 
-func (v *nocloudVolume) Setup(virtDev string) (*libvirtxml.DomainDisk, error) {
+func (v *nocloudVolume) Setup() (*libvirtxml.DomainDisk, error) {
 	g := NewCloudInitGenerator(v.config)
 	isoPath, nocloudDiskDef, err := g.GenerateDisk()
 	if err != nil {
 		return nil, err
 	}
 	v.config.TempFile = isoPath
-	nocloudDiskDef.Target.Dev = virtDev
 	return nocloudDiskDef, nil
 }
 

--- a/pkg/libvirttools/qcow2_flexvolume.go
+++ b/pkg/libvirttools/qcow2_flexvolume.go
@@ -83,7 +83,7 @@ func (v *qcow2Volume) createQCOW2Volume(name string, capacity uint64, capacityUn
 	})
 }
 
-func (v *qcow2Volume) Setup(virtDev string) (*libvirtxml.DomainDisk, error) {
+func (v *qcow2Volume) Setup() (*libvirtxml.DomainDisk, error) {
 	vol, err := v.createQCOW2Volume(v.volumeName(), uint64(v.capacity), v.capacityUnit)
 	if err != nil {
 		return nil, fmt.Errorf("error during creation of volume '%s' with virtlet description %s: %v", v.volumeName(), v.name, err)
@@ -104,7 +104,6 @@ func (v *qcow2Volume) Setup(virtDev string) (*libvirtxml.DomainDisk, error) {
 		Device: "disk",
 		Source: &libvirtxml.DomainDiskSource{File: path},
 		Driver: &libvirtxml.DomainDiskDriver{Name: "qemu", Type: "qcow2"},
-		Target: &libvirtxml.DomainDiskTarget{Dev: virtDev, Bus: "virtio"},
 	}, nil
 }
 

--- a/pkg/libvirttools/raw_flexvolume.go
+++ b/pkg/libvirttools/raw_flexvolume.go
@@ -72,7 +72,7 @@ func (v *rawDeviceVolume) verifyRawDeviceWhitelisted(path string) error {
 	return fmt.Errorf("device '%s' not whitelisted on this virtlet node", path)
 }
 
-func (v *rawDeviceVolume) Setup(virtDev string) (*libvirtxml.DomainDisk, error) {
+func (v *rawDeviceVolume) Setup() (*libvirtxml.DomainDisk, error) {
 	if err := v.verifyRawDeviceWhitelisted(v.devPath); err != nil {
 		return nil, err
 	}
@@ -85,7 +85,6 @@ func (v *rawDeviceVolume) Setup(virtDev string) (*libvirtxml.DomainDisk, error) 
 		Device: "disk",
 		Source: &libvirtxml.DomainDiskSource{Device: v.devPath},
 		Driver: &libvirtxml.DomainDiskDriver{Name: "qemu", Type: "raw"},
-		Target: &libvirtxml.DomainDiskTarget{Dev: virtDev, Bus: "virtio"},
 	}, nil
 }
 

--- a/pkg/libvirttools/root_volumesource.go
+++ b/pkg/libvirttools/root_volumesource.go
@@ -51,7 +51,7 @@ func (v *rootVolume) cloneVolume(name string, from virt.VirtStorageVolume) (virt
 	}, from)
 }
 
-func (v *rootVolume) Setup(virtDev string) (*libvirtxml.DomainDisk, error) {
+func (v *rootVolume) Setup() (*libvirtxml.DomainDisk, error) {
 	imageVolume, err := v.owner.ImageManager().GetImageVolume(v.config.Image)
 	if err != nil {
 		return nil, err
@@ -71,7 +71,6 @@ func (v *rootVolume) Setup(virtDev string) (*libvirtxml.DomainDisk, error) {
 		Device: "disk",
 		Driver: &libvirtxml.DomainDiskDriver{Name: "qemu", Type: "qcow2"},
 		Source: &libvirtxml.DomainDiskSource{File: volPath},
-		Target: &libvirtxml.DomainDiskTarget{Dev: virtDev, Bus: "virtio"},
 	}, nil
 }
 

--- a/pkg/libvirttools/root_volumesource.go
+++ b/pkg/libvirttools/root_volumesource.go
@@ -51,7 +51,9 @@ func (v *rootVolume) cloneVolume(name string, from virt.VirtStorageVolume) (virt
 	}, from)
 }
 
-func (v *rootVolume) Setup() (*libvirtxml.DomainDisk, error) {
+func (v *rootVolume) Uuid() string { return "" }
+
+func (v *rootVolume) Setup(volumeMap map[string]string) (*libvirtxml.DomainDisk, error) {
 	imageVolume, err := v.owner.ImageManager().GetImageVolume(v.config.Image)
 	if err != nil {
 		return nil, err

--- a/pkg/libvirttools/virtualization_test.go
+++ b/pkg/libvirttools/virtualization_test.go
@@ -292,6 +292,12 @@ func TestDomainDefinitions(t *testing.T) {
                                   - name: cloudy`,
 			},
 		},
+		{
+			name: "virtio disk driver",
+			annotations: map[string]string{
+				"VirtletDiskDriver": "virtio",
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			rec := fake.NewToplevelRecorder()

--- a/pkg/libvirttools/virtualization_test.go
+++ b/pkg/libvirttools/virtualization_test.go
@@ -37,6 +37,7 @@ import (
 const (
 	fakeImageName = "fake/image1"
 	fakeCNIConfig = `{"noCniForNow":true}`
+	fakeUuid      = "abb67e3c-71b3-4ddd-5505-8c4215d5c4eb"
 )
 
 type containerTester struct {
@@ -91,8 +92,10 @@ func newContainerTester(t *testing.T, rec *fake.TopLevelRecorder) *containerTest
 
 	volSrc := CombineVMVolumeSources(
 		GetRootVolume,
-		GetNocloudVolume,
-		ScanFlexvolumes)
+		ScanFlexvolumes,
+		// XXX: GetNocloudVolume must go last because it
+		// doesn't produce correct name for cdrom devices
+		GetNocloudVolume)
 	ct.virtTool, err = NewVirtualizationTool(domainConn, storageConn, imageTool, ct.boltClient, "volumes", "loop*", volSrc)
 	if err != nil {
 		t.Fatalf("failed to create VirtualizationTool: %v", err)
@@ -222,12 +225,21 @@ func TestContainerLifecycle(t *testing.T) {
 	gm.Verify(t, ct.rec.Content())
 }
 
+type volMount struct {
+	name          string
+	containerPath string
+}
+
 func TestDomainDefinitions(t *testing.T) {
-	flexVolumeDriver := flexvolume.NewFlexVolumeDriver(flexvolume.NullMounter)
+	flexVolumeDriver := flexvolume.NewFlexVolumeDriver(func() string {
+		// note that this is only good for just one flexvolume
+		return fakeUuid
+	}, flexvolume.NullMounter)
 	for _, tc := range []struct {
 		name        string
 		annotations map[string]string
 		flexVolumes map[string]map[string]interface{}
+		mounts      []volMount
 	}{
 		{
 			name: "plain domain",
@@ -276,6 +288,12 @@ func TestDomainDefinitions(t *testing.T) {
 					"user":    "libvirt",
 				},
 			},
+			mounts: []volMount{
+				{
+					name:          "ceph",
+					containerPath: "/var/lib/whatever",
+				},
+			},
 		},
 		{
 			name: "cloud-init",
@@ -322,6 +340,13 @@ func TestDomainDefinitions(t *testing.T) {
 				}
 			}
 
+			var mounts []*kubeapi.Mount
+			for _, m := range tc.mounts {
+				mounts = append(mounts, &kubeapi.Mount{
+					HostPath:      filepath.Join(ct.kubeletRootDir, sandbox.Metadata.Uid, "volumes/virtlet~flexvolume_driver", m.name),
+					ContainerPath: m.containerPath,
+				})
+			}
 			req := &kubeapi.CreateContainerRequest{
 				PodSandboxId: sandbox.Metadata.Uid,
 				Config: &kubeapi.ContainerConfig{
@@ -331,6 +356,7 @@ func TestDomainDefinitions(t *testing.T) {
 					Image: &kubeapi.ImageSpec{
 						Image: fakeImageName,
 					},
+					Mounts: mounts,
 				},
 				SandboxConfig: sandbox,
 			}

--- a/pkg/libvirttools/vmconfig.go
+++ b/pkg/libvirttools/vmconfig.go
@@ -22,6 +22,13 @@ type VMKeyValue struct {
 	Value string
 }
 
+// VMMount denotes a host directory corresponding to a volume which is
+// to be mounted inside the VM
+type VMMount struct {
+	ContainerPath string
+	HostPath      string
+}
+
 // VMConfig contains the information needed to start create a VM
 // TODO: use this struct to store VM metadata
 type VMConfig struct {
@@ -58,6 +65,9 @@ type VMConfig struct {
 	DomainUUID string
 	// Environment variables to set in the VM
 	Environment []*VMKeyValue
+	// Host directories corresponding to the volumes which are to
+	// be mounted inside the VM
+	Mounts []*VMMount
 	// A temporary file or directory associated with this domain.
 	// Currently used by nocloudVolume
 	// TODO: this field should be moved to VMStatus.

--- a/pkg/libvirttools/volumes.go
+++ b/pkg/libvirttools/volumes.go
@@ -42,7 +42,8 @@ type VolumeOwner interface {
 type VMVolumeSource func(config *VMConfig, owner VolumeOwner) ([]VMVolume, error)
 
 type VMVolume interface {
-	Setup() (*libvirtxml.DomainDisk, error)
+	Uuid() string
+	Setup(volumeMap map[string]string) (*libvirtxml.DomainDisk, error)
 	Teardown() error
 }
 

--- a/pkg/libvirttools/volumes.go
+++ b/pkg/libvirttools/volumes.go
@@ -42,7 +42,7 @@ type VolumeOwner interface {
 type VMVolumeSource func(config *VMConfig, owner VolumeOwner) ([]VMVolume, error)
 
 type VMVolume interface {
-	Setup(virtDev string) (*libvirtxml.DomainDisk, error)
+	Setup() (*libvirtxml.DomainDisk, error)
 	Teardown() error
 }
 

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -80,8 +80,10 @@ func NewVirtletManager(libvirtUri, poolName, downloadProtocol, storageBackend, m
 	// TODO: there should be easy-to-use VirtualizationTool (or at least VMVolumeSource) provider
 	volSrc := libvirttools.CombineVMVolumeSources(
 		libvirttools.GetRootVolume,
-		libvirttools.GetNocloudVolume,
-		libvirttools.ScanFlexvolumes)
+		libvirttools.ScanFlexvolumes,
+		// XXX: GetNocloudVolume must go last because it
+		// doesn't produce correct name for cdrom devices
+		libvirttools.GetNocloudVolume)
 	// TODO: pool name should be passed like for imageTool
 	libvirtVirtualizationTool, err := libvirttools.NewVirtualizationTool(conn, conn, libvirtImageTool, boltClient, "volumes", rawDevices, volSrc)
 	if err != nil {

--- a/pkg/utils/json.go
+++ b/pkg/utils/json.go
@@ -63,7 +63,7 @@ func WriteJson(filename string, v interface{}, perm os.FileMode) error {
 		return fmt.Errorf("couldn't marshal the data to JSON for %q: %v", filename, err)
 	}
 	if err := ioutil.WriteFile(filename, content, perm); err != nil {
-		return fmt.Errorf("error writing JSON data file %q: %V", filename, err)
+		return fmt.Errorf("error writing JSON data file %q: %v", filename, err)
 	}
 	return nil
 }

--- a/tests/e2e/e2e.sh
+++ b/tests/e2e/e2e.sh
@@ -152,7 +152,7 @@ fi
 # wait for login prompt to appear
 vmchat-short cirros-vm-rbd
 
-"${vmssh}" cirros@cirros-vm-rbd 'sudo /usr/sbin/mkfs.ext2 /dev/vdc && sudo mount /dev/vdc /mnt && ls -l /mnt | grep lost+found'
+"${vmssh}" cirros@cirros-vm-rbd 'sudo /usr/sbin/mkfs.ext2 /dev/vdb && sudo mount /dev/vdb /mnt && ls -l /mnt | grep lost+found'
 
 # check vnc consoles are available for both domains
 if ! kubectl exec "${virtlet_pod_name}" -c virtlet --namespace=kube-system -- /bin/sh -c "apt-get install -y vncsnapshot"; then

--- a/tests/integration/container_test.go
+++ b/tests/integration/container_test.go
@@ -70,7 +70,7 @@ func newContainerTester(t *testing.T) *containerTester {
 			{Image: imageCirrosUrl},
 			{Image: imageCirrosUrl2},
 		},
-		fv: flexvolume.NewFlexVolumeDriver(flexvolume.NewLinuxMounter()),
+		fv: flexvolume.NewFlexVolumeDriver(utils.NewUuid, flexvolume.NewLinuxMounter()),
 	}
 }
 


### PR DESCRIPTION
- [x] use `virtio-scsi` for disks by default to  get more predictable disk ordering
- [x] support mounting flexvolumes into VM via cloud-init
- [x] update docs

Fixes #287

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/317)
<!-- Reviewable:end -->
