### PR TITLE
Fix CNI failure handling

### DIFF
--- a/pkg/bolttools/sandbox.go
+++ b/pkg/bolttools/sandbox.go
@@ -37,7 +37,7 @@ func (b *BoltClient) EnsureSandboxSchema() error {
 	})
 }
 
-func (b *BoltClient) SetPodSandbox(config *kubeapi.PodSandboxConfig, networkConfiguration []byte, timeFunc func() time.Time) error {
+func (b *BoltClient) SetPodSandbox(config *kubeapi.PodSandboxConfig, networkConfiguration []byte, state kubeapi.PodSandboxState, timeFunc func() time.Time) error {
 	podId := config.Metadata.Uid
 
 	strLabels, err := json.Marshal(config.GetLabels())
@@ -95,7 +95,7 @@ func (b *BoltClient) SetPodSandbox(config *kubeapi.PodSandboxConfig, networkConf
 			return err
 		}
 
-		if err := sandboxBucket.Put([]byte("state"), []byte{byte(kubeapi.PodSandboxState_SANDBOX_READY)}); err != nil {
+		if err := sandboxBucket.Put([]byte("state"), []byte{byte(state)}); err != nil {
 			return err
 		}
 

--- a/pkg/bolttools/sandbox_test.go
+++ b/pkg/bolttools/sandbox_test.go
@@ -57,7 +57,7 @@ func TestRemovePodSandbox(t *testing.T) {
 		uid := ""
 		if tc.sandbox != nil {
 			uid = tc.sandbox.GetMetadata().Uid
-			if err := b.SetPodSandbox(tc.sandbox, []byte{}, time.Now); err != nil {
+			if err := b.SetPodSandbox(tc.sandbox, []byte{}, kubeapi.PodSandboxState_SANDBOX_READY, time.Now); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/pkg/bolttools/utils_test.go
+++ b/pkg/bolttools/utils_test.go
@@ -170,7 +170,7 @@ func SetUpBolt(t *testing.T, sandboxConfigs []*kubeapi.PodSandboxConfig, contain
 	}
 
 	for _, sandbox := range sandboxConfigs {
-		if err := b.SetPodSandbox(sandbox, []byte{}, time.Now); err != nil {
+		if err := b.SetPodSandbox(sandbox, []byte{}, kubeapi.PodSandboxState_SANDBOX_READY, time.Now); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/pkg/libvirttools/virtualization_test.go
+++ b/pkg/libvirttools/virtualization_test.go
@@ -121,7 +121,7 @@ func newContainerTester(t *testing.T, rec *fake.TopLevelRecorder) *containerTest
 }
 
 func (ct *containerTester) setPodSandbox(config *kubeapi.PodSandboxConfig) {
-	if err := ct.boltClient.SetPodSandbox(config, []byte(fakeCNIConfig), ct.fakeTime); err != nil {
+	if err := ct.boltClient.SetPodSandbox(config, []byte(fakeCNIConfig), kubeapi.PodSandboxState_SANDBOX_READY, ct.fakeTime); err != nil {
 		ct.t.Fatalf("Failed to store pod sandbox: %v", err)
 	}
 }

--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -46,7 +46,7 @@ type ImageMetadataStore interface {
 
 // SandboxMetadataStore contains methods to operate on POD sandboxes
 type SandboxMetadataStore interface {
-	SetPodSandbox(config *kubeapi.PodSandboxConfig, networkConfiguration []byte, timeFunc func() time.Time) error
+	SetPodSandbox(config *kubeapi.PodSandboxConfig, networkConfiguration []byte, state kubeapi.PodSandboxState, timeFunc func() time.Time) error
 	UpdatePodState(podId string, state byte) error
 	RemovePodSandbox(podId string) error
 	GetPodSandboxContainerID(podId string) (string, error)


### PR DESCRIPTION
Return pod sandbox id even if network setup is failed
Return SANDBOX_NOTREADY state for pods with failed networks
Do pod network teardown upon sandbox stop

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/324)
<!-- Reviewable:end -->
