### PR TITLE
Follow upstream changes of libvirt-xml-go

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 84efe2eff9ba1012d0a62ae9adb195b38aa588872ef1ebfa8c04e725bfd689c3
-updated: 2017-07-07T19:33:46.322269832+03:00
+hash: 4dbb56bd2f62c42b2e4b8a0030bf68c43814678defb0afeed48a08e1f2660e7e
+updated: 2017-08-04T09:14:47.288882682+02:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -146,7 +146,6 @@ imports:
 - name: github.com/coreos/pkg
   version: fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8
   subpackages:
-  - capnslog
   - dlopen
   - health
   - httputil
@@ -319,7 +318,7 @@ imports:
 - name: github.com/libvirt/libvirt-go
   version: c3209e4ba8b8dda65c85ca0ac04302e55895caf7
 - name: github.com/libvirt/libvirt-go-xml
-  version: cc4025ea01eee7c73a7c75b4211b07125a8119ae
+  version: 83a754119fc7239caffd1f50e08cb13b1b3825ef
 - name: github.com/mailru/easyjson
   version: d5b7844b561a7bc640052f1b935f7b800330d7e0
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -23,7 +23,7 @@ import:
 - package: github.com/libvirt/libvirt-go
   version: c3209e4ba8b8dda65c85ca0ac04302e55895caf7
 - package: github.com/libvirt/libvirt-go-xml
-  version: cc4025ea01eee7c73a7c75b4211b07125a8119ae
+  version: 83a754119fc7239caffd1f50e08cb13b1b3825ef
 - package: k8s.io/kubernetes
   version: v1.7.0
 - package: k8s.io/apiserver

--- a/libvirt-xml-go.patch
+++ b/libvirt-xml-go.patch
@@ -1,25 +1,11 @@
 diff --git a/domain.go b/domain.go
-index eb7ff9e..46cd806 100644
+index a5d3203..d15af6b 100644
 --- a/domain.go
 +++ b/domain.go
-@@ -522,27 +522,70 @@ type DomainFeatureList struct {
+@@ -597,6 +597,32 @@ type DomainFeatureList struct {
  	SMM        *DomainFeatureState  `xml:"smm"`
  }
- 
-+type QemuArg struct {
-+	Value string `xml:"value,attr"`
-+}
-+
-+type QemuEnv struct {
-+	Name  string `xml:"name,attr"`
-+	Value string `xml:"value,attr,omitempty"`
-+}
-+
-+type DomainCMDLine struct {
-+	Args []QemuArg `xml:"arg"`
-+	Envs []QemuEnv `xml:"env"`
-+}
-+
+
 +type DomainCPUTuneShares struct {
 +	Value uint `xml:",chardata"`
 +}
@@ -46,47 +32,50 @@ index eb7ff9e..46cd806 100644
 +	Locked *DomainMemoryBackingLocked `xml:"locked"`
 +}
 +
- // NB, try to keep the order of fields in this struct
+ type DomainQEMUCommandlineArg struct {
+ 	Value string `xml:"value,attr"`
+ }
+@@ -616,24 +642,26 @@ type DomainQEMUCommandline struct {
  // matching the order of XML elements that libvirt
  // will generate when dumping XML.
  type Domain struct {
--	XMLName       xml.Name           `xml:"domain"`
--	Type          string             `xml:"type,attr,omitempty"`
--	Name          string             `xml:"name"`
--	UUID          string             `xml:"uuid,omitempty"`
--	Memory        *DomainMemory      `xml:"memory"`
--	CurrentMemory *DomainMemory      `xml:"currentMemory"`
--	MaximumMemory *DomainMaxMemory   `xml:"maxMemory"`
--	VCPU          *DomainVCPU        `xml:"vcpu"`
--	Resource      *DomainResource    `xml:"resource"`
--	SysInfo       *DomainSysInfo     `xml:"sysinfo"`
--	OS            *DomainOS          `xml:"os"`
--	Features      *DomainFeatureList `xml:"features"`
--	CPU           *DomainCPU         `xml:"cpu"`
--	OnPoweroff    string             `xml:"on_poweroff,omitempty"`
--	OnReboot      string             `xml:"on_reboot,omitempty"`
--	OnCrash       string             `xml:"on_crash,omitempty"`
--	Devices       *DomainDeviceList  `xml:"devices"`
-+	XMLName       xml.Name             `xml:"domain"`
-+	Type          string               `xml:"type,attr,omitempty"`
-+	Name          string               `xml:"name"`
-+	UUID          string               `xml:"uuid,omitempty"`
-+	Memory        *DomainMemory        `xml:"memory"`
-+	CurrentMemory *DomainMemory        `xml:"currentMemory"`
-+	MaximumMemory *DomainMaxMemory     `xml:"maxMemory"`
-+	MemoryBacking *DomainMemoryBacking `xml:"memoryBacking"`
-+	VCPU          *DomainVCPU          `xml:"vcpu"`
-+	CPUTune       *DomainCPUTune       `xml:"cputune"`
-+	Resource      *DomainResource      `xml:"resource"`
-+	SysInfo       *DomainSysInfo       `xml:"sysinfo"`
-+	OS            *DomainOS            `xml:"os"`
-+	Features      *DomainFeatureList   `xml:"features"`
-+	CPU           *DomainCPU           `xml:"cpu"`
-+	OnPoweroff    string               `xml:"on_poweroff,omitempty"`
-+	OnReboot      string               `xml:"on_reboot,omitempty"`
-+	OnCrash       string               `xml:"on_crash,omitempty"`
-+	Devices       *DomainDeviceList    `xml:"devices"`
-+	CMDLine       *DomainCMDLine       `xml:"http://libvirt.org/schemas/domain/qemu/1.0 commandline"`
+-	XMLName         xml.Name           `xml:"domain"`
+-	Type            string             `xml:"type,attr,omitempty"`
+-	Name            string             `xml:"name"`
+-	UUID            string             `xml:"uuid,omitempty"`
+-	Memory          *DomainMemory      `xml:"memory"`
+-	CurrentMemory   *DomainMemory      `xml:"currentMemory"`
+-	MaximumMemory   *DomainMaxMemory   `xml:"maxMemory"`
+-	VCPU            *DomainVCPU        `xml:"vcpu"`
+-	Resource        *DomainResource    `xml:"resource"`
+-	SysInfo         *DomainSysInfo     `xml:"sysinfo"`
+-	OS              *DomainOS          `xml:"os"`
+-	Features        *DomainFeatureList `xml:"features"`
+-	CPU             *DomainCPU         `xml:"cpu"`
+-	Clock           *DomainClock       `xml:"clock,omitempty"`
+-	OnPoweroff      string             `xml:"on_poweroff,omitempty"`
+-	OnReboot        string             `xml:"on_reboot,omitempty"`
+-	OnCrash         string             `xml:"on_crash,omitempty"`
+-	Devices         *DomainDeviceList  `xml:"devices"`
++	XMLName         xml.Name             `xml:"domain"`
++	Type            string               `xml:"type,attr,omitempty"`
++	Name            string               `xml:"name"`
++	UUID            string               `xml:"uuid,omitempty"`
++	Memory          *DomainMemory        `xml:"memory"`
++	CurrentMemory   *DomainMemory        `xml:"currentMemory"`
++	MaximumMemory   *DomainMaxMemory     `xml:"maxMemory"`
++	MemoryBacking   *DomainMemoryBacking `xml:"memoryBacking"`
++	VCPU            *DomainVCPU          `xml:"vcpu"`
++	CPUTune         *DomainCPUTune       `xml:"cputune"`
++	Resource        *DomainResource      `xml:"resource"`
++	SysInfo         *DomainSysInfo       `xml:"sysinfo"`
++	OS              *DomainOS            `xml:"os"`
++	Features        *DomainFeatureList   `xml:"features"`
++	CPU             *DomainCPU           `xml:"cpu"`
++	Clock           *DomainClock         `xml:"clock,omitempty"`
++	OnPoweroff      string               `xml:"on_poweroff,omitempty"`
++	OnReboot        string               `xml:"on_reboot,omitempty"`
++	OnCrash         string               `xml:"on_crash,omitempty"`
++	Devices         *DomainDeviceList    `xml:"devices"`
+ 	QEMUCommandline *DomainQEMUCommandline
  }
- 
- func (d *Domain) Unmarshal(doc string) error {

--- a/pkg/libvirttools/TestContainerLifecycle.json
+++ b/pkg/libvirttools/TestContainerLifecycle.json
@@ -193,6 +193,7 @@
         "SMM": null
       },
       "CPU": null,
+      "Clock": null,
       "OnPoweroff": "destroy",
       "OnReboot": "restart",
       "OnCrash": "restart",
@@ -224,7 +225,8 @@
               "Type": "qcow2",
               "Cache": "",
               "IO": "",
-              "ErrorPolicy": ""
+              "ErrorPolicy": "",
+              "Discard": ""
             },
             "Auth": null,
             "Source": {
@@ -241,6 +243,7 @@
               "Dev": "sda",
               "Bus": "scsi"
             },
+            "IOTune": null,
             "Serial": "",
             "ReadOnly": null,
             "Shareable": null,
@@ -255,7 +258,8 @@
               "Target": 0,
               "Unit": 0
             },
-            "Boot": null
+            "Boot": null,
+            "WWN": ""
           },
           {
             "XMLName": {
@@ -270,7 +274,8 @@
               "Type": "raw",
               "Cache": "",
               "IO": "",
-              "ErrorPolicy": ""
+              "ErrorPolicy": "",
+              "Discard": ""
             },
             "Auth": null,
             "Source": {
@@ -287,6 +292,7 @@
               "Dev": "sdb",
               "Bus": "scsi"
             },
+            "IOTune": null,
             "Serial": "",
             "ReadOnly": {},
             "Shareable": null,
@@ -301,7 +307,8 @@
               "Target": 0,
               "Unit": 1
             },
-            "Boot": null
+            "Boot": null,
+            "WWN": ""
           }
         ],
         "Filesystems": null,
@@ -351,6 +358,10 @@
         ],
         "Graphics": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "vnc",
             "AutoPort": "",
             "Port": -1,
@@ -390,9 +401,14 @@
         ],
         "Channels": null,
         "MemBalloon": null,
-        "Sounds": null
+        "Sounds": null,
+        "RNGs": null
       },
-      "CMDLine": {
+      "QEMUCommandline": {
+        "XMLName": {
+          "Space": "",
+          "Local": ""
+        },
         "Args": null,
         "Envs": [
           {

--- a/pkg/libvirttools/TestDomainDefinitions__ceph_flexvolume.json
+++ b/pkg/libvirttools/TestDomainDefinitions__ceph_flexvolume.json
@@ -212,6 +212,7 @@
         "SMM": null
       },
       "CPU": null,
+      "Clock": null,
       "OnPoweroff": "destroy",
       "OnReboot": "restart",
       "OnCrash": "restart",
@@ -243,7 +244,8 @@
               "Type": "qcow2",
               "Cache": "",
               "IO": "",
-              "ErrorPolicy": ""
+              "ErrorPolicy": "",
+              "Discard": ""
             },
             "Auth": null,
             "Source": {
@@ -260,6 +262,7 @@
               "Dev": "sda",
               "Bus": "scsi"
             },
+            "IOTune": null,
             "Serial": "",
             "ReadOnly": null,
             "Shareable": null,
@@ -274,7 +277,8 @@
               "Target": 0,
               "Unit": 0
             },
-            "Boot": null
+            "Boot": null,
+            "WWN": ""
           },
           {
             "XMLName": {
@@ -289,7 +293,8 @@
               "Type": "raw",
               "Cache": "",
               "IO": "",
-              "ErrorPolicy": ""
+              "ErrorPolicy": "",
+              "Discard": ""
             },
             "Auth": {
               "Username": "libvirt",
@@ -320,6 +325,7 @@
               "Dev": "sdb",
               "Bus": "scsi"
             },
+            "IOTune": null,
             "Serial": "",
             "ReadOnly": null,
             "Shareable": null,
@@ -334,7 +340,8 @@
               "Target": 0,
               "Unit": 1
             },
-            "Boot": null
+            "Boot": null,
+            "WWN": ""
           },
           {
             "XMLName": {
@@ -349,7 +356,8 @@
               "Type": "raw",
               "Cache": "",
               "IO": "",
-              "ErrorPolicy": ""
+              "ErrorPolicy": "",
+              "Discard": ""
             },
             "Auth": null,
             "Source": {
@@ -366,6 +374,7 @@
               "Dev": "sdc",
               "Bus": "scsi"
             },
+            "IOTune": null,
             "Serial": "",
             "ReadOnly": {},
             "Shareable": null,
@@ -380,7 +389,8 @@
               "Target": 0,
               "Unit": 2
             },
-            "Boot": null
+            "Boot": null,
+            "WWN": ""
           }
         ],
         "Filesystems": null,
@@ -430,6 +440,10 @@
         ],
         "Graphics": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "vnc",
             "AutoPort": "",
             "Port": -1,
@@ -469,9 +483,14 @@
         ],
         "Channels": null,
         "MemBalloon": null,
-        "Sounds": null
+        "Sounds": null,
+        "RNGs": null
       },
-      "CMDLine": {
+      "QEMUCommandline": {
+        "XMLName": {
+          "Space": "",
+          "Local": ""
+        },
         "Args": null,
         "Envs": [
           {

--- a/pkg/libvirttools/TestDomainDefinitions__cloud-init.json
+++ b/pkg/libvirttools/TestDomainDefinitions__cloud-init.json
@@ -189,6 +189,7 @@
         "SMM": null
       },
       "CPU": null,
+      "Clock": null,
       "OnPoweroff": "destroy",
       "OnReboot": "restart",
       "OnCrash": "restart",
@@ -220,7 +221,8 @@
               "Type": "qcow2",
               "Cache": "",
               "IO": "",
-              "ErrorPolicy": ""
+              "ErrorPolicy": "",
+              "Discard": ""
             },
             "Auth": null,
             "Source": {
@@ -237,6 +239,7 @@
               "Dev": "sda",
               "Bus": "scsi"
             },
+            "IOTune": null,
             "Serial": "",
             "ReadOnly": null,
             "Shareable": null,
@@ -251,7 +254,8 @@
               "Target": 0,
               "Unit": 0
             },
-            "Boot": null
+            "Boot": null,
+            "WWN": ""
           },
           {
             "XMLName": {
@@ -266,7 +270,8 @@
               "Type": "raw",
               "Cache": "",
               "IO": "",
-              "ErrorPolicy": ""
+              "ErrorPolicy": "",
+              "Discard": ""
             },
             "Auth": null,
             "Source": {
@@ -283,6 +288,7 @@
               "Dev": "sdb",
               "Bus": "scsi"
             },
+            "IOTune": null,
             "Serial": "",
             "ReadOnly": {},
             "Shareable": null,
@@ -297,7 +303,8 @@
               "Target": 0,
               "Unit": 1
             },
-            "Boot": null
+            "Boot": null,
+            "WWN": ""
           }
         ],
         "Filesystems": null,
@@ -347,6 +354,10 @@
         ],
         "Graphics": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "vnc",
             "AutoPort": "",
             "Port": -1,
@@ -386,9 +397,14 @@
         ],
         "Channels": null,
         "MemBalloon": null,
-        "Sounds": null
+        "Sounds": null,
+        "RNGs": null
       },
-      "CMDLine": {
+      "QEMUCommandline": {
+        "XMLName": {
+          "Space": "",
+          "Local": ""
+        },
         "Args": null,
         "Envs": [
           {

--- a/pkg/libvirttools/TestDomainDefinitions__cloud-init_with_user_data.json
+++ b/pkg/libvirttools/TestDomainDefinitions__cloud-init_with_user_data.json
@@ -189,6 +189,7 @@
         "SMM": null
       },
       "CPU": null,
+      "Clock": null,
       "OnPoweroff": "destroy",
       "OnReboot": "restart",
       "OnCrash": "restart",
@@ -220,7 +221,8 @@
               "Type": "qcow2",
               "Cache": "",
               "IO": "",
-              "ErrorPolicy": ""
+              "ErrorPolicy": "",
+              "Discard": ""
             },
             "Auth": null,
             "Source": {
@@ -237,6 +239,7 @@
               "Dev": "sda",
               "Bus": "scsi"
             },
+            "IOTune": null,
             "Serial": "",
             "ReadOnly": null,
             "Shareable": null,
@@ -251,7 +254,8 @@
               "Target": 0,
               "Unit": 0
             },
-            "Boot": null
+            "Boot": null,
+            "WWN": ""
           },
           {
             "XMLName": {
@@ -266,7 +270,8 @@
               "Type": "raw",
               "Cache": "",
               "IO": "",
-              "ErrorPolicy": ""
+              "ErrorPolicy": "",
+              "Discard": ""
             },
             "Auth": null,
             "Source": {
@@ -283,6 +288,7 @@
               "Dev": "sdb",
               "Bus": "scsi"
             },
+            "IOTune": null,
             "Serial": "",
             "ReadOnly": {},
             "Shareable": null,
@@ -297,7 +303,8 @@
               "Target": 0,
               "Unit": 1
             },
-            "Boot": null
+            "Boot": null,
+            "WWN": ""
           }
         ],
         "Filesystems": null,
@@ -347,6 +354,10 @@
         ],
         "Graphics": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "vnc",
             "AutoPort": "",
             "Port": -1,
@@ -386,9 +397,14 @@
         ],
         "Channels": null,
         "MemBalloon": null,
-        "Sounds": null
+        "Sounds": null,
+        "RNGs": null
       },
-      "CMDLine": {
+      "QEMUCommandline": {
+        "XMLName": {
+          "Space": "",
+          "Local": ""
+        },
         "Args": null,
         "Envs": [
           {

--- a/pkg/libvirttools/TestDomainDefinitions__plain_domain.json
+++ b/pkg/libvirttools/TestDomainDefinitions__plain_domain.json
@@ -189,6 +189,7 @@
         "SMM": null
       },
       "CPU": null,
+      "Clock": null,
       "OnPoweroff": "destroy",
       "OnReboot": "restart",
       "OnCrash": "restart",
@@ -220,7 +221,8 @@
               "Type": "qcow2",
               "Cache": "",
               "IO": "",
-              "ErrorPolicy": ""
+              "ErrorPolicy": "",
+              "Discard": ""
             },
             "Auth": null,
             "Source": {
@@ -237,6 +239,7 @@
               "Dev": "sda",
               "Bus": "scsi"
             },
+            "IOTune": null,
             "Serial": "",
             "ReadOnly": null,
             "Shareable": null,
@@ -251,7 +254,8 @@
               "Target": 0,
               "Unit": 0
             },
-            "Boot": null
+            "Boot": null,
+            "WWN": ""
           },
           {
             "XMLName": {
@@ -266,7 +270,8 @@
               "Type": "raw",
               "Cache": "",
               "IO": "",
-              "ErrorPolicy": ""
+              "ErrorPolicy": "",
+              "Discard": ""
             },
             "Auth": null,
             "Source": {
@@ -283,6 +288,7 @@
               "Dev": "sdb",
               "Bus": "scsi"
             },
+            "IOTune": null,
             "Serial": "",
             "ReadOnly": {},
             "Shareable": null,
@@ -297,7 +303,8 @@
               "Target": 0,
               "Unit": 1
             },
-            "Boot": null
+            "Boot": null,
+            "WWN": ""
           }
         ],
         "Filesystems": null,
@@ -347,6 +354,10 @@
         ],
         "Graphics": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "vnc",
             "AutoPort": "",
             "Port": -1,
@@ -386,9 +397,14 @@
         ],
         "Channels": null,
         "MemBalloon": null,
-        "Sounds": null
+        "Sounds": null,
+        "RNGs": null
       },
-      "CMDLine": {
+      "QEMUCommandline": {
+        "XMLName": {
+          "Space": "",
+          "Local": ""
+        },
         "Args": null,
         "Envs": [
           {

--- a/pkg/libvirttools/TestDomainDefinitions__raw_devices.json
+++ b/pkg/libvirttools/TestDomainDefinitions__raw_devices.json
@@ -189,6 +189,7 @@
         "SMM": null
       },
       "CPU": null,
+      "Clock": null,
       "OnPoweroff": "destroy",
       "OnReboot": "restart",
       "OnCrash": "restart",
@@ -220,7 +221,8 @@
               "Type": "qcow2",
               "Cache": "",
               "IO": "",
-              "ErrorPolicy": ""
+              "ErrorPolicy": "",
+              "Discard": ""
             },
             "Auth": null,
             "Source": {
@@ -237,6 +239,7 @@
               "Dev": "sda",
               "Bus": "scsi"
             },
+            "IOTune": null,
             "Serial": "",
             "ReadOnly": null,
             "Shareable": null,
@@ -251,7 +254,8 @@
               "Target": 0,
               "Unit": 0
             },
-            "Boot": null
+            "Boot": null,
+            "WWN": ""
           },
           {
             "XMLName": {
@@ -266,7 +270,8 @@
               "Type": "raw",
               "Cache": "",
               "IO": "",
-              "ErrorPolicy": ""
+              "ErrorPolicy": "",
+              "Discard": ""
             },
             "Auth": null,
             "Source": {
@@ -283,6 +288,7 @@
               "Dev": "sdb",
               "Bus": "scsi"
             },
+            "IOTune": null,
             "Serial": "",
             "ReadOnly": null,
             "Shareable": null,
@@ -297,7 +303,8 @@
               "Target": 0,
               "Unit": 1
             },
-            "Boot": null
+            "Boot": null,
+            "WWN": ""
           },
           {
             "XMLName": {
@@ -312,7 +319,8 @@
               "Type": "raw",
               "Cache": "",
               "IO": "",
-              "ErrorPolicy": ""
+              "ErrorPolicy": "",
+              "Discard": ""
             },
             "Auth": null,
             "Source": {
@@ -329,6 +337,7 @@
               "Dev": "sdc",
               "Bus": "scsi"
             },
+            "IOTune": null,
             "Serial": "",
             "ReadOnly": {},
             "Shareable": null,
@@ -343,7 +352,8 @@
               "Target": 0,
               "Unit": 2
             },
-            "Boot": null
+            "Boot": null,
+            "WWN": ""
           }
         ],
         "Filesystems": null,
@@ -393,6 +403,10 @@
         ],
         "Graphics": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "vnc",
             "AutoPort": "",
             "Port": -1,
@@ -432,9 +446,14 @@
         ],
         "Channels": null,
         "MemBalloon": null,
-        "Sounds": null
+        "Sounds": null,
+        "RNGs": null
       },
-      "CMDLine": {
+      "QEMUCommandline": {
+        "XMLName": {
+          "Space": "",
+          "Local": ""
+        },
         "Args": null,
         "Envs": [
           {

--- a/pkg/libvirttools/TestDomainDefinitions__vcpu_count.json
+++ b/pkg/libvirttools/TestDomainDefinitions__vcpu_count.json
@@ -189,6 +189,7 @@
         "SMM": null
       },
       "CPU": null,
+      "Clock": null,
       "OnPoweroff": "destroy",
       "OnReboot": "restart",
       "OnCrash": "restart",
@@ -220,7 +221,8 @@
               "Type": "qcow2",
               "Cache": "",
               "IO": "",
-              "ErrorPolicy": ""
+              "ErrorPolicy": "",
+              "Discard": ""
             },
             "Auth": null,
             "Source": {
@@ -237,6 +239,7 @@
               "Dev": "sda",
               "Bus": "scsi"
             },
+            "IOTune": null,
             "Serial": "",
             "ReadOnly": null,
             "Shareable": null,
@@ -251,7 +254,8 @@
               "Target": 0,
               "Unit": 0
             },
-            "Boot": null
+            "Boot": null,
+            "WWN": ""
           },
           {
             "XMLName": {
@@ -266,7 +270,8 @@
               "Type": "raw",
               "Cache": "",
               "IO": "",
-              "ErrorPolicy": ""
+              "ErrorPolicy": "",
+              "Discard": ""
             },
             "Auth": null,
             "Source": {
@@ -283,6 +288,7 @@
               "Dev": "sdb",
               "Bus": "scsi"
             },
+            "IOTune": null,
             "Serial": "",
             "ReadOnly": {},
             "Shareable": null,
@@ -297,7 +303,8 @@
               "Target": 0,
               "Unit": 1
             },
-            "Boot": null
+            "Boot": null,
+            "WWN": ""
           }
         ],
         "Filesystems": null,
@@ -347,6 +354,10 @@
         ],
         "Graphics": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "vnc",
             "AutoPort": "",
             "Port": -1,
@@ -386,9 +397,14 @@
         ],
         "Channels": null,
         "MemBalloon": null,
-        "Sounds": null
+        "Sounds": null,
+        "RNGs": null
       },
-      "CMDLine": {
+      "QEMUCommandline": {
+        "XMLName": {
+          "Space": "",
+          "Local": ""
+        },
         "Args": null,
         "Envs": [
           {

--- a/pkg/libvirttools/TestDomainDefinitions__virtio_disk_driver.json
+++ b/pkg/libvirttools/TestDomainDefinitions__virtio_disk_driver.json
@@ -189,6 +189,7 @@
         "SMM": null
       },
       "CPU": null,
+      "Clock": null,
       "OnPoweroff": "destroy",
       "OnReboot": "restart",
       "OnCrash": "restart",
@@ -220,7 +221,8 @@
               "Type": "qcow2",
               "Cache": "",
               "IO": "",
-              "ErrorPolicy": ""
+              "ErrorPolicy": "",
+              "Discard": ""
             },
             "Auth": null,
             "Source": {
@@ -237,6 +239,7 @@
               "Dev": "vda",
               "Bus": "virtio"
             },
+            "IOTune": null,
             "Serial": "",
             "ReadOnly": null,
             "Shareable": null,
@@ -251,7 +254,8 @@
               "Target": null,
               "Unit": null
             },
-            "Boot": null
+            "Boot": null,
+            "WWN": ""
           },
           {
             "XMLName": {
@@ -266,7 +270,8 @@
               "Type": "raw",
               "Cache": "",
               "IO": "",
-              "ErrorPolicy": ""
+              "ErrorPolicy": "",
+              "Discard": ""
             },
             "Auth": null,
             "Source": {
@@ -283,6 +288,7 @@
               "Dev": "vdb",
               "Bus": "virtio"
             },
+            "IOTune": null,
             "Serial": "",
             "ReadOnly": {},
             "Shareable": null,
@@ -297,7 +303,8 @@
               "Target": null,
               "Unit": null
             },
-            "Boot": null
+            "Boot": null,
+            "WWN": ""
           }
         ],
         "Filesystems": null,
@@ -347,6 +354,10 @@
         ],
         "Graphics": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "vnc",
             "AutoPort": "",
             "Port": -1,
@@ -386,9 +397,14 @@
         ],
         "Channels": null,
         "MemBalloon": null,
-        "Sounds": null
+        "Sounds": null,
+        "RNGs": null
       },
-      "CMDLine": {
+      "QEMUCommandline": {
+        "XMLName": {
+          "Space": "",
+          "Local": ""
+        },
         "Args": null,
         "Envs": [
           {

--- a/pkg/libvirttools/TestDomainDefinitions__volumes.json
+++ b/pkg/libvirttools/TestDomainDefinitions__volumes.json
@@ -300,6 +300,7 @@
         "SMM": null
       },
       "CPU": null,
+      "Clock": null,
       "OnPoweroff": "destroy",
       "OnReboot": "restart",
       "OnCrash": "restart",
@@ -331,7 +332,8 @@
               "Type": "qcow2",
               "Cache": "",
               "IO": "",
-              "ErrorPolicy": ""
+              "ErrorPolicy": "",
+              "Discard": ""
             },
             "Auth": null,
             "Source": {
@@ -348,6 +350,7 @@
               "Dev": "sda",
               "Bus": "scsi"
             },
+            "IOTune": null,
             "Serial": "",
             "ReadOnly": null,
             "Shareable": null,
@@ -362,7 +365,8 @@
               "Target": 0,
               "Unit": 0
             },
-            "Boot": null
+            "Boot": null,
+            "WWN": ""
           },
           {
             "XMLName": {
@@ -377,7 +381,8 @@
               "Type": "qcow2",
               "Cache": "",
               "IO": "",
-              "ErrorPolicy": ""
+              "ErrorPolicy": "",
+              "Discard": ""
             },
             "Auth": null,
             "Source": {
@@ -394,6 +399,7 @@
               "Dev": "sdb",
               "Bus": "scsi"
             },
+            "IOTune": null,
             "Serial": "",
             "ReadOnly": null,
             "Shareable": null,
@@ -408,7 +414,8 @@
               "Target": 0,
               "Unit": 1
             },
-            "Boot": null
+            "Boot": null,
+            "WWN": ""
           },
           {
             "XMLName": {
@@ -423,7 +430,8 @@
               "Type": "qcow2",
               "Cache": "",
               "IO": "",
-              "ErrorPolicy": ""
+              "ErrorPolicy": "",
+              "Discard": ""
             },
             "Auth": null,
             "Source": {
@@ -440,6 +448,7 @@
               "Dev": "sdc",
               "Bus": "scsi"
             },
+            "IOTune": null,
             "Serial": "",
             "ReadOnly": null,
             "Shareable": null,
@@ -454,7 +463,8 @@
               "Target": 0,
               "Unit": 2
             },
-            "Boot": null
+            "Boot": null,
+            "WWN": ""
           },
           {
             "XMLName": {
@@ -469,7 +479,8 @@
               "Type": "qcow2",
               "Cache": "",
               "IO": "",
-              "ErrorPolicy": ""
+              "ErrorPolicy": "",
+              "Discard": ""
             },
             "Auth": null,
             "Source": {
@@ -486,6 +497,7 @@
               "Dev": "sdd",
               "Bus": "scsi"
             },
+            "IOTune": null,
             "Serial": "",
             "ReadOnly": null,
             "Shareable": null,
@@ -500,7 +512,8 @@
               "Target": 0,
               "Unit": 3
             },
-            "Boot": null
+            "Boot": null,
+            "WWN": ""
           },
           {
             "XMLName": {
@@ -515,7 +528,8 @@
               "Type": "raw",
               "Cache": "",
               "IO": "",
-              "ErrorPolicy": ""
+              "ErrorPolicy": "",
+              "Discard": ""
             },
             "Auth": null,
             "Source": {
@@ -532,6 +546,7 @@
               "Dev": "sde",
               "Bus": "scsi"
             },
+            "IOTune": null,
             "Serial": "",
             "ReadOnly": {},
             "Shareable": null,
@@ -546,7 +561,8 @@
               "Target": 0,
               "Unit": 4
             },
-            "Boot": null
+            "Boot": null,
+            "WWN": ""
           }
         ],
         "Filesystems": null,
@@ -596,6 +612,10 @@
         ],
         "Graphics": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "vnc",
             "AutoPort": "",
             "Port": -1,
@@ -635,9 +655,14 @@
         ],
         "Channels": null,
         "MemBalloon": null,
-        "Sounds": null
+        "Sounds": null,
+        "RNGs": null
       },
-      "CMDLine": {
+      "QEMUCommandline": {
+        "XMLName": {
+          "Space": "",
+          "Local": ""
+        },
         "Args": null,
         "Envs": [
           {

--- a/pkg/libvirttools/TestDomainForcedShutdown.json
+++ b/pkg/libvirttools/TestDomainForcedShutdown.json
@@ -189,6 +189,7 @@
         "SMM": null
       },
       "CPU": null,
+      "Clock": null,
       "OnPoweroff": "destroy",
       "OnReboot": "restart",
       "OnCrash": "restart",
@@ -220,7 +221,8 @@
               "Type": "qcow2",
               "Cache": "",
               "IO": "",
-              "ErrorPolicy": ""
+              "ErrorPolicy": "",
+              "Discard": ""
             },
             "Auth": null,
             "Source": {
@@ -237,6 +239,7 @@
               "Dev": "sda",
               "Bus": "scsi"
             },
+            "IOTune": null,
             "Serial": "",
             "ReadOnly": null,
             "Shareable": null,
@@ -251,7 +254,8 @@
               "Target": 0,
               "Unit": 0
             },
-            "Boot": null
+            "Boot": null,
+            "WWN": ""
           },
           {
             "XMLName": {
@@ -266,7 +270,8 @@
               "Type": "raw",
               "Cache": "",
               "IO": "",
-              "ErrorPolicy": ""
+              "ErrorPolicy": "",
+              "Discard": ""
             },
             "Auth": null,
             "Source": {
@@ -283,6 +288,7 @@
               "Dev": "sdb",
               "Bus": "scsi"
             },
+            "IOTune": null,
             "Serial": "",
             "ReadOnly": {},
             "Shareable": null,
@@ -297,7 +303,8 @@
               "Target": 0,
               "Unit": 1
             },
-            "Boot": null
+            "Boot": null,
+            "WWN": ""
           }
         ],
         "Filesystems": null,
@@ -347,6 +354,10 @@
         ],
         "Graphics": [
           {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
             "Type": "vnc",
             "AutoPort": "",
             "Port": -1,
@@ -386,9 +397,14 @@
         ],
         "Channels": null,
         "MemBalloon": null,
-        "Sounds": null
+        "Sounds": null,
+        "RNGs": null
       },
-      "CMDLine": {
+      "QEMUCommandline": {
+        "XMLName": {
+          "Space": "",
+          "Local": ""
+        },
         "Args": null,
         "Envs": [
           {

--- a/pkg/libvirttools/TestRootVolumeLifeCycle.json
+++ b/pkg/libvirttools/TestRootVolumeLifeCycle.json
@@ -49,7 +49,8 @@
         "Type": "qcow2",
         "Cache": "",
         "IO": "",
-        "ErrorPolicy": ""
+        "ErrorPolicy": "",
+        "Discard": ""
       },
       "Auth": null,
       "Source": {
@@ -63,11 +64,13 @@
         "StartupPolicy": ""
       },
       "Target": null,
+      "IOTune": null,
       "Serial": "",
       "ReadOnly": null,
       "Shareable": null,
       "Address": null,
-      "Boot": null
+      "Boot": null,
+      "WWN": ""
     }
   },
   {

--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -140,11 +140,11 @@ func (ds *domainSettings) createDomain() *libvirtxml.Domain {
 		},
 		MemoryBacking: &libvirtxml.DomainMemoryBacking{Locked: &libvirtxml.DomainMemoryBackingLocked{}},
 
-		CMDLine: &libvirtxml.DomainCMDLine{
-			Envs: []libvirtxml.QemuEnv{
-				libvirtxml.QemuEnv{Name: "VIRTLET_EMULATOR", Value: emulator},
-				libvirtxml.QemuEnv{Name: "VIRTLET_NS", Value: ds.netNSPath},
-				libvirtxml.QemuEnv{Name: "VIRTLET_CNI_CONFIG", Value: ds.cniConfig},
+		QEMUCommandline: &libvirtxml.DomainQEMUCommandline{
+			Envs: []libvirtxml.DomainQEMUCommandlineEnv{
+				libvirtxml.DomainQEMUCommandlineEnv{Name: "VIRTLET_EMULATOR", Value: emulator},
+				libvirtxml.DomainQEMUCommandlineEnv{Name: "VIRTLET_NS", Value: ds.netNSPath},
+				libvirtxml.DomainQEMUCommandlineEnv{Name: "VIRTLET_CNI_CONFIG", Value: ds.cniConfig},
 			},
 		},
 	}


### PR DESCRIPTION
Virtlet uses a patch to adjust libvirt-xml-go domain definition. But due to changes in libvirt-xml-go upstream it's no longer possible to apply the patch. With this commit we update the patch so that it now follows the upstream. Also, some changes were conflicting therefore we needed to modify the Virtlet code that relies on those changes. 

Namely, virtlet's patch suggested following struct for providing bootcmd:
```
DomainCMDLine
|-> Args: []QemuArg
|-> Envs: []QemuEnv
```

but the upstream code now provides following struct:
```
DomainQEMUCommandline
|-> Args: []DomainQEMUCommandlineArg
|-> Envs: []DomainQEMUCommandlineEnv
```

So we had to enforce such naming also in Virtlet code.

Fixes https://github.com/Mirantis/virtlet/issues/375

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/376)
<!-- Reviewable:end -->
