### PR TITLE
Make possible to use multiple ceph secrets

### DIFF
--- a/examples/cirros-vm-rbd-volume.yaml.tmpl
+++ b/examples/cirros-vm-rbd-volume.yaml.tmpl
@@ -26,7 +26,7 @@ spec:
         # This memory limit is applied to the libvirt domain definition
         memory: 128Mi
   volumes:
-  - name: test
+  - name: test1
     flexVolume:
       driver: "virtlet/flexvolume_driver"
       options:
@@ -34,5 +34,15 @@ spec:
         monitor: @MON_IP@:6789
         user: libvirt
         secret: @SECRET@
-        volume: rbd-test-image
+        volume: rbd-test-image1
+        pool: libvirt-pool
+  - name: test2
+    flexVolume:
+      driver: "virtlet/flexvolume_driver"
+      options:
+        type: ceph
+        monitor: @MON_IP@:6789
+        user: libvirt
+        secret: @SECRET@
+        volume: rbd-test-image2
         pool: libvirt-pool

--- a/pkg/libvirttools/TestDomainDefinitions__ceph_flexvolume.json
+++ b/pkg/libvirttools/TestDomainDefinitions__ceph_flexvolume.json
@@ -116,17 +116,17 @@
       "Ephemeral": "no",
       "Private": "no",
       "Description": "",
-      "UUID": "231700d5-c9a6-5a49-738d-99a954c51550",
+      "UUID": "",
       "Usage": {
         "Type": "ceph",
         "Volume": "",
-        "Name": "libvirt",
+        "Name": "libvirt-231700d5-c9a6-5a49-738d-99a954c51550-ceph",
         "Target": ""
       }
     }
   },
   {
-    "name": "domain conn: secret 231700d5-c9a6-5a49-738d-99a954c51550: SetValue",
+    "name": "domain conn: secret libvirt-231700d5-c9a6-5a49-738d-99a954c51550-ceph: SetValue",
     "data": "66 6f 6f 62 61 72 0a"
   },
   {
@@ -295,8 +295,8 @@
               "Username": "libvirt",
               "Secret": {
                 "Type": "ceph",
-                "Usage": "",
-                "UUID": "231700d5-c9a6-5a49-738d-99a954c51550"
+                "Usage": "libvirt-231700d5-c9a6-5a49-738d-99a954c51550-ceph",
+                "UUID": ""
               }
             },
             "Source": {
@@ -498,6 +498,6 @@
     "data": "root_231700d5-c9a6-5a49-738d-99a954c51550"
   },
   {
-    "name": "domain conn: secret 231700d5-c9a6-5a49-738d-99a954c51550: Remove"
+    "name": "domain conn: secret libvirt-231700d5-c9a6-5a49-738d-99a954c51550-ceph: Remove"
   }
 ]

--- a/pkg/libvirttools/libvirt_domain.go
+++ b/pkg/libvirttools/libvirt_domain.go
@@ -111,6 +111,23 @@ func (dc *LibvirtDomainConnection) LookupSecretByUUIDString(uuid string) (virt.V
 	return &LibvirtSecret{secret}, nil
 }
 
+func (dc *LibvirtDomainConnection) LookupSecretByUsageName(usageType string, usageName string) (virt.VirtSecret, error) {
+
+	if usageType != "ceph" {
+		return nil, fmt.Errorf("unsupported type %q for secret with usage name: %q", usageType, usageName)
+	}
+
+	secret, err := dc.conn.LookupSecretByUsage(libvirt.SECRET_USAGE_TYPE_CEPH, usageName)
+	if err != nil {
+		libvirtErr, ok := err.(libvirt.Error)
+		if ok && libvirtErr.Code == libvirt.ERR_NO_SECRET {
+			return nil, virt.ErrSecretNotFound
+		}
+		return nil, err
+	}
+	return &LibvirtSecret{secret}, nil
+}
+
 type LibvirtDomain struct {
 	d *libvirt.Domain
 }

--- a/pkg/virt/domain_interface.go
+++ b/pkg/virt/domain_interface.go
@@ -72,6 +72,10 @@ type VirtDomainConnection interface {
 	// secret cannot be found but no other error occurred, it returns
 	// ErrSecretNotFound
 	LookupSecretByUUIDString(uuid string) (VirtSecret, error)
+	// LookupSecretByUsageName tries to locate the secret by its Usage name. In case if the
+	// secret cannot be found but no other error occurred, it returns
+	// ErrSecretNotFound
+	LookupSecretByUsageName(usageType string, usageName string) (VirtSecret, error)
 }
 
 // Secret represents a secret that's used by the domain

--- a/tests/e2e/run_ceph.sh
+++ b/tests/e2e/run_ceph.sh
@@ -50,7 +50,8 @@ docker exec ${container_name} /bin/bash -c 'echo -e "rbd default features = 1\nr
 # Add rbd pool and volume
 docker exec ${container_name} ceph osd pool create libvirt-pool 8 8
 docker exec ceph_cluster /bin/bash -c "apt-get update && apt-get install -y qemu-utils"
-docker exec ${container_name} qemu-img create -f rbd rbd:libvirt-pool/rbd-test-image 10M 
+docker exec ${container_name} qemu-img create -f rbd rbd:libvirt-pool/rbd-test-image1 10M 
+docker exec ${container_name} qemu-img create -f rbd rbd:libvirt-pool/rbd-test-image2 10M
 docker exec ${container_name} qemu-img create -f rbd rbd:libvirt-pool/rbd-test-image-pv 10M
 
 # Add user for virtlet


### PR DESCRIPTION
Both secret UUID and Usage name must be unique across all definitions to make it possible to have several volumes attached to domain and have multiple domains with attached ceph volumes without causing conflicts, now
- UUID is always generated randomly
- secret's Usage name is generated as `<ceph-user>-<UUIDv5>-<volume-name>`

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/358)
<!-- Reviewable:end -->
