### PR TITLE
Change returned image id

### DIFF
--- a/pkg/libvirttools/image.go
+++ b/pkg/libvirttools/image.go
@@ -93,11 +93,6 @@ func (i *ImageTool) GetImageVolume(imageName string) (virt.VirtStorageVolume, er
 	return i.pool.LookupVolumeByName(imageVolumeName)
 }
 
-func ImageNameFromVirtVolumeName(volumeName string) string {
-	parts := strings.SplitN(volumeName, "_", 2)
-	return parts[1]
-}
-
 func stripTagFromImageName(imageName string) string {
 	return strings.Split(imageName, ":")[0]
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -518,7 +518,7 @@ func (v *VirtletManager) imageFromVolume(virtVolume virt.VirtStorageVolume) (*ku
 	}
 
 	return &kubeapi.Image{
-		Id:       libvirttools.ImageNameFromVirtVolumeName(virtVolume.Name()),
+		Id:       imageName,
 		RepoTags: []string{imageName},
 		Size_:    size,
 	}, nil

--- a/tests/integration/vars.go
+++ b/tests/integration/vars.go
@@ -19,7 +19,7 @@ package integration
 var (
 	imageCirrosUrl     = "localhost/cirros-0.3.4-x86_64-disk.img"
 	imageCopyCirrosUrl = "localhost/copy/cirros-0.3.4-x86_64-disk.img"
-	imageCirrosId      = "cirros-0.3.4-x86_64-disk.img"
+	imageCirrosId      = "localhost/cirros-0.3.4-x86_64-disk.img"
 	cirrosVolumeSize   = 41126400
 	imageCirrosUrl2    = "localhost/cirros-0.3.3-x86_64-disk.img"
 )


### PR DESCRIPTION
We could have a conflict with images from different urls with same file
name. Also there was an issue with starting pod with image pull policy
set to `IfNotPresent` when we had image already in store.

This change fixes both issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/331)
<!-- Reviewable:end -->
