### PR TITLE
Revert "Move /run/virtlet.sock to /var/run/virtlet.sock"

### DIFF
--- a/cmd/criproxy/criproxy.go
+++ b/cmd/criproxy/criproxy.go
@@ -34,7 +34,7 @@ const (
 
 var (
 	listen = flag.String("listen", "/run/criproxy.sock",
-		"The unix socket to listen on, e.g. /var/run/virtlet.sock")
+		"The unix socket to listen on, e.g. /run/virtlet.sock")
 	connect = flag.String("connect", "/var/run/dockershim.sock",
 		"CRI runtime ids and unix socket(s) to connect to, e.g. /var/run/dockershim.sock,alt:/var/run/another.sock")
 	kubeletConfigPath = flag.String("kubeletcfg", "/etc/criproxy/kubelet.conf", "path to saved kubelet config file")
@@ -102,7 +102,7 @@ func installCriProxy(execPath, savedConfigPath string) error {
 			"3",
 			"-alsologtostderr",
 			"-connect",
-			"docker,virtlet:/var/run/virtlet.sock",
+			"docker,virtlet:/run/virtlet.sock",
 		},
 		ProxySocketPath: "/run/criproxy.sock",
 	}, nil)

--- a/cmd/virtlet/virtlet.go
+++ b/cmd/virtlet/virtlet.go
@@ -34,10 +34,10 @@ var (
 		"Storage pool in which the images should be stored")
 	storageBackend = flag.String("storage-backend", "dir",
 		"Libvirt storage pool type/backend")
-	boltPath = flag.String("bolt-path", "/var/lib/virtlet/virtlet.db",
+	boltPath = flag.String("bolt-path", "/var/data/virtlet/virtlet.db",
 		"Path to the bolt database file")
-	listen = flag.String("listen", "/var/run/virtlet.sock",
-		"The unix socket to listen on, e.g. /var/run/virtlet.sock")
+	listen = flag.String("listen", "/run/virtlet.sock",
+		"The unix socket to listen on, e.g. /run/virtlet.sock")
 	cniPluginsDir = flag.String("cni-bin-dir", "/opt/cni/bin",
 		"Path to CNI plugin binaries")
 	cniConfigsDir = flag.String("cni-conf-dir", "/etc/cni/net.d",

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -76,7 +76,7 @@ docker run -d --privileged \
        nsenter --mount=/proc/1/ns/mnt -- \
        /opt/criproxy/bin/criproxy \
        -v 3 -alsologtostderr \
-       -connect docker,virtlet:/var/run/virtlet.sock
+       -connect docker,virtlet:/run/virtlet.sock
 ```
 
 `-v` option of `criproxy` controls the verbosity here. 0-1 means some

--- a/deploy/real-cluster.md
+++ b/deploy/real-cluster.md
@@ -81,7 +81,7 @@ the following content (you can also use `systemctl --force edit criproxy.service
 Description=CRI Proxy
 
 [Service]
-ExecStart=/usr/local/bin/criproxy -v 3 -alsologtostderr -connect docker,virtlet:/var/run/virtlet.sock -kubeletcfg /etc/criproxy/kubelet.conf -listen /run/criproxy.sock
+ExecStart=/usr/local/bin/criproxy -v 3 -alsologtostderr -connect docker,virtlet:/run/virtlet.sock -kubeletcfg /etc/criproxy/kubelet.conf -listen /run/criproxy.sock
 Restart=always
 StartLimitInterval=0
 RestartSec=10

--- a/docs/criproxy.md
+++ b/docs/criproxy.md
@@ -16,14 +16,14 @@ image name / pod id / container id prefixes.
 
 Let's say CRI proxy is started as follows:
 ```
-/usr/local/bin/criproxy -v 3 -alsologtostderr -connect docker,virtlet:/var/run/virtlet.sock
+/usr/local/bin/criproxy -v 3 -alsologtostderr -connect docker,virtlet:/run/virtlet.sock
 ```
 
 `-v 3 -alsologtostderr` options here may be quite useful for
 debugging, because they make CRI proxy log detailed info about every
 CRI request going through it, including any errors and the result.
 
-`-connect docker,virtlet:/var/run/virtlet.sock` specifies the list of
+`-connect docker,virtlet:/run/virtlet.sock` specifies the list of
 runtimes that the proxy passes requests to.
 
 The `docker` part is a special case, meaning that `criproxy` must
@@ -31,11 +31,11 @@ start in-process `docker-shim` and use it as the primary (prefixless)
 runtime.  It's also possible to specify other primary runtime instead,
 e.g. `/run/some-other-runtime.sock`.
 
-`virtlet:/var/run/virtlet.sock` denotes an alternative runtime
+`virtlet:/run/virtlet.sock` denotes an alternative runtime
 socket. This means that image service requests that include image
 names starting with `virtlet/` must be directed to the CRI
 implementation listening on a Unix domain socket at
-`/var/run/virtlet.sock`. Pods that need to run on `virtlet` runtime must
+`/run/virtlet.sock`. Pods that need to run on `virtlet` runtime must
 have `virtlet` as the value of `kubernetes.io/target-runtime`
 annotation.
 

--- a/pkg/criproxy/proxy.go
+++ b/pkg/criproxy/proxy.go
@@ -1035,7 +1035,7 @@ func (r *RuntimeProxy) clientForImage(image *runtimeapi.ImageSpec, noErrorIfNotC
 // (add apiClient.Name() or something)
 
 // TODO: tolerate runtime disconnection & enable the 'race' test on travis
-// dbox.go:185] ListPodSandbox failed: rpc error: code = 2 desc = "/var/run/virtlet.sock": rpc error: code = 14 desc = grpc: the connection is unavailable
-// GenericPLEG: Unable to retrieve pods: rpc error: code = 2 desc = "/var/run/virtlet.sock": rpc error: code = 14 desc = grpc: the connection is unavailable
+// dbox.go:185] ListPodSandbox failed: rpc error: code = 2 desc = "/run/virtlet.sock": rpc error: code = 14 desc = grpc: the connection is unavailable
+// GenericPLEG: Unable to retrieve pods: rpc error: code = 2 desc = "/run/virtlet.sock": rpc error: code = 14 desc = grpc: the connection is unavailable
 
 // https://github.com/grpc/grpc-go/blob/master/codes/codes.go


### PR DESCRIPTION
It broke some non-DIND deployments.

This reverts commit b083cefbd5c4c05295fa1a4aa31b6d333f3cd287.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/354)
<!-- Reviewable:end -->
