### PR TITLE
Disable libguestfs debugging in integration tests

### DIFF
--- a/tests/integration/manager.go
+++ b/tests/integration/manager.go
@@ -32,15 +32,6 @@ const (
 	virtletSocket = "/tmp/virtlet.sock"
 )
 
-func createEnviron() []string {
-	environ := os.Environ()
-
-	environ = append(environ, "LIBGUESTFS_DEBUG=1")
-	environ = append(environ, "LIBGUESTFS_TRACE=1")
-
-	return environ
-}
-
 type VirtletManager struct {
 	libvirtUri string
 	pid        int
@@ -82,7 +73,7 @@ func (v *VirtletManager) Run() error {
 		"-image-download-protocol=http",
 	}, &syscall.ProcAttr{
 		Dir:   virtletDir,
-		Env:   createEnviron(),
+		Env:   os.Environ(),
 		Files: []uintptr{0, 1, 2},
 		Sys:   &syscall.SysProcAttr{},
 	})


### PR DESCRIPTION
We don't use it most of the time, but it comprises a large part of
Travis CI output currently. I think it's better reenabled from
scripts if/when it's needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/345)
<!-- Reviewable:end -->
