### PR TITLE
Fix container metadata & annotation handling

### DIFF
--- a/pkg/bolttools/utils_test.go
+++ b/pkg/bolttools/utils_test.go
@@ -182,7 +182,7 @@ func SetUpBolt(t *testing.T, sandboxConfigs []*kubeapi.PodSandboxConfig, contain
 	}
 
 	for _, container := range containerConfigs {
-		if err := b.SetContainer(container.Name, container.ContainerId, container.SandboxId, container.Image, container.RootImageVolumeName, container.Labels, container.Annotations, "/tmp/nocloud.iso", clock); err != nil {
+		if err := b.SetContainer(container.Name, container.ContainerId, container.SandboxId, container.Image, container.RootImageVolumeName, container.Labels, container.Annotations, "/tmp/nocloud.iso", 0, clock); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/pkg/libvirttools/TestContainerLifecycle.json
+++ b/pkg/libvirttools/TestContainerLifecycle.json
@@ -424,7 +424,8 @@
         "id": "231700d5-c9a6-5a49-738d-99a954c51550",
         "pod_sandbox_id": "69eec606-0493-5825-73a4-c5e0c0236155",
         "metadata": {
-          "name": "231700d5-c9a6-5a49-738d-99a954c51550"
+          "name": "container1",
+          "attempt": 42
         },
         "image": {
           "image": "fake/image1"
@@ -436,6 +437,9 @@
           "io.kubernetes.pod.name": "testName_0",
           "io.kubernetes.pod.namespace": "default",
           "io.kubernetes.pod.uid": "69eec606-0493-5825-73a4-c5e0c0236155"
+        },
+        "annotations": {
+          "foo": "bar"
         }
       }
     ]
@@ -448,7 +452,8 @@
     "data": {
       "id": "231700d5-c9a6-5a49-738d-99a954c51550",
       "metadata": {
-        "name": "container1"
+        "name": "container1",
+        "attempt": 42
       },
       "state": 1,
       "created_at": 1496175540000000000,
@@ -462,6 +467,9 @@
         "io.kubernetes.pod.name": "testName_0",
         "io.kubernetes.pod.namespace": "default",
         "io.kubernetes.pod.uid": "69eec606-0493-5825-73a4-c5e0c0236155"
+      },
+      "annotations": {
+        "foo": "bar"
       }
     }
   },
@@ -473,7 +481,8 @@
     "data": {
       "id": "231700d5-c9a6-5a49-738d-99a954c51550",
       "metadata": {
-        "name": "container1"
+        "name": "container1",
+        "attempt": 42
       },
       "state": 2,
       "created_at": 1496175540000000000,
@@ -487,6 +496,9 @@
         "io.kubernetes.pod.name": "testName_0",
         "io.kubernetes.pod.namespace": "default",
         "io.kubernetes.pod.uid": "69eec606-0493-5825-73a4-c5e0c0236155"
+      },
+      "annotations": {
+        "foo": "bar"
       }
     }
   },

--- a/pkg/libvirttools/TestDomainForcedShutdown.json
+++ b/pkg/libvirttools/TestDomainForcedShutdown.json
@@ -439,7 +439,8 @@
     "data": {
       "id": "231700d5-c9a6-5a49-738d-99a954c51550",
       "metadata": {
-        "name": "container1"
+        "name": "container1",
+        "attempt": 42
       },
       "state": 2,
       "created_at": 1496175540000000000,
@@ -453,6 +454,9 @@
         "io.kubernetes.pod.name": "testName_0",
         "io.kubernetes.pod.namespace": "default",
         "io.kubernetes.pod.uid": "69eec606-0493-5825-73a4-c5e0c0236155"
+      },
+      "annotations": {
+        "foo": "bar"
       }
     }
   },

--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -388,7 +388,7 @@ func (v *VirtualizationTool) CreateContainer(config *VMConfig, netNSPath, cniCon
 		err = v.metadataStore.SetContainer(config.Name, settings.domainUUID,
 			config.PodSandboxId, config.Image, cloneName,
 			labels, config.ContainerAnnotations,
-			nocloudFile, v.clock)
+			nocloudFile, config.Attempt, v.clock)
 	}
 	if err != nil {
 		return "", err
@@ -705,7 +705,8 @@ func (v *VirtualizationTool) getContainer(domain virt.VirtDomain) (*kubeapi.Cont
 	podSandboxId := containerInfo.SandboxId
 
 	metadata := &kubeapi.ContainerMetadata{
-		Name: containerId,
+		Name:    containerInfo.Name,
+		Attempt: containerInfo.Attempt,
 	}
 
 	image := &kubeapi.ImageSpec{Image: containerInfo.Image}
@@ -840,14 +841,15 @@ func (v *VirtualizationTool) ContainerStatus(containerId string) (*kubeapi.Conta
 		Id: containerId,
 		Metadata: &kubeapi.ContainerMetadata{
 			Name:    containerInfo.Name,
-			Attempt: 0,
+			Attempt: containerInfo.Attempt,
 		},
-		Image:     image,
-		ImageRef:  containerInfo.Image,
-		State:     containerInfo.State,
-		CreatedAt: containerInfo.CreatedAt,
-		StartedAt: containerInfo.StartedAt,
-		Labels:    containerInfo.Labels,
+		Image:       image,
+		ImageRef:    containerInfo.Image,
+		State:       containerInfo.State,
+		CreatedAt:   containerInfo.CreatedAt,
+		StartedAt:   containerInfo.StartedAt,
+		Labels:      containerInfo.Labels,
+		Annotations: containerInfo.Annotations,
 	}, nil
 }
 

--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -32,6 +32,7 @@ type ContainerInfo struct {
 	Labels              map[string]string
 	Annotations         map[string]string
 	SandBoxAnnotations  map[string]string
+	Attempt             uint32
 	NocloudFile         string
 	State               kubeapi.ContainerState
 }
@@ -58,7 +59,7 @@ type SandboxMetadataStore interface {
 
 // ContainerMetadataStore contains methods to operate on containers (VMs)
 type ContainerMetadataStore interface {
-	SetContainer(name, containerId, sandboxId, image, rootImageVolumeName string, labels, annotations map[string]string, nocloudFile string, clock clockwork.Clock) error
+	SetContainer(name, containerId, sandboxId, image, rootImageVolumeName string, labels, annotations map[string]string, nocloudFile string, attempt uint32, clock clockwork.Clock) error
 	UpdateStartedAt(containerId string, startedAt string) error
 	UpdateState(containerId string, state byte) error
 	GetContainerInfo(containerId string) (*ContainerInfo, error)


### PR DESCRIPTION
This fixes Virtlet on Kubernetes 1.6.5+

Virtlet was broken since kubernetes/kubernetes@576c8cb026817c617ff9b3f897b061350bac041c because container annotations were not returned by `ContainerStatus()`.
This commit also fixes saving container attempt number and the container name returned by `ContainerStatus()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/337)
<!-- Reviewable:end -->
