### PR TITLE
Fix hung domains and other VM lifecycle edge cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,7 @@ addons:
 
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install -y expect
-  - sudo apt-get install libxml2-utils
+  - sudo apt-get install -y libxml2-utils jq
 
 before_script:
   - sudo /etc/init.d/mysql stop

--- a/examples/ubuntu-vm.yaml
+++ b/examples/ubuntu-vm.yaml
@@ -18,6 +18,10 @@ spec:
             operator: In
             values:
             - virtlet
+  # This is the number of seconds Virtlet gives the VM to shut down cleanly.
+  # The default value of 30 seconds is ok for containers but probably too
+  # low for VM, so overriding it here is strongly advised.
+  terminationGracePeriodSeconds: 120
   containers:
   - name: ubuntu-vm
     image: virtlet/cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: c3e8bb2d74e1ee4ba62edccda9945b80238226e5236c91456a23a945446a080c
-updated: 2017-06-10T18:28:53.78884615+03:00
+hash: 6614ef51794b9d3b6dd265c4fb11ab1bfa0c3e5dde84198ed5401844987754f7
+updated: 2017-06-19T16:15:10.800293005+03:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -228,6 +228,8 @@ imports:
   - winfile
 - name: github.com/jmespath/go-jmespath
   version: 3433f3ea46d9f8019119e7dd41274e112a2359a9
+- name: github.com/jonboulle/clockwork
+  version: bcac9884e7502bb2b474c0339d889cb981a2f27f
 - name: github.com/juju/ratelimit
   version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/kr/pty
@@ -371,11 +373,11 @@ imports:
   - peer
   - transport
 - name: gopkg.in/fsnotify.v1
-  version: 96c060f6a6b7e0d6f75fddd10efeaca3e5d1bcb0
+  version: 7be54206639f256967dd82fa767397ba5f8f48f5
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/tomb.v1
-  version: dd632973f1e7218eb1089048e0798ec9ae7dceb8
+  version: c131134a1947e9afd9cecfe11f4c6dff0732ae58
 - name: gopkg.in/yaml.v2
   version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
 - name: k8s.io/apimachinery

--- a/glide.yaml
+++ b/glide.yaml
@@ -32,3 +32,5 @@ import:
   version: 76153773eaa3a268131d3d993290a194a1370585
 - package: k8s.io/apimachinery
   version: 75b8dd260ef0469d96d578705a87cffd0e09dab8
+- package: github.com/jonboulle/clockwork
+  version: bcac9884e7502bb2b474c0339d889cb981a2f27f

--- a/pkg/bolttools/sandbox.go
+++ b/pkg/bolttools/sandbox.go
@@ -20,9 +20,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
-	"time"
 
 	"github.com/boltdb/bolt"
+	"github.com/jonboulle/clockwork"
 	"k8s.io/apimachinery/pkg/fields"
 	kubeapi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 )
@@ -37,7 +37,7 @@ func (b *BoltClient) EnsureSandboxSchema() error {
 	})
 }
 
-func (b *BoltClient) SetPodSandbox(config *kubeapi.PodSandboxConfig, networkConfiguration []byte, state kubeapi.PodSandboxState, timeFunc func() time.Time) error {
+func (b *BoltClient) SetPodSandbox(config *kubeapi.PodSandboxConfig, networkConfiguration []byte, state kubeapi.PodSandboxState, clock clockwork.Clock) error {
 	podId := config.Metadata.Uid
 
 	strLabels, err := json.Marshal(config.GetLabels())
@@ -75,7 +75,7 @@ func (b *BoltClient) SetPodSandbox(config *kubeapi.PodSandboxConfig, networkConf
 			return err
 		}
 
-		if err := sandboxBucket.Put([]byte("createdAt"), []byte(strconv.FormatInt(timeFunc().UnixNano(), 10))); err != nil {
+		if err := sandboxBucket.Put([]byte("createdAt"), []byte(strconv.FormatInt(clock.Now().UnixNano(), 10))); err != nil {
 			return err
 		}
 

--- a/pkg/bolttools/sandbox_test.go
+++ b/pkg/bolttools/sandbox_test.go
@@ -19,8 +19,8 @@ package bolttools
 import (
 	"reflect"
 	"testing"
-	"time"
 
+	"github.com/jonboulle/clockwork"
 	kubeapi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 
 	"github.com/Mirantis/virtlet/tests/criapi"
@@ -57,7 +57,7 @@ func TestRemovePodSandbox(t *testing.T) {
 		uid := ""
 		if tc.sandbox != nil {
 			uid = tc.sandbox.GetMetadata().Uid
-			if err := b.SetPodSandbox(tc.sandbox, []byte{}, kubeapi.PodSandboxState_SANDBOX_READY, time.Now); err != nil {
+			if err := b.SetPodSandbox(tc.sandbox, []byte{}, kubeapi.PodSandboxState_SANDBOX_READY, clockwork.NewRealClock()); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/pkg/bolttools/utils_test.go
+++ b/pkg/bolttools/utils_test.go
@@ -19,11 +19,12 @@ package bolttools
 import (
 	"fmt"
 	"testing"
-	"time"
+
+	"github.com/boltdb/bolt"
+	"github.com/jonboulle/clockwork"
+	kubeapi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 
 	"github.com/Mirantis/virtlet/tests/criapi"
-	"github.com/boltdb/bolt"
-	kubeapi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 )
 
 func TestGet(t *testing.T) {
@@ -169,8 +170,9 @@ func SetUpBolt(t *testing.T, sandboxConfigs []*kubeapi.PodSandboxConfig, contain
 		t.Fatal(err)
 	}
 
+	clock := clockwork.NewRealClock()
 	for _, sandbox := range sandboxConfigs {
-		if err := b.SetPodSandbox(sandbox, []byte{}, kubeapi.PodSandboxState_SANDBOX_READY, time.Now); err != nil {
+		if err := b.SetPodSandbox(sandbox, []byte{}, kubeapi.PodSandboxState_SANDBOX_READY, clock); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -180,7 +182,7 @@ func SetUpBolt(t *testing.T, sandboxConfigs []*kubeapi.PodSandboxConfig, contain
 	}
 
 	for _, container := range containerConfigs {
-		if err := b.SetContainer(container.Name, container.ContainerId, container.SandboxId, container.Image, container.RootImageVolumeName, container.Labels, container.Annotations, "/tmp/nocloud.iso", time.Now); err != nil {
+		if err := b.SetContainer(container.Name, container.ContainerId, container.SandboxId, container.Image, container.RootImageVolumeName, container.Labels, container.Annotations, "/tmp/nocloud.iso", clock); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/pkg/bolttools/virtualization.go
+++ b/pkg/bolttools/virtualization.go
@@ -20,12 +20,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
-	"time"
 
 	"github.com/boltdb/bolt"
 	kubeapi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 
 	"github.com/Mirantis/virtlet/pkg/metadata"
+	"github.com/jonboulle/clockwork"
 )
 
 func (b *BoltClient) EnsureVirtualizationSchema() error {
@@ -40,7 +40,7 @@ func (b *BoltClient) EnsureVirtualizationSchema() error {
 	return err
 }
 
-func (b *BoltClient) SetContainer(name, containerId, sandboxId, image, rootImageVolumeName string, labels, annotations map[string]string, nocloudFile string, timeFunc func() time.Time) error {
+func (b *BoltClient) SetContainer(name, containerId, sandboxId, image, rootImageVolumeName string, labels, annotations map[string]string, nocloudFile string, clock clockwork.Clock) error {
 	strLabels, err := json.Marshal(labels)
 	if err != nil {
 		return err
@@ -66,7 +66,7 @@ func (b *BoltClient) SetContainer(name, containerId, sandboxId, image, rootImage
 			return err
 		}
 
-		if err := bucket.Put([]byte("createdAt"), []byte(strconv.FormatInt(timeFunc().UnixNano(), 10))); err != nil {
+		if err := bucket.Put([]byte("createdAt"), []byte(strconv.FormatInt(clock.Now().UnixNano(), 10))); err != nil {
 			return err
 		}
 

--- a/pkg/libvirttools/TestContainerLifecycle.json
+++ b/pkg/libvirttools/TestContainerLifecycle.json
@@ -444,7 +444,7 @@
     "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Create"
   },
   {
-    "name": "container status the container is created",
+    "name": "container status after the container is started",
     "data": {
       "id": "231700d5-c9a6-5a49-738d-99a954c51550",
       "metadata": {
@@ -469,7 +469,7 @@
     "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Shutdown"
   },
   {
-    "name": "container status the container is stopped",
+    "name": "container status after the container is stopped",
     "data": {
       "id": "231700d5-c9a6-5a49-738d-99a954c51550",
       "metadata": {
@@ -489,9 +489,6 @@
         "io.kubernetes.pod.uid": "69eec606-0493-5825-73a4-c5e0c0236155"
       }
     }
-  },
-  {
-    "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Shutdown"
   },
   {
     "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"

--- a/pkg/libvirttools/TestDomainDefinitions__ceph_flexvolume.json
+++ b/pkg/libvirttools/TestDomainDefinitions__ceph_flexvolume.json
@@ -491,9 +491,6 @@
     }
   },
   {
-    "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Shutdown"
-  },
-  {
     "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
   },
   {

--- a/pkg/libvirttools/TestDomainDefinitions__cloud-init.json
+++ b/pkg/libvirttools/TestDomainDefinitions__cloud-init.json
@@ -408,9 +408,6 @@
     }
   },
   {
-    "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Shutdown"
-  },
-  {
     "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
   },
   {

--- a/pkg/libvirttools/TestDomainDefinitions__cloud-init_with_user_data.json
+++ b/pkg/libvirttools/TestDomainDefinitions__cloud-init_with_user_data.json
@@ -408,9 +408,6 @@
     }
   },
   {
-    "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Shutdown"
-  },
-  {
     "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
   },
   {

--- a/pkg/libvirttools/TestDomainDefinitions__plain_domain.json
+++ b/pkg/libvirttools/TestDomainDefinitions__plain_domain.json
@@ -408,9 +408,6 @@
     }
   },
   {
-    "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Shutdown"
-  },
-  {
     "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
   },
   {

--- a/pkg/libvirttools/TestDomainDefinitions__raw_devices.json
+++ b/pkg/libvirttools/TestDomainDefinitions__raw_devices.json
@@ -454,9 +454,6 @@
     }
   },
   {
-    "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Shutdown"
-  },
-  {
     "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
   },
   {

--- a/pkg/libvirttools/TestDomainDefinitions__vcpu_count.json
+++ b/pkg/libvirttools/TestDomainDefinitions__vcpu_count.json
@@ -408,9 +408,6 @@
     }
   },
   {
-    "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Shutdown"
-  },
-  {
     "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
   },
   {

--- a/pkg/libvirttools/TestDomainDefinitions__volumes.json
+++ b/pkg/libvirttools/TestDomainDefinitions__volumes.json
@@ -657,9 +657,6 @@
     }
   },
   {
-    "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Shutdown"
-  },
-  {
     "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
   },
   {

--- a/pkg/libvirttools/TestDomainForcedShutdown.json
+++ b/pkg/libvirttools/TestDomainForcedShutdown.json
@@ -234,22 +234,22 @@
               "StartupPolicy": ""
             },
             "Target": {
-              "Dev": "vda",
-              "Bus": "virtio"
+              "Dev": "sda",
+              "Bus": "scsi"
             },
             "Serial": "",
             "ReadOnly": null,
             "Shareable": null,
             "Address": {
-              "Type": "pci",
-              "Controller": null,
-              "Domain": 0,
-              "Bus": 1,
+              "Type": "drive",
+              "Controller": 0,
+              "Domain": null,
+              "Bus": 0,
               "Port": null,
-              "Slot": 1,
-              "Function": 0,
-              "Target": null,
-              "Unit": null
+              "Slot": null,
+              "Function": null,
+              "Target": 0,
+              "Unit": 0
             },
             "Boot": null
           },
@@ -280,22 +280,22 @@
               "StartupPolicy": ""
             },
             "Target": {
-              "Dev": "vdb",
-              "Bus": "virtio"
+              "Dev": "sdb",
+              "Bus": "scsi"
             },
             "Serial": "",
             "ReadOnly": {},
             "Shareable": null,
             "Address": {
-              "Type": "pci",
-              "Controller": null,
-              "Domain": 0,
-              "Bus": 1,
+              "Type": "drive",
+              "Controller": 0,
+              "Domain": null,
+              "Bus": 0,
               "Port": null,
-              "Slot": 2,
-              "Function": 0,
-              "Target": null,
-              "Unit": null
+              "Slot": null,
+              "Function": null,
+              "Target": 0,
+              "Unit": 1
             },
             "Boot": null
           }
@@ -406,6 +406,58 @@
         ]
       }
     }
+  },
+  {
+    "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Create"
+  },
+  {
+    "name": "invoking StopContainer()"
+  },
+  {
+    "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Shutdown",
+    "data": {
+      "ignored": true
+    }
+  },
+  {
+    "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Shutdown",
+    "data": {
+      "ignored": true
+    }
+  },
+  {
+    "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Shutdown",
+    "data": {
+      "ignored": true
+    }
+  },
+  {
+    "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Destroy"
+  },
+  {
+    "name": "container status after the container is stopped",
+    "data": {
+      "id": "231700d5-c9a6-5a49-738d-99a954c51550",
+      "metadata": {
+        "name": "container1"
+      },
+      "state": 2,
+      "created_at": 1496175540000000000,
+      "started_at": 1496175541000000000,
+      "image": {
+        "image": "fake/image1"
+      },
+      "image_ref": "fake/image1",
+      "labels": {
+        "io.kubernetes.container.name": "container1",
+        "io.kubernetes.pod.name": "testName_0",
+        "io.kubernetes.pod.namespace": "default",
+        "io.kubernetes.pod.uid": "69eec606-0493-5825-73a4-c5e0c0236155"
+      }
+    }
+  },
+  {
+    "name": "invoking RemoveContainer()"
   },
   {
     "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"

--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -44,10 +44,12 @@ const (
 	noKvmDomainType   = "qemu"
 	noKvmEmulator     = "/usr/bin/qemu-system-x86_64"
 
-	domainShutdownRetryInterval = 10 * time.Second
-	domainShutdownTimeout       = 60 * time.Second
-	domainDestroyCheckInterval  = 500 * time.Millisecond
-	domainDestroyTimeout        = 5 * time.Second
+	domainStartCheckInterval      = 250 * time.Millisecond
+	domainStartTimeout            = 10 * time.Second
+	domainShutdownRetryInterval   = 5 * time.Second
+	domainShutdownOnRemoveTimeout = 60 * time.Second
+	domainDestroyCheckInterval    = 500 * time.Millisecond
+	domainDestroyTimeout          = 5 * time.Second
 
 	ContainerNsUuid       = "67b7fb47-7735-4b64-86d2-6d062d121966"
 	defaultKubeletRootDir = "/var/lib/kubelet/pods"
@@ -402,9 +404,41 @@ func (v *VirtualizationTool) StartContainer(containerId string) error {
 		err = domain.Create()
 	}
 
+	// XXX: maybe we don't really have to wait here but I couldn't
+	// find it in libvirt docs.
+	err = utils.WaitLoop(func() (bool, error) {
+		state, err := domain.State()
+		if err != nil {
+			return false, fmt.Errorf("failed to get state of the domain %q: %v", containerId, err)
+		}
+		switch state {
+		case virt.DOMAIN_RUNNING:
+			return true, nil
+		case virt.DOMAIN_SHUTDOWN:
+			return false, fmt.Errorf("unexpected shutdown for new domain %q", containerId)
+		case virt.DOMAIN_CRASHED:
+			return false, fmt.Errorf("domain %q crashed on start", containerId)
+		default:
+			return false, nil
+		}
+	}, domainStartCheckInterval, domainStartTimeout, v.clock)
+
+	if err == nil {
+		err = v.metadataStore.UpdateState(containerId, byte(kubeapi.ContainerState_CONTAINER_RUNNING))
+	}
+
+	if err == nil {
+		err = v.metadataStore.UpdateStartedAt(containerId, strconv.FormatInt(v.clock.Now().UnixNano(), 10))
+	}
+
 	if err != nil {
+		// FIXME: we do this here because kubelet may attempt new `CreateContainer()`
+		// calls for this VM after failed `StartContainer()` without first removing it.
+		// Better solution is perhaps moving domain setup logic to `StartContainer()`
+		// and cleaning it all up upon failure, but for now we just remove the VM
+		// so the next `CreateContainer()` call succeeds.
 		if rmErr := v.RemoveContainer(containerId); rmErr != nil {
-			return fmt.Errorf("Container start error: %v \n %v", err, rmErr)
+			return fmt.Errorf("Container start error: %v \n+ container removal error: %v", err, rmErr)
 		} else {
 			return err
 		}
@@ -413,33 +447,60 @@ func (v *VirtualizationTool) StartContainer(containerId string) error {
 	return nil
 }
 
-func (v *VirtualizationTool) StopContainer(containerId string) error {
+func (v *VirtualizationTool) StopContainer(containerId string, timeout time.Duration) error {
 	domain, err := v.domainConn.LookupDomainByUUIDString(containerId)
 	if err != nil {
 		return err
 	}
 
-	// TODO: handle shutdown errors!!!!
-	// TODO: this call must be idempotent!!!!
-	// TODO: handle grace period!!!!
-	//       (but add some extra wait to it perhaps?)
-	// TODO: destroy the domain after failure
-	// To process cases when VM is booting and cannot handle the shutdown signal
-	// send sequential shutdown requests with 1 sec interval until domain is shutoff or time after 60 sec.
-	return utils.WaitLoop(func() (bool, error) {
-		domain.Shutdown()
-
+	// We try to shut down the VM gracefully first. This may take several attempts
+	// because shutdown requests may be ignored e.g. when the VM boots.
+	// If this fails, we just destroy the domain (i.e. power off the VM).
+	err = utils.WaitLoop(func() (bool, error) {
 		_, err := v.domainConn.LookupDomainByUUIDString(containerId)
-		if err != nil {
-			return true, err
+		if err == virt.ErrDomainNotFound {
+			return true, nil
 		}
+		if err != nil {
+			return false, fmt.Errorf("failed to look up the domain %q: %v", containerId, err)
+		}
+
+		// domain.Shutdown() may return 'invalid operation' error if domain is already
+		// shut down. But checking the state beforehand will not make the situation
+		// any simpler because we'll still have a race, thus we need multiple attempts
+		domainShutdownErr := domain.Shutdown()
 
 		state, err := domain.State()
 		if err != nil {
-			return false, err
+			return false, fmt.Errorf("failed to get state of the domain %q: %v", containerId, err)
 		}
-		return state == virt.DOMAIN_SHUTDOWN || state == virt.DOMAIN_SHUTOFF, nil
-	}, domainShutdownRetryInterval, domainShutdownTimeout, v.clock)
+
+		if state == virt.DOMAIN_SHUTOFF {
+			return true, nil
+		}
+
+		if domainShutdownErr != nil {
+			// The domain is not in 'DOMAIN_SHUTOFF' state and domain.Shutdown() failed,
+			// so we need to return the error that happened during Shutdown()
+			return false, fmt.Errorf("failed to shut down domain %q: %v", containerId, err)
+		}
+
+		return false, nil
+	}, domainShutdownRetryInterval, timeout, v.clock)
+
+	if err != nil {
+		glog.Warningf("Failed to shut down VM %q: %v -- trying to destroy the domain", containerId, err)
+		// if the domain is destroyed successfully we return no error
+		if err = domain.Destroy(); err != nil {
+			return fmt.Errorf("failed to destroy the domain: %v", err)
+		}
+	}
+
+	if err == nil {
+		err = v.metadataStore.UpdateState(containerId, byte(kubeapi.ContainerState_CONTAINER_EXITED))
+	}
+
+	return err
 }
 
 func (v *VirtualizationTool) removeDomain(containerId string, config *VMConfig) error {
@@ -451,28 +512,32 @@ func (v *VirtualizationTool) removeDomain(containerId string, config *VMConfig) 
 	}
 
 	if domain != nil {
-		if err := v.StopContainer(containerId); err != nil {
-			if err := domain.Destroy(); err != nil {
-				return err
+		state, err := domain.State()
+		if err != nil {
+			return fmt.Errorf("failed to get state of the domain %q: %v", containerId, err)
+		}
+		if state != virt.DOMAIN_SHUTOFF {
+			if err := v.StopContainer(containerId, domainShutdownOnRemoveTimeout); err != nil {
+				return fmt.Errorf("error removing the domain %q: %v", containerId, err)
 			}
 		}
 
 		if err := domain.Undefine(); err != nil {
+			return fmt.Errorf("error undefining the domain %q: %v", containerId, err)
+		}
+
+		// Wait until domain is really removed or timeout after 5 sec.
+		if err := utils.WaitLoop(func() (bool, error) {
+			if _, err := v.domainConn.LookupDomainByUUIDString(containerId); err == virt.ErrDomainNotFound {
+				return true, nil
+			} else if err != nil {
+				// Unexpected error occured
+				return false, fmt.Errorf("error looking up domain %q: %v", containerId, err)
+			}
+			return false, nil
+		}, domainDestroyCheckInterval, domainDestroyTimeout, v.clock); err != nil {
 			return err
 		}
-	}
-
-	// Wait until domain is really removed or timeout after 5 sec.
-	if err := utils.WaitLoop(func() (bool, error) {
-		if _, err := v.domainConn.LookupDomainByUUIDString(containerId); err == virt.ErrDomainNotFound {
-			return true, nil
-		} else if err != nil {
-			// Unexpected error occured
-			return false, fmt.Errorf("error looking up domain %q: %v", containerId, err)
-		}
-		return false, nil
-	}, domainDestroyCheckInterval, domainDestroyTimeout, v.clock); err != nil {
-		return err
 	}
 
 	if err := v.teardownVolumes(config); err != nil {
@@ -528,6 +593,9 @@ func virtToKubeState(domainState virt.DomainState, lastState kubeapi.ContainerSt
 	var containerState kubeapi.ContainerState
 
 	switch domainState {
+	case virt.DOMAIN_SHUTDOWN:
+		// the domain is being shut down, but is still running
+		fallthrough
 	case virt.DOMAIN_RUNNING:
 		containerState = kubeapi.ContainerState_CONTAINER_RUNNING
 	case virt.DOMAIN_PAUSED:
@@ -536,8 +604,6 @@ func virtToKubeState(domainState virt.DomainState, lastState kubeapi.ContainerSt
 		} else {
 			containerState = kubeapi.ContainerState_CONTAINER_EXITED
 		}
-	case virt.DOMAIN_SHUTDOWN:
-		containerState = kubeapi.ContainerState_CONTAINER_EXITED
 	case virt.DOMAIN_SHUTOFF:
 		if lastState == kubeapi.ContainerState_CONTAINER_CREATED {
 			containerState = kubeapi.ContainerState_CONTAINER_CREATED
@@ -574,14 +640,6 @@ func (v *VirtualizationTool) getContainerInfo(domain virt.VirtDomain, containerI
 		if err := v.metadataStore.UpdateState(containerId, byte(containerState)); err != nil {
 			return nil, err
 		}
-		startedAt := v.clock.Now().UnixNano()
-		if containerState == kubeapi.ContainerState_CONTAINER_RUNNING {
-			strStartedAt := strconv.FormatInt(startedAt, 10)
-			if err := v.metadataStore.UpdateStartedAt(containerId, strStartedAt); err != nil {
-				return nil, err
-			}
-		}
-		containerInfo.StartedAt = startedAt
 		containerInfo.State = containerState
 	}
 	return containerInfo, nil

--- a/pkg/libvirttools/virtualization_test.go
+++ b/pkg/libvirttools/virtualization_test.go
@@ -278,6 +278,21 @@ func TestDomainForcedShutdown(t *testing.T) {
 	gm.Verify(t, ct.rec.Content())
 }
 
+func TestDoubleStartError(t *testing.T) {
+	ct := newContainerTester(t, fake.NewToplevelRecorder())
+	defer ct.teardown()
+
+	sandbox := criapi.GetSandboxes(1)[0]
+	ct.setPodSandbox(sandbox)
+
+	containerId := ct.createContainer(sandbox, nil)
+	ct.clock.Advance(1 * time.Second)
+	ct.startContainer(containerId)
+	if err := ct.virtTool.StartContainer(containerId); err == nil {
+		t.Errorf("2nd StartContainer() didn't produce an error")
+	}
+}
+
 type volMount struct {
 	name          string
 	containerPath string

--- a/pkg/libvirttools/virtualization_test.go
+++ b/pkg/libvirttools/virtualization_test.go
@@ -36,9 +36,10 @@ import (
 )
 
 const (
-	fakeImageName = "fake/image1"
-	fakeCNIConfig = `{"noCniForNow":true}`
-	fakeUuid      = "abb67e3c-71b3-4ddd-5505-8c4215d5c4eb"
+	fakeImageName        = "fake/image1"
+	fakeCNIConfig        = `{"noCniForNow":true}`
+	fakeUuid             = "abb67e3c-71b3-4ddd-5505-8c4215d5c4eb"
+	stopContainerTimeout = 30 * time.Second
 )
 
 type containerTester struct {
@@ -48,6 +49,8 @@ type containerTester struct {
 	kubeletRootDir string
 	virtTool       *VirtualizationTool
 	rec            *fake.TopLevelRecorder
+	domainConn     *fake.FakeDomainConnection
+	storageConn    *fake.FakeStorageConnection
 	boltClient     *bolttools.BoltClient
 }
 
@@ -65,8 +68,8 @@ func newContainerTester(t *testing.T, rec *fake.TopLevelRecorder) *containerTest
 
 	downloader := utils.NewFakeDownloader(ct.tmpDir)
 	ct.rec = rec
-	domainConn := fake.NewFakeDomainConnection(ct.rec.Child("domain conn"))
-	storageConn := fake.NewFakeStorageConnection(ct.rec.Child("storage"))
+	ct.domainConn = fake.NewFakeDomainConnection(ct.rec.Child("domain conn"))
+	ct.storageConn = fake.NewFakeStorageConnection(ct.rec.Child("storage"))
 
 	ct.boltClient, err = bolttools.NewFakeBoltClient()
 	if err != nil {
@@ -83,7 +86,7 @@ func newContainerTester(t *testing.T, rec *fake.TopLevelRecorder) *containerTest
 		t.Fatalf("boltClient: failed to create virtualization schema: %v", err)
 	}
 
-	imageTool, err := NewImageTool(storageConn, downloader, "default")
+	imageTool, err := NewImageTool(ct.storageConn, downloader, "default")
 	if err != nil {
 		t.Fatalf("Failed to create ImageTool: %v", err)
 	}
@@ -94,7 +97,7 @@ func newContainerTester(t *testing.T, rec *fake.TopLevelRecorder) *containerTest
 		// XXX: GetNocloudVolume must go last because it
 		// doesn't produce correct name for cdrom devices
 		GetNocloudVolume)
-	ct.virtTool, err = NewVirtualizationTool(domainConn, storageConn, imageTool, ct.boltClient, "volumes", "loop*", volSrc)
+	ct.virtTool, err = NewVirtualizationTool(ct.domainConn, ct.storageConn, imageTool, ct.boltClient, "volumes", "loop*", volSrc)
 	if err != nil {
 		t.Fatalf("failed to create VirtualizationTool: %v", err)
 	}
@@ -128,21 +131,7 @@ func (ct *containerTester) teardown() {
 	os.RemoveAll(ct.tmpDir)
 }
 
-func TestContainerLifecycle(t *testing.T) {
-	ct := newContainerTester(t, fake.NewToplevelRecorder())
-	defer ct.teardown()
-
-	sandbox := criapi.GetSandboxes(1)[0]
-	ct.setPodSandbox(sandbox)
-
-	containers, err := ct.virtTool.ListContainers(nil)
-	switch {
-	case err != nil:
-		t.Fatalf("ListContainers() failed: %v", err)
-	case len(containers) != 0:
-		t.Errorf("Unexpected containers when no containers are started: %#v", containers)
-	}
-
+func (ct *containerTester) createContainer(sandbox *kubeapi.PodSandboxConfig, mounts []*kubeapi.Mount) string {
 	req := &kubeapi.CreateContainerRequest{
 		PodSandboxId: sandbox.Metadata.Uid,
 		Config: &kubeapi.ContainerConfig{
@@ -152,22 +141,72 @@ func TestContainerLifecycle(t *testing.T) {
 			Image: &kubeapi.ImageSpec{
 				Image: fakeImageName,
 			},
+			Mounts: mounts,
 		},
 		SandboxConfig: sandbox,
 	}
 	vmConfig, err := GetVMConfig(req)
 	if err != nil {
-		t.Fatalf("GetVMConfig(): %v", err)
+		ct.t.Fatalf("GetVMConfig(): %v", err)
 	}
 	containerId, err := ct.virtTool.CreateContainer(vmConfig, "/tmp/fakenetns", fakeCNIConfig)
 	if err != nil {
-		t.Fatalf("CreateContainer(): %v", err)
+		ct.t.Fatalf("CreateContainer: %v", err)
+	}
+	return containerId
+}
+
+func (ct *containerTester) listContainers(filter *kubeapi.ContainerFilter) []*kubeapi.Container {
+	containers, err := ct.virtTool.ListContainers(nil)
+	if err != nil {
+		ct.t.Fatalf("ListContainers() failed: %v", err)
+	}
+	return containers
+}
+
+func (ct *containerTester) containerStatus(containerId string) *kubeapi.ContainerStatus {
+	status, err := ct.virtTool.ContainerStatus(containerId)
+	if err != nil {
+		ct.t.Errorf("ContainerStatus(): %v", err)
+	}
+	return status
+
+}
+
+func (ct *containerTester) startContainer(containerId string) {
+	if err := ct.virtTool.StartContainer(containerId); err != nil {
+		ct.t.Fatalf("StartContainer failed for container %q: %v", containerId, err)
+	}
+}
+
+func (ct *containerTester) stopContainer(containerId string) {
+	if err := ct.virtTool.StopContainer(containerId, stopContainerTimeout); err != nil {
+		ct.t.Fatalf("StopContainer failed for container %q: %v", containerId, err)
+	}
+}
+
+func (ct *containerTester) removeContainer(containerId string) {
+	if err := ct.virtTool.RemoveContainer(containerId); err != nil {
+		ct.t.Fatalf("RemoveContainer failed for container %q: %v", containerId, err)
+	}
+}
+
+func TestContainerLifecycle(t *testing.T) {
+	ct := newContainerTester(t, fake.NewToplevelRecorder())
+	defer ct.teardown()
+
+	sandbox := criapi.GetSandboxes(1)[0]
+	ct.setPodSandbox(sandbox)
+
+	containers := ct.listContainers(nil)
+	if len(containers) != 0 {
+		t.Errorf("Unexpected containers when no containers are started: %#v", containers)
 	}
 
-	containers, err = ct.virtTool.ListContainers(nil)
+	containerId := ct.createContainer(sandbox, nil)
+
+	containers = ct.listContainers(nil)
 	switch {
-	case err != nil:
-		t.Errorf("ListContainers() failed: %v", err)
 	case len(containers) != 1:
 		t.Errorf("Expected single container to be started, but got: %#v", containers)
 	case containers[0].Id != containerId:
@@ -178,44 +217,64 @@ func TestContainerLifecycle(t *testing.T) {
 	ct.rec.Rec("container list after the container is created", containers)
 
 	ct.clock.Advance(1 * time.Second)
-	if err = ct.virtTool.StartContainer(containerId); err != nil {
-		t.Fatalf("StartContainer failed for container %q: %v", containerId, err)
-	}
+	ct.startContainer(containerId)
 
-	status, err := ct.virtTool.ContainerStatus(containerId)
-	switch {
-	case err != nil:
-		t.Errorf("ContainerStatus(): %v", err)
-	case status.State != kubeapi.ContainerState_CONTAINER_RUNNING:
-		t.Errorf("Bad container state: %v instead of %v", containers[0].State, kubeapi.ContainerState_CONTAINER_RUNNING)
+	status := ct.containerStatus(containerId)
+	if status.State != kubeapi.ContainerState_CONTAINER_RUNNING {
+		t.Errorf("Bad container state: %v instead of %v", status.State, kubeapi.ContainerState_CONTAINER_RUNNING)
 	}
-	ct.rec.Rec("container status the container is created", status)
+	ct.rec.Rec("container status after the container is started", status)
 
-	if err = ct.virtTool.StopContainer(containerId); err != nil {
-		t.Fatalf("StopContainer failed for container %q: %v", containerId, err)
+	ct.stopContainer(containerId)
+
+	status = ct.containerStatus(containerId)
+	if status.State != kubeapi.ContainerState_CONTAINER_EXITED {
+		t.Errorf("Bad container state: %v instead of %v", status.State, kubeapi.ContainerState_CONTAINER_EXITED)
 	}
+	ct.rec.Rec("container status after the container is stopped", status)
 
-	status, err = ct.virtTool.ContainerStatus(containerId)
-	switch {
-	case err != nil:
-		t.Errorf("ContainerStatus(): %v", err)
-	case status.State != kubeapi.ContainerState_CONTAINER_EXITED:
-		t.Errorf("Bad container state: %v instead of %v", containers[0].State, kubeapi.ContainerState_CONTAINER_EXITED)
-	}
-	ct.rec.Rec("container status the container is stopped", status)
+	ct.removeContainer(containerId)
 
-	if err = ct.virtTool.RemoveContainer(containerId); err != nil {
-		t.Fatalf("RemoveContainer failed for container %q: %v", containerId, err)
-	}
-
-	containers, err = ct.virtTool.ListContainers(nil)
-	switch {
-	case err != nil:
-		t.Fatalf("ListContainers() failed: %v", err)
-	case len(containers) != 0:
+	containers = ct.listContainers(nil)
+	if len(containers) != 0 {
 		t.Errorf("Unexpected containers when no containers are started: %#v", containers)
 	}
 
+	gm.Verify(t, ct.rec.Content())
+}
+
+func TestDomainForcedShutdown(t *testing.T) {
+	ct := newContainerTester(t, fake.NewToplevelRecorder())
+	defer ct.teardown()
+
+	sandbox := criapi.GetSandboxes(1)[0]
+	ct.setPodSandbox(sandbox)
+
+	containerId := ct.createContainer(sandbox, nil)
+	ct.clock.Advance(1 * time.Second)
+	ct.startContainer(containerId)
+
+	ct.domainConn.SetIgnoreShutdown(true)
+	go func() {
+		// record a couple of ignored shutdown attempts before container destruction
+		ct.clock.BlockUntil(1)
+		ct.clock.Advance(6 * time.Second)
+		ct.clock.BlockUntil(1)
+		ct.clock.Advance(6 * time.Second)
+		ct.clock.BlockUntil(1)
+		ct.clock.Advance(30 * time.Second)
+	}()
+
+	ct.rec.Rec("invoking StopContainer()", nil)
+	ct.stopContainer(containerId)
+	status := ct.containerStatus(containerId)
+	if status.State != kubeapi.ContainerState_CONTAINER_EXITED {
+		t.Errorf("Bad container state: %v instead of %v", status.State, kubeapi.ContainerState_CONTAINER_EXITED)
+	}
+	ct.rec.Rec("container status after the container is stopped", status)
+
+	ct.rec.Rec("invoking RemoveContainer()", nil)
+	ct.removeContainer(containerId)
 	gm.Verify(t, ct.rec.Content())
 }
 
@@ -341,32 +400,8 @@ func TestDomainDefinitions(t *testing.T) {
 					ContainerPath: m.containerPath,
 				})
 			}
-			req := &kubeapi.CreateContainerRequest{
-				PodSandboxId: sandbox.Metadata.Uid,
-				Config: &kubeapi.ContainerConfig{
-					Metadata: &kubeapi.ContainerMetadata{
-						Name: "container1",
-					},
-					Image: &kubeapi.ImageSpec{
-						Image: fakeImageName,
-					},
-					Mounts: mounts,
-				},
-				SandboxConfig: sandbox,
-			}
-			vmConfig, err := GetVMConfig(req)
-			if err != nil {
-				t.Fatalf("GetVMConfig(): %v", err)
-			}
-			containerId, err := ct.virtTool.CreateContainer(vmConfig, "/tmp/fakenetns", fakeCNIConfig)
-			if err != nil {
-				t.Fatalf("CreateContainer: %v", err)
-			}
-
-			if err = ct.virtTool.RemoveContainer(containerId); err != nil {
-				t.Fatalf("RemoveContainer failed for container %q: %v", containerId, err)
-			}
-
+			containerId := ct.createContainer(sandbox, mounts)
+			ct.removeContainer(containerId)
 			gm.Verify(t, ct.rec.Content())
 		})
 	}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -22,10 +22,10 @@ import (
 	"net"
 	"os"
 	"syscall"
-	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/golang/glog"
+	"github.com/jonboulle/clockwork"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	kubeapi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
@@ -208,7 +208,7 @@ func (v *VirtletManager) RunPodSandbox(ctx context.Context, in *kubeapi.RunPodSa
 		state = kubeapi.PodSandboxState_SANDBOX_NOTREADY
 	}
 
-	if storeErr := v.metadataStore.SetPodSandbox(config, netConfigAsBytes, state, time.Now); storeErr != nil {
+	if storeErr := v.metadataStore.SetPodSandbox(config, netConfigAsBytes, state, clockwork.NewRealClock()); storeErr != nil {
 		glog.Errorf("Error when creating pod sandbox for pod %s (%s): %v", podName, podId, storeErr)
 		return nil, storeErr
 	}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"os"
 	"syscall"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/golang/glog"
@@ -402,7 +403,7 @@ func (v *VirtletManager) StopContainer(ctx context.Context, in *kubeapi.StopCont
 	glog.V(2).Infof("StopContainer called for containerID: %s", in.ContainerId)
 	glog.V(3).Infof("StopContainer: %s", spew.Sdump(in))
 
-	if err := v.libvirtVirtualizationTool.StopContainer(in.ContainerId); err != nil {
+	if err := v.libvirtVirtualizationTool.StopContainer(in.ContainerId, time.Duration(in.Timeout)*time.Second); err != nil {
 		glog.Errorf("Error when stopping container %s: %v", in.ContainerId, err)
 		return nil, err
 	}

--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -17,8 +17,7 @@ limitations under the License.
 package metadata
 
 import (
-	"time"
-
+	"github.com/jonboulle/clockwork"
 	kubeapi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 )
 
@@ -46,7 +45,7 @@ type ImageMetadataStore interface {
 
 // SandboxMetadataStore contains methods to operate on POD sandboxes
 type SandboxMetadataStore interface {
-	SetPodSandbox(config *kubeapi.PodSandboxConfig, networkConfiguration []byte, state kubeapi.PodSandboxState, timeFunc func() time.Time) error
+	SetPodSandbox(config *kubeapi.PodSandboxConfig, networkConfiguration []byte, state kubeapi.PodSandboxState, clock clockwork.Clock) error
 	UpdatePodState(podId string, state byte) error
 	RemovePodSandbox(podId string) error
 	GetPodSandboxContainerID(podId string) (string, error)
@@ -59,7 +58,7 @@ type SandboxMetadataStore interface {
 
 // ContainerMetadataStore contains methods to operate on containers (VMs)
 type ContainerMetadataStore interface {
-	SetContainer(name, containerId, sandboxId, image, rootImageVolumeName string, labels, annotations map[string]string, nocloudFile string, timeFunc func() time.Time) error
+	SetContainer(name, containerId, sandboxId, image, rootImageVolumeName string, labels, annotations map[string]string, nocloudFile string, clock clockwork.Clock) error
 	UpdateStartedAt(containerId string, startedAt string) error
 	UpdateState(containerId string, state byte) error
 	GetContainerInfo(containerId string) (*ContainerInfo, error)

--- a/pkg/utils/wait.go
+++ b/pkg/utils/wait.go
@@ -19,11 +19,18 @@ package utils
 import (
 	"fmt"
 	"time"
+
+	"github.com/jonboulle/clockwork"
 )
 
-// WaitLoop executes test func in loop until it returns error, true, or timeout passes
-func WaitLoop(test func() (bool, error), retryPeriod time.Duration, timeout time.Duration) error {
-	for start := time.Now(); time.Since(start) < timeout; time.Sleep(retryPeriod) {
+// WaitLoop executes test func in loop until it returns error, true, or the timeout elapses.
+// clock argument denotes a clock object to use for waiting.
+// When clock is nil, WaitLoop uses clockwork.NewRealClock()
+func WaitLoop(test func() (bool, error), retryPeriod time.Duration, timeout time.Duration, clock clockwork.Clock) error {
+	if clock == nil {
+		clock = clockwork.NewRealClock()
+	}
+	for start := clock.Now(); clock.Since(start) < timeout; clock.Sleep(retryPeriod) {
 		result, err := test()
 		if err != nil {
 			return err

--- a/tests/integration/container_test.go
+++ b/tests/integration/container_test.go
@@ -236,7 +236,7 @@ func (ct *containerTester) waitForContainerRunning(containerId, containerName st
 		}
 
 		return false, nil
-	}, time.Second, 20*time.Second)
+	}, time.Second, 20*time.Second, nil)
 
 	if err != nil {
 		ct.t.Errorf("Container not reaching RUNNING state: %v", err)


### PR DESCRIPTION
Support `terminationGracePeriodSeconds` for VM pods.
Virtlet will try to wait for this number of seconds for VM
to shut down gracefully, then it will destroy the domain.
Update container statuses on `StartContainer()`/`StopContainer()`.
Wait for domain to become running in StartContainer().
Lessen the dependency on `ContainerStatus()`/`ListContainers()` call
sequence.
Add a comment on why we're removing the domain upon
failed `StartContainer()` call.
Add libvirttools test for hung domains.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/328)
<!-- Reviewable:end -->
