### PR TITLE
Improve CRI proxy logging

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -66,7 +66,7 @@ docker rm -f $(docker ps -q --filter=label=criproxy=true)
 docker run -d --privileged \
       -l criproxy=true \
       --restart always \
-       --log-opt max-size=10m \
+       --log-opt max-size=100m \
        --name criproxy \
        --net=host \
        --pid=host \
@@ -82,6 +82,8 @@ docker run -d --privileged \
 `-v` option of `criproxy` controls the verbosity here. 0-1 means some
 very basic logging during startup and displaying serious errors, 2 is
 the same as 1 plus logging of CRI request errors and 3 causes dumping
-of actual CRI requests and responses in addition to what's logged on
-level 2. `--log-opt` docker option controls the maximum size of the
-docker log for CRI proxy container.
+of actual CRI requests and responses except for `ListPodSandbox`,
+`ListContainers` and `ListImages` requests in addition to what's
+logged on level 2. Level 4 adds dumping `List*` requests which may
+cause the log to grow fast. `--log-opt` docker option controls the
+maximum size of the docker log for CRI proxy container.

--- a/pkg/criproxy/proxy.go
+++ b/pkg/criproxy/proxy.go
@@ -460,7 +460,6 @@ func (r *RuntimeProxy) PodSandboxStatus(ctx context.Context, in *runtimeapi.PodS
 		glog.V(2).Infof("FAIL: PodSandboxStatus(): %v", err)
 		return nil, err
 	}
-	glog.V(3).Infof("ENTER: PodSandboxStatus() [%s]: %s", client.id, spew.Sdump(in))
 	in.PodSandboxId = unprefixed
 
 	glog.V(3).Infof("ENTER: PodSandboxStatus() [%s]: %s", client.id, spew.Sdump(in))
@@ -492,7 +491,7 @@ func (r *RuntimeProxy) ListPodSandbox(ctx context.Context, in *runtimeapi.ListPo
 		clientStr = client.id
 	}
 
-	glog.V(3).Infof("ENTER: ListPodSandbox() [%s]: %s", clientStr, spew.Sdump(in))
+	glog.V(4).Infof("ENTER: ListPodSandbox() [%s]: %s", clientStr, spew.Sdump(in))
 	var sandboxes []*runtimeapi.PodSandbox
 	for _, client := range clients {
 		if client.currentState() != clientStateConnected {
@@ -515,7 +514,7 @@ func (r *RuntimeProxy) ListPodSandbox(ctx context.Context, in *runtimeapi.ListPo
 	}
 
 	resp := &runtimeapi.ListPodSandboxResponse{Items: sandboxes}
-	glog.V(3).Infof("LEAVE: ListPodSandbox() [%s]: %s", clientStr, spew.Sdump(resp))
+	glog.V(4).Infof("LEAVE: ListPodSandbox() [%s]: %s", clientStr, spew.Sdump(resp))
 	return resp, nil
 }
 
@@ -666,7 +665,7 @@ func (r *RuntimeProxy) ListContainers(ctx context.Context, in *runtimeapi.ListCo
 		}
 	}
 
-	glog.V(3).Infof("ENTER: ListContainers() [%s]: %s", clientStr, spew.Sdump(in))
+	glog.V(4).Infof("ENTER: ListContainers() [%s]: %s", clientStr, spew.Sdump(in))
 	var containers []*runtimeapi.Container
 	for _, client := range clients {
 		if client.currentState() != clientStateConnected {
@@ -689,7 +688,7 @@ func (r *RuntimeProxy) ListContainers(ctx context.Context, in *runtimeapi.ListCo
 	}
 
 	resp := &runtimeapi.ListContainersResponse{Containers: containers}
-	glog.V(3).Infof("LEAVE: ListContainers() [%s]: %s", clientStr, spew.Sdump(resp))
+	glog.V(4).Infof("LEAVE: ListContainers() [%s]: %s", clientStr, spew.Sdump(resp))
 	return resp, nil
 }
 
@@ -868,7 +867,7 @@ func (r *RuntimeProxy) ListImages(ctx context.Context, in *runtimeapi.ListImages
 		clientStr = client.id
 	}
 
-	glog.V(3).Infof("ENTER: ListImages() [%s]: %s", clientStr, spew.Sdump(in))
+	glog.V(4).Infof("ENTER: ListImages() [%s]: %s", clientStr, spew.Sdump(in))
 	var images []*runtimeapi.Image
 	for _, client := range clients {
 		if client.currentState() != clientStateConnected {
@@ -891,7 +890,7 @@ func (r *RuntimeProxy) ListImages(ctx context.Context, in *runtimeapi.ListImages
 	}
 
 	resp := &runtimeapi.ListImagesResponse{Images: images}
-	glog.V(3).Infof("LEAVE: ListImages() [%s]: %s", clientStr, spew.Sdump(resp))
+	glog.V(4).Infof("LEAVE: ListImages() [%s]: %s", clientStr, spew.Sdump(resp))
 	return resp, nil
 }
 


### PR DESCRIPTION
Move spammy/periodic `List*` request logging to level 4.
Remove duplicate `PodSandboxStatus()` log.
Set CRI proxy log limit to 100m in the example (10m is way too low for
e.g. level 4).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/344)
<!-- Reviewable:end -->
