### PR TITLE
volumes: Support subdirs for cm/secrets passed as volumes

### DIFF
--- a/docs/volumes.md
+++ b/docs/volumes.md
@@ -410,9 +410,6 @@ It does so using `write_files`
 module which is used to write Secret/ConfigMap content to appropriate
 locations.
 
-Virtlet only handles files in the top level directory for each
-Secret/ConfigMap `VolumeMounts` entry. This limitation is to be lifted soon.
-
 ### Consuming a ConfigMap using Kubernetes volume
 
 See [the following example](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#add-configmap-data-to-a-volume)


### PR DESCRIPTION
There is no possibility to create config map or secret with files embedded in subdirectories, but following **"Projection of secret keys to specific paths"** in [secrets](https://kubernetes.io/docs/concepts/configuration/secret/) documentation one can "project" value for key in particular config map or secret to file in subdir of such volume.

This PR provides support for such "projections", which are made by kubelet, which prepares volume directory, and then it's content is reconstructed by Virtlet as `write_files` entries for cloud init provider.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/343)
<!-- Reviewable:end -->
