### PR TITLE
Provide garbage collection

### DIFF
--- a/docs/cri-tools.md
+++ b/docs/cri-tools.md
@@ -162,7 +162,7 @@ download.cirros-cloud.net/0.3.5/cirros-0.3.5-x86_64-disk.img
 # virsh vol-list --pool volumes
  Name                 Path
 ------------------------------------------------------------------------------
- root_264e1739-7b6a-5a3d-564c-baae69b5bdb0 /var/lib/virtlet/root_264e1739-7b6a-5a3d-564c-baae69b5bdb0
+ virtlet_root_264e1739-7b6a-5a3d-564c-baae69b5bdb0 /var/lib/virtlet/virtlet_root_264e1739-7b6a-5a3d-564c-baae69b5bdb0
 
 root@3ef5de7d492b:/go/src/github.com/Mirantis/virtlet# virsh list --all
  Id    Name                           State

--- a/docs/volumes.md
+++ b/docs/volumes.md
@@ -287,7 +287,7 @@ spec:
 # virsh domblklist 2
 Target     Source
 ------------------------------------------------
-sda        /var/lib/virtlet/root_de0ae972-4154-4f8f-70ff-48335987b5ce
+sda        /var/lib/virtlet/virtlet_root_de0ae972-4154-4f8f-70ff-48335987b5ce
 sdb        libvirt-pool/rbd-test-image
 ```
 

--- a/examples/virsh.sh
+++ b/examples/virsh.sh
@@ -25,8 +25,11 @@ function get_pod_domain_id {
   if [[ ${namespace} ]]; then
       namespace_opts="-n ${namespace}"
   fi
-  kubectl get pod ${namespace_opts} "${pod_name}" \
-          -o 'jsonpath={.status.containerStatuses[0].containerID}-{.status.containerStatuses[0].name}'|sed 's/.*__//'
+  container_id=$(kubectl get pod ${namespace_opts} "${pod_name}" \
+	  -o 'jsonpath={.status.containerStatuses[0].containerID}'|sed 's/.*__//')
+  container_name=$(kubectl get pod ${namespace_opts} "${pod_name}" \
+	  -o 'jsonpath={.status.containerStatuses[0].name}'|sed 's/.*__//')
+  echo "virtlet-${container_id:0:13}-${container_name}"
 }
 
 if [[ ${1:-} = "poddomain" ]]; then
@@ -40,7 +43,7 @@ fi
 
 for ((n=0; n < ${#args[@]}; n++)); do
   if [[ ${args[${n}]} =~ ^@ ]]; then
-    args[${n}]="virtlet-$(get_pod_domain_id "${args[${n}]}")"
+    args[${n}]="$(get_pod_domain_id "${args[${n}]}")"
   fi
 done
 

--- a/examples/virsh.sh
+++ b/examples/virsh.sh
@@ -40,7 +40,7 @@ fi
 
 for ((n=0; n < ${#args[@]}; n++)); do
   if [[ ${args[${n}]} =~ ^@ ]]; then
-    args[${n}]="$(get_pod_domain_id "${args[${n}]}")"
+    args[${n}]="virtlet-$(get_pod_domain_id "${args[${n}]}")"
   fi
 done
 

--- a/pkg/libvirttools/TestContainerLifecycle.json
+++ b/pkg/libvirttools/TestContainerLifecycle.json
@@ -88,7 +88,7 @@
           "Local": ""
         },
         "Type": "file",
-        "Name": "root_231700d5-c9a6-5a49-738d-99a954c51550",
+        "Name": "virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550",
         "Key": "",
         "Allocation": null,
         "Capacity": null,
@@ -228,7 +228,7 @@
             },
             "Auth": null,
             "Source": {
-              "File": "/var/lib/virtlet/volumes/root_231700d5-c9a6-5a49-738d-99a954c51550",
+              "File": "/var/lib/virtlet/volumes/virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550",
               "Device": "",
               "Protocol": "",
               "Name": "",
@@ -478,7 +478,7 @@
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",
-    "data": "root_231700d5-c9a6-5a49-738d-99a954c51550"
+    "data": "virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550"
   },
   {
     "name": "container status after the container is stopped",
@@ -511,7 +511,7 @@
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",
-    "data": "root_231700d5-c9a6-5a49-738d-99a954c51550"
+    "data": "virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550"
   },
   {
     "name": "domain conn: ListDomains",

--- a/pkg/libvirttools/TestContainerLifecycle.json
+++ b/pkg/libvirttools/TestContainerLifecycle.json
@@ -125,7 +125,7 @@
         "Local": ""
       },
       "Type": "kvm",
-      "Name": "virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1",
+      "Name": "virtlet-231700d5-c9a6-container1",
       "UUID": "231700d5-c9a6-5a49-738d-99a954c51550",
       "Memory": {
         "Value": 1024,
@@ -414,7 +414,7 @@
   {
     "name": "domain conn: ListDomains",
     "data": [
-      "virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1"
+      "virtlet-231700d5-c9a6-container1"
     ]
   },
   {
@@ -445,7 +445,7 @@
     ]
   },
   {
-    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Create"
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Create"
   },
   {
     "name": "container status after the container is started",
@@ -474,7 +474,7 @@
     }
   },
   {
-    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Shutdown"
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Shutdown"
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",
@@ -507,7 +507,7 @@
     }
   },
   {
-    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Undefine"
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",

--- a/pkg/libvirttools/TestContainerLifecycle.json
+++ b/pkg/libvirttools/TestContainerLifecycle.json
@@ -125,7 +125,7 @@
         "Local": ""
       },
       "Type": "kvm",
-      "Name": "231700d5-c9a6-5a49-738d-99a954c51550-container1",
+      "Name": "virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1",
       "UUID": "231700d5-c9a6-5a49-738d-99a954c51550",
       "Memory": {
         "Value": 1024,
@@ -414,7 +414,7 @@
   {
     "name": "domain conn: ListDomains",
     "data": [
-      "231700d5-c9a6-5a49-738d-99a954c51550-container1"
+      "virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1"
     ]
   },
   {
@@ -445,7 +445,7 @@
     ]
   },
   {
-    "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Create"
+    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Create"
   },
   {
     "name": "container status after the container is started",
@@ -474,7 +474,7 @@
     }
   },
   {
-    "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Shutdown"
+    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Shutdown"
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",
@@ -507,7 +507,7 @@
     }
   },
   {
-    "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
+    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",

--- a/pkg/libvirttools/TestDomainDefinitions__ceph_flexvolume.json
+++ b/pkg/libvirttools/TestDomainDefinitions__ceph_flexvolume.json
@@ -144,7 +144,7 @@
         "Local": ""
       },
       "Type": "kvm",
-      "Name": "virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1",
+      "Name": "virtlet-231700d5-c9a6-container1",
       "UUID": "231700d5-c9a6-5a49-738d-99a954c51550",
       "Memory": {
         "Value": 1024,
@@ -491,7 +491,7 @@
     }
   },
   {
-    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Undefine"
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",

--- a/pkg/libvirttools/TestDomainDefinitions__ceph_flexvolume.json
+++ b/pkg/libvirttools/TestDomainDefinitions__ceph_flexvolume.json
@@ -144,7 +144,7 @@
         "Local": ""
       },
       "Type": "kvm",
-      "Name": "231700d5-c9a6-5a49-738d-99a954c51550-container1",
+      "Name": "virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1",
       "UUID": "231700d5-c9a6-5a49-738d-99a954c51550",
       "Memory": {
         "Value": 1024,
@@ -491,7 +491,7 @@
     }
   },
   {
-    "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
+    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",

--- a/pkg/libvirttools/TestDomainDefinitions__ceph_flexvolume.json
+++ b/pkg/libvirttools/TestDomainDefinitions__ceph_flexvolume.json
@@ -84,7 +84,7 @@
           "Local": ""
         },
         "Type": "file",
-        "Name": "root_231700d5-c9a6-5a49-738d-99a954c51550",
+        "Name": "virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550",
         "Key": "",
         "Allocation": null,
         "Capacity": null,
@@ -247,7 +247,7 @@
             },
             "Auth": null,
             "Source": {
-              "File": "/var/lib/virtlet/volumes/root_231700d5-c9a6-5a49-738d-99a954c51550",
+              "File": "/var/lib/virtlet/volumes/virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550",
               "Device": "",
               "Protocol": "",
               "Name": "",
@@ -495,7 +495,7 @@
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",
-    "data": "root_231700d5-c9a6-5a49-738d-99a954c51550"
+    "data": "virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550"
   },
   {
     "name": "domain conn: secret libvirt-231700d5-c9a6-5a49-738d-99a954c51550-ceph: Remove"

--- a/pkg/libvirttools/TestDomainDefinitions__cloud-init.json
+++ b/pkg/libvirttools/TestDomainDefinitions__cloud-init.json
@@ -84,7 +84,7 @@
           "Local": ""
         },
         "Type": "file",
-        "Name": "root_231700d5-c9a6-5a49-738d-99a954c51550",
+        "Name": "virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550",
         "Key": "",
         "Allocation": null,
         "Capacity": null,
@@ -224,7 +224,7 @@
             },
             "Auth": null,
             "Source": {
-              "File": "/var/lib/virtlet/volumes/root_231700d5-c9a6-5a49-738d-99a954c51550",
+              "File": "/var/lib/virtlet/volumes/virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550",
               "Device": "",
               "Protocol": "",
               "Name": "",
@@ -412,6 +412,6 @@
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",
-    "data": "root_231700d5-c9a6-5a49-738d-99a954c51550"
+    "data": "virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550"
   }
 ]

--- a/pkg/libvirttools/TestDomainDefinitions__cloud-init.json
+++ b/pkg/libvirttools/TestDomainDefinitions__cloud-init.json
@@ -121,7 +121,7 @@
         "Local": ""
       },
       "Type": "kvm",
-      "Name": "231700d5-c9a6-5a49-738d-99a954c51550-container1",
+      "Name": "virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1",
       "UUID": "231700d5-c9a6-5a49-738d-99a954c51550",
       "Memory": {
         "Value": 1024,
@@ -408,7 +408,7 @@
     }
   },
   {
-    "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
+    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",

--- a/pkg/libvirttools/TestDomainDefinitions__cloud-init.json
+++ b/pkg/libvirttools/TestDomainDefinitions__cloud-init.json
@@ -121,7 +121,7 @@
         "Local": ""
       },
       "Type": "kvm",
-      "Name": "virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1",
+      "Name": "virtlet-231700d5-c9a6-container1",
       "UUID": "231700d5-c9a6-5a49-738d-99a954c51550",
       "Memory": {
         "Value": 1024,
@@ -408,7 +408,7 @@
     }
   },
   {
-    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Undefine"
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",

--- a/pkg/libvirttools/TestDomainDefinitions__cloud-init_with_user_data.json
+++ b/pkg/libvirttools/TestDomainDefinitions__cloud-init_with_user_data.json
@@ -84,7 +84,7 @@
           "Local": ""
         },
         "Type": "file",
-        "Name": "root_231700d5-c9a6-5a49-738d-99a954c51550",
+        "Name": "virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550",
         "Key": "",
         "Allocation": null,
         "Capacity": null,
@@ -224,7 +224,7 @@
             },
             "Auth": null,
             "Source": {
-              "File": "/var/lib/virtlet/volumes/root_231700d5-c9a6-5a49-738d-99a954c51550",
+              "File": "/var/lib/virtlet/volumes/virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550",
               "Device": "",
               "Protocol": "",
               "Name": "",
@@ -412,6 +412,6 @@
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",
-    "data": "root_231700d5-c9a6-5a49-738d-99a954c51550"
+    "data": "virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550"
   }
 ]

--- a/pkg/libvirttools/TestDomainDefinitions__cloud-init_with_user_data.json
+++ b/pkg/libvirttools/TestDomainDefinitions__cloud-init_with_user_data.json
@@ -121,7 +121,7 @@
         "Local": ""
       },
       "Type": "kvm",
-      "Name": "231700d5-c9a6-5a49-738d-99a954c51550-container1",
+      "Name": "virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1",
       "UUID": "231700d5-c9a6-5a49-738d-99a954c51550",
       "Memory": {
         "Value": 1024,
@@ -408,7 +408,7 @@
     }
   },
   {
-    "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
+    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",

--- a/pkg/libvirttools/TestDomainDefinitions__cloud-init_with_user_data.json
+++ b/pkg/libvirttools/TestDomainDefinitions__cloud-init_with_user_data.json
@@ -121,7 +121,7 @@
         "Local": ""
       },
       "Type": "kvm",
-      "Name": "virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1",
+      "Name": "virtlet-231700d5-c9a6-container1",
       "UUID": "231700d5-c9a6-5a49-738d-99a954c51550",
       "Memory": {
         "Value": 1024,
@@ -408,7 +408,7 @@
     }
   },
   {
-    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Undefine"
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",

--- a/pkg/libvirttools/TestDomainDefinitions__plain_domain.json
+++ b/pkg/libvirttools/TestDomainDefinitions__plain_domain.json
@@ -84,7 +84,7 @@
           "Local": ""
         },
         "Type": "file",
-        "Name": "root_231700d5-c9a6-5a49-738d-99a954c51550",
+        "Name": "virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550",
         "Key": "",
         "Allocation": null,
         "Capacity": null,
@@ -224,7 +224,7 @@
             },
             "Auth": null,
             "Source": {
-              "File": "/var/lib/virtlet/volumes/root_231700d5-c9a6-5a49-738d-99a954c51550",
+              "File": "/var/lib/virtlet/volumes/virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550",
               "Device": "",
               "Protocol": "",
               "Name": "",
@@ -412,6 +412,6 @@
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",
-    "data": "root_231700d5-c9a6-5a49-738d-99a954c51550"
+    "data": "virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550"
   }
 ]

--- a/pkg/libvirttools/TestDomainDefinitions__plain_domain.json
+++ b/pkg/libvirttools/TestDomainDefinitions__plain_domain.json
@@ -121,7 +121,7 @@
         "Local": ""
       },
       "Type": "kvm",
-      "Name": "231700d5-c9a6-5a49-738d-99a954c51550-container1",
+      "Name": "virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1",
       "UUID": "231700d5-c9a6-5a49-738d-99a954c51550",
       "Memory": {
         "Value": 1024,
@@ -408,7 +408,7 @@
     }
   },
   {
-    "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
+    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",

--- a/pkg/libvirttools/TestDomainDefinitions__plain_domain.json
+++ b/pkg/libvirttools/TestDomainDefinitions__plain_domain.json
@@ -121,7 +121,7 @@
         "Local": ""
       },
       "Type": "kvm",
-      "Name": "virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1",
+      "Name": "virtlet-231700d5-c9a6-container1",
       "UUID": "231700d5-c9a6-5a49-738d-99a954c51550",
       "Memory": {
         "Value": 1024,
@@ -408,7 +408,7 @@
     }
   },
   {
-    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Undefine"
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",

--- a/pkg/libvirttools/TestDomainDefinitions__raw_devices.json
+++ b/pkg/libvirttools/TestDomainDefinitions__raw_devices.json
@@ -121,7 +121,7 @@
         "Local": ""
       },
       "Type": "kvm",
-      "Name": "231700d5-c9a6-5a49-738d-99a954c51550-container1",
+      "Name": "virtlet-231700d5-c9a6-container1",
       "UUID": "231700d5-c9a6-5a49-738d-99a954c51550",
       "Memory": {
         "Value": 1024,
@@ -454,7 +454,7 @@
     }
   },
   {
-    "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Undefine"
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",

--- a/pkg/libvirttools/TestDomainDefinitions__raw_devices.json
+++ b/pkg/libvirttools/TestDomainDefinitions__raw_devices.json
@@ -84,7 +84,7 @@
           "Local": ""
         },
         "Type": "file",
-        "Name": "root_231700d5-c9a6-5a49-738d-99a954c51550",
+        "Name": "virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550",
         "Key": "",
         "Allocation": null,
         "Capacity": null,
@@ -224,7 +224,7 @@
             },
             "Auth": null,
             "Source": {
-              "File": "/var/lib/virtlet/volumes/root_231700d5-c9a6-5a49-738d-99a954c51550",
+              "File": "/var/lib/virtlet/volumes/virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550",
               "Device": "",
               "Protocol": "",
               "Name": "",
@@ -458,6 +458,6 @@
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",
-    "data": "root_231700d5-c9a6-5a49-738d-99a954c51550"
+    "data": "virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550"
   }
 ]

--- a/pkg/libvirttools/TestDomainDefinitions__vcpu_count.json
+++ b/pkg/libvirttools/TestDomainDefinitions__vcpu_count.json
@@ -84,7 +84,7 @@
           "Local": ""
         },
         "Type": "file",
-        "Name": "root_231700d5-c9a6-5a49-738d-99a954c51550",
+        "Name": "virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550",
         "Key": "",
         "Allocation": null,
         "Capacity": null,
@@ -224,7 +224,7 @@
             },
             "Auth": null,
             "Source": {
-              "File": "/var/lib/virtlet/volumes/root_231700d5-c9a6-5a49-738d-99a954c51550",
+              "File": "/var/lib/virtlet/volumes/virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550",
               "Device": "",
               "Protocol": "",
               "Name": "",
@@ -412,6 +412,6 @@
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",
-    "data": "root_231700d5-c9a6-5a49-738d-99a954c51550"
+    "data": "virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550"
   }
 ]

--- a/pkg/libvirttools/TestDomainDefinitions__vcpu_count.json
+++ b/pkg/libvirttools/TestDomainDefinitions__vcpu_count.json
@@ -121,7 +121,7 @@
         "Local": ""
       },
       "Type": "kvm",
-      "Name": "231700d5-c9a6-5a49-738d-99a954c51550-container1",
+      "Name": "virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1",
       "UUID": "231700d5-c9a6-5a49-738d-99a954c51550",
       "Memory": {
         "Value": 1024,
@@ -408,7 +408,7 @@
     }
   },
   {
-    "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
+    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",

--- a/pkg/libvirttools/TestDomainDefinitions__vcpu_count.json
+++ b/pkg/libvirttools/TestDomainDefinitions__vcpu_count.json
@@ -121,7 +121,7 @@
         "Local": ""
       },
       "Type": "kvm",
-      "Name": "virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1",
+      "Name": "virtlet-231700d5-c9a6-container1",
       "UUID": "231700d5-c9a6-5a49-738d-99a954c51550",
       "Memory": {
         "Value": 1024,
@@ -408,7 +408,7 @@
     }
   },
   {
-    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Undefine"
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",

--- a/pkg/libvirttools/TestDomainDefinitions__virtio_disk_driver.json
+++ b/pkg/libvirttools/TestDomainDefinitions__virtio_disk_driver.json
@@ -84,7 +84,7 @@
           "Local": ""
         },
         "Type": "file",
-        "Name": "root_231700d5-c9a6-5a49-738d-99a954c51550",
+        "Name": "virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550",
         "Key": "",
         "Allocation": null,
         "Capacity": null,
@@ -224,7 +224,7 @@
             },
             "Auth": null,
             "Source": {
-              "File": "/var/lib/virtlet/volumes/root_231700d5-c9a6-5a49-738d-99a954c51550",
+              "File": "/var/lib/virtlet/volumes/virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550",
               "Device": "",
               "Protocol": "",
               "Name": "",
@@ -412,6 +412,6 @@
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",
-    "data": "root_231700d5-c9a6-5a49-738d-99a954c51550"
+    "data": "virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550"
   }
 ]

--- a/pkg/libvirttools/TestDomainDefinitions__virtio_disk_driver.json
+++ b/pkg/libvirttools/TestDomainDefinitions__virtio_disk_driver.json
@@ -121,7 +121,7 @@
         "Local": ""
       },
       "Type": "kvm",
-      "Name": "231700d5-c9a6-5a49-738d-99a954c51550-container1",
+      "Name": "virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1",
       "UUID": "231700d5-c9a6-5a49-738d-99a954c51550",
       "Memory": {
         "Value": 1024,
@@ -408,7 +408,7 @@
     }
   },
   {
-    "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
+    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",

--- a/pkg/libvirttools/TestDomainDefinitions__virtio_disk_driver.json
+++ b/pkg/libvirttools/TestDomainDefinitions__virtio_disk_driver.json
@@ -121,7 +121,7 @@
         "Local": ""
       },
       "Type": "kvm",
-      "Name": "virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1",
+      "Name": "virtlet-231700d5-c9a6-container1",
       "UUID": "231700d5-c9a6-5a49-738d-99a954c51550",
       "Memory": {
         "Value": 1024,
@@ -408,7 +408,7 @@
     }
   },
   {
-    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Undefine"
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",

--- a/pkg/libvirttools/TestDomainDefinitions__volumes.json
+++ b/pkg/libvirttools/TestDomainDefinitions__volumes.json
@@ -232,7 +232,7 @@
         "Local": ""
       },
       "Type": "kvm",
-      "Name": "virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1",
+      "Name": "virtlet-231700d5-c9a6-container1",
       "UUID": "231700d5-c9a6-5a49-738d-99a954c51550",
       "Memory": {
         "Value": 1024,
@@ -657,7 +657,7 @@
     }
   },
   {
-    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Undefine"
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",

--- a/pkg/libvirttools/TestDomainDefinitions__volumes.json
+++ b/pkg/libvirttools/TestDomainDefinitions__volumes.json
@@ -84,7 +84,7 @@
           "Local": ""
         },
         "Type": "file",
-        "Name": "root_231700d5-c9a6-5a49-738d-99a954c51550",
+        "Name": "virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550",
         "Key": "",
         "Allocation": null,
         "Capacity": null,
@@ -335,7 +335,7 @@
             },
             "Auth": null,
             "Source": {
-              "File": "/var/lib/virtlet/volumes/root_231700d5-c9a6-5a49-738d-99a954c51550",
+              "File": "/var/lib/virtlet/volumes/virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550",
               "Device": "",
               "Protocol": "",
               "Name": "",
@@ -661,7 +661,7 @@
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",
-    "data": "root_231700d5-c9a6-5a49-738d-99a954c51550"
+    "data": "virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550"
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",

--- a/pkg/libvirttools/TestDomainDefinitions__volumes.json
+++ b/pkg/libvirttools/TestDomainDefinitions__volumes.json
@@ -232,7 +232,7 @@
         "Local": ""
       },
       "Type": "kvm",
-      "Name": "231700d5-c9a6-5a49-738d-99a954c51550-container1",
+      "Name": "virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1",
       "UUID": "231700d5-c9a6-5a49-738d-99a954c51550",
       "Memory": {
         "Value": 1024,
@@ -657,7 +657,7 @@
     }
   },
   {
-    "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
+    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",

--- a/pkg/libvirttools/TestDomainDefinitions__volumes.json
+++ b/pkg/libvirttools/TestDomainDefinitions__volumes.json
@@ -114,7 +114,7 @@
         "Local": ""
       },
       "Type": "",
-      "Name": "231700d5-c9a6-5a49-738d-99a954c51550-vol1",
+      "Name": "virtlet-231700d5-c9a6-5a49-738d-99a954c51550-vol1",
       "Key": "",
       "Allocation": {
         "Unit": "",
@@ -141,7 +141,7 @@
     }
   },
   {
-    "name": "storage: volumes: 231700d5-c9a6-5a49-738d-99a954c51550-vol1: Format"
+    "name": "storage: volumes: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-vol1: Format"
   },
   {
     "name": "storage: volumes: CreateStorageVol",
@@ -151,7 +151,7 @@
         "Local": ""
       },
       "Type": "",
-      "Name": "231700d5-c9a6-5a49-738d-99a954c51550-vol2",
+      "Name": "virtlet-231700d5-c9a6-5a49-738d-99a954c51550-vol2",
       "Key": "",
       "Allocation": {
         "Unit": "",
@@ -178,7 +178,7 @@
     }
   },
   {
-    "name": "storage: volumes: 231700d5-c9a6-5a49-738d-99a954c51550-vol2: Format"
+    "name": "storage: volumes: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-vol2: Format"
   },
   {
     "name": "storage: volumes: CreateStorageVol",
@@ -188,7 +188,7 @@
         "Local": ""
       },
       "Type": "",
-      "Name": "231700d5-c9a6-5a49-738d-99a954c51550-vol3",
+      "Name": "virtlet-231700d5-c9a6-5a49-738d-99a954c51550-vol3",
       "Key": "",
       "Allocation": {
         "Unit": "",
@@ -215,7 +215,7 @@
     }
   },
   {
-    "name": "storage: volumes: 231700d5-c9a6-5a49-738d-99a954c51550-vol3: Format"
+    "name": "storage: volumes: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-vol3: Format"
   },
   {
     "name": "domain conn: iso image",
@@ -381,7 +381,7 @@
             },
             "Auth": null,
             "Source": {
-              "File": "/var/lib/virtlet/volumes/231700d5-c9a6-5a49-738d-99a954c51550-vol1",
+              "File": "/var/lib/virtlet/volumes/virtlet-231700d5-c9a6-5a49-738d-99a954c51550-vol1",
               "Device": "",
               "Protocol": "",
               "Name": "",
@@ -427,7 +427,7 @@
             },
             "Auth": null,
             "Source": {
-              "File": "/var/lib/virtlet/volumes/231700d5-c9a6-5a49-738d-99a954c51550-vol2",
+              "File": "/var/lib/virtlet/volumes/virtlet-231700d5-c9a6-5a49-738d-99a954c51550-vol2",
               "Device": "",
               "Protocol": "",
               "Name": "",
@@ -473,7 +473,7 @@
             },
             "Auth": null,
             "Source": {
-              "File": "/var/lib/virtlet/volumes/231700d5-c9a6-5a49-738d-99a954c51550-vol3",
+              "File": "/var/lib/virtlet/volumes/virtlet-231700d5-c9a6-5a49-738d-99a954c51550-vol3",
               "Device": "",
               "Protocol": "",
               "Name": "",
@@ -665,14 +665,14 @@
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",
-    "data": "231700d5-c9a6-5a49-738d-99a954c51550-vol1"
+    "data": "virtlet-231700d5-c9a6-5a49-738d-99a954c51550-vol1"
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",
-    "data": "231700d5-c9a6-5a49-738d-99a954c51550-vol2"
+    "data": "virtlet-231700d5-c9a6-5a49-738d-99a954c51550-vol2"
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",
-    "data": "231700d5-c9a6-5a49-738d-99a954c51550-vol3"
+    "data": "virtlet-231700d5-c9a6-5a49-738d-99a954c51550-vol3"
   }
 ]

--- a/pkg/libvirttools/TestDomainForcedShutdown.json
+++ b/pkg/libvirttools/TestDomainForcedShutdown.json
@@ -121,7 +121,7 @@
         "Local": ""
       },
       "Type": "kvm",
-      "Name": "virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1",
+      "Name": "virtlet-231700d5-c9a6-container1",
       "UUID": "231700d5-c9a6-5a49-738d-99a954c51550",
       "Memory": {
         "Value": 1024,
@@ -408,31 +408,31 @@
     }
   },
   {
-    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Create"
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Create"
   },
   {
     "name": "invoking StopContainer()"
   },
   {
-    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Shutdown",
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Shutdown",
     "data": {
       "ignored": true
     }
   },
   {
-    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Shutdown",
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Shutdown",
     "data": {
       "ignored": true
     }
   },
   {
-    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Shutdown",
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Shutdown",
     "data": {
       "ignored": true
     }
   },
   {
-    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Destroy"
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Destroy"
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",
@@ -468,7 +468,7 @@
     "name": "invoking RemoveContainer()"
   },
   {
-    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Undefine"
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",

--- a/pkg/libvirttools/TestDomainForcedShutdown.json
+++ b/pkg/libvirttools/TestDomainForcedShutdown.json
@@ -121,7 +121,7 @@
         "Local": ""
       },
       "Type": "kvm",
-      "Name": "231700d5-c9a6-5a49-738d-99a954c51550-container1",
+      "Name": "virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1",
       "UUID": "231700d5-c9a6-5a49-738d-99a954c51550",
       "Memory": {
         "Value": 1024,
@@ -408,31 +408,31 @@
     }
   },
   {
-    "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Create"
+    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Create"
   },
   {
     "name": "invoking StopContainer()"
   },
   {
-    "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Shutdown",
+    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Shutdown",
     "data": {
       "ignored": true
     }
   },
   {
-    "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Shutdown",
+    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Shutdown",
     "data": {
       "ignored": true
     }
   },
   {
-    "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Shutdown",
+    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Shutdown",
     "data": {
       "ignored": true
     }
   },
   {
-    "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Destroy"
+    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Destroy"
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",
@@ -468,7 +468,7 @@
     "name": "invoking RemoveContainer()"
   },
   {
-    "name": "domain conn: 231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
+    "name": "domain conn: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-container1: Undefine"
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",

--- a/pkg/libvirttools/TestDomainForcedShutdown.json
+++ b/pkg/libvirttools/TestDomainForcedShutdown.json
@@ -84,7 +84,7 @@
           "Local": ""
         },
         "Type": "file",
-        "Name": "root_231700d5-c9a6-5a49-738d-99a954c51550",
+        "Name": "virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550",
         "Key": "",
         "Allocation": null,
         "Capacity": null,
@@ -224,7 +224,7 @@
             },
             "Auth": null,
             "Source": {
-              "File": "/var/lib/virtlet/volumes/root_231700d5-c9a6-5a49-738d-99a954c51550",
+              "File": "/var/lib/virtlet/volumes/virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550",
               "Device": "",
               "Protocol": "",
               "Name": "",
@@ -436,7 +436,7 @@
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",
-    "data": "root_231700d5-c9a6-5a49-738d-99a954c51550"
+    "data": "virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550"
   },
   {
     "name": "container status after the container is stopped",
@@ -472,6 +472,6 @@
   },
   {
     "name": "storage: volumes: RemoveVolumeByName",
-    "data": "root_231700d5-c9a6-5a49-738d-99a954c51550"
+    "data": "virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550"
   }
 ]

--- a/pkg/libvirttools/TestRootVolumeLifeCycle.json
+++ b/pkg/libvirttools/TestRootVolumeLifeCycle.json
@@ -12,7 +12,7 @@
           "Local": ""
         },
         "Type": "file",
-        "Name": "root_77f29a0e-46af-4188-a6af-9ff8b8a65224",
+        "Name": "virtlet_root_77f29a0e-46af-4188-a6af-9ff8b8a65224",
         "Key": "",
         "Allocation": null,
         "Capacity": null,
@@ -35,7 +35,7 @@
     }
   },
   {
-    "name": "root disk retuned by root_volumesource",
+    "name": "root disk retuned by virtlet_root_volumesource",
     "data": {
       "XMLName": {
         "Space": "",
@@ -53,7 +53,7 @@
       },
       "Auth": null,
       "Source": {
-        "File": "/fake/volumes/pool/root_77f29a0e-46af-4188-a6af-9ff8b8a65224",
+        "File": "/fake/volumes/pool/virtlet_root_77f29a0e-46af-4188-a6af-9ff8b8a65224",
         "Device": "",
         "Protocol": "",
         "Name": "",
@@ -72,6 +72,6 @@
   },
   {
     "name": "volumes: RemoveVolumeByName",
-    "data": "root_77f29a0e-46af-4188-a6af-9ff8b8a65224"
+    "data": "virtlet_root_77f29a0e-46af-4188-a6af-9ff8b8a65224"
   }
 ]

--- a/pkg/libvirttools/gc.go
+++ b/pkg/libvirttools/gc.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2017 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package libvirttools
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func (v *VirtualizationTool) GarbageCollect() error {
+	ids, err := v.retrieveListOfContainerIDs()
+	if err != nil {
+		return err
+	}
+
+	if err := v.removeOrphanDomains(ids); err != nil {
+		return err
+	}
+
+	if err := v.removeOrphanRootVolumes(ids); err != nil {
+		return err
+	}
+
+	if err := v.removeOrphanQcow2Volumes(ids); err != nil {
+		return err
+	}
+
+	if err := v.removeOrphanNoCloudImages(ids); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (v *VirtualizationTool) retrieveListOfContainerIDs() ([]string, error) {
+	var containerIDs []string
+
+	sandboxes, err := v.metadataStore.ListPodSandboxes(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, sandbox := range sandboxes {
+		containers, err := v.metadataStore.ListPodContainers(sandbox.GetID())
+		if err != nil {
+			return nil, err
+		}
+		for _, container := range containers {
+			containerIDs = append(containerIDs, container.GetID())
+		}
+	}
+
+	return containerIDs, nil
+}
+
+func inList(list []string, filter func(string) bool) bool {
+	for _, element := range list {
+		if filter(element) {
+			return true
+		}
+	}
+	return false
+}
+
+func (v *VirtualizationTool) removeOrphanDomains(ids []string) error {
+	domains, err := v.domainConn.ListDomains()
+	if err != nil {
+		return err
+	}
+
+	for _, domain := range domains {
+		name, err := domain.Name()
+		if err != nil {
+			return err
+		}
+
+		filter := func(id string) bool {
+			return strings.HasPrefix("virtlet-"+id, name)
+		}
+
+		if !inList(ids, filter) {
+			d, err := v.DomainConnection().LookupDomainByName(name)
+			if err != nil {
+				return err
+			}
+
+			// ignore errors from stopping domain
+			d.Destroy()
+			if err := d.Undefine(); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (v *VirtualizationTool) removeOrphanRootVolumes(ids []string) error {
+	volumes, err := v.volumePool.ListAllVolumes()
+	if err != nil {
+		return err
+	}
+
+	for _, volume := range volumes {
+		path, err := volume.Path()
+		if err != nil {
+			return err
+		}
+
+		filename := filepath.Base(path)
+		filter := func(id string) bool {
+			return "virtlet_root_"+id == filename
+		}
+
+		if !inList(ids, filter) {
+			if err := volume.Remove(); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (v *VirtualizationTool) removeOrphanQcow2Volumes(ids []string) error {
+	volumes, err := v.volumePool.ListAllVolumes()
+	if err != nil {
+		return err
+	}
+
+	for _, volume := range volumes {
+		path, err := volume.Path()
+		if err != nil {
+			return err
+		}
+
+		filename := filepath.Base(path)
+		filter := func(id string) bool {
+			return strings.HasPrefix("virtlet-"+id, filename)
+		}
+
+		if !inList(ids, filter) {
+			if err := volume.Remove(); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (v *VirtualizationTool) removeOrphanNoCloudImages(ids []string) error {
+	files, err := filepath.Glob(filepath.Join(nocloudIsoDir, "nocloud-*.iso"))
+	if err != nil {
+		return err
+	}
+
+	for _, path := range files {
+		filename := filepath.Base(path)
+
+		filter := func(id string) bool {
+			return filename == "nocloud-"+id+".iso"
+		}
+
+		if !inList(ids, filter) {
+			if err := os.Remove(path); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/libvirttools/libvirt_domain.go
+++ b/pkg/libvirttools/libvirt_domain.go
@@ -181,6 +181,10 @@ func (domain *LibvirtDomain) UUIDString() (string, error) {
 	return domain.d.GetUUIDString()
 }
 
+func (domain *LibvirtDomain) Name() (string, error) {
+	return domain.d.GetName()
+}
+
 type LibvirtSecret struct {
 	s *libvirt.Secret
 }

--- a/pkg/libvirttools/qcow2_flexvolume.go
+++ b/pkg/libvirttools/qcow2_flexvolume.go
@@ -74,12 +74,12 @@ func newQCOW2Volume(volumeName, configPath string, config *VMConfig, owner Volum
 }
 
 func (v *qcow2Volume) volumeName() string {
-	return v.config.DomainUUID + "-" + v.name
+	return "virtlet-" + v.config.DomainUUID + "-" + v.name
 }
 
-func (v *qcow2Volume) createQCOW2Volume(name string, capacity uint64, capacityUnit string) (virt.VirtStorageVolume, error) {
+func (v *qcow2Volume) createQCOW2Volume(capacity uint64, capacityUnit string) (virt.VirtStorageVolume, error) {
 	return v.owner.StoragePool().CreateStorageVol(&libvirtxml.StorageVolume{
-		Name:       name,
+		Name:       v.volumeName(),
 		Allocation: &libvirtxml.StorageVolumeSize{Value: 0},
 		Capacity:   &libvirtxml.StorageVolumeSize{Unit: capacityUnit, Value: capacity},
 		Target:     &libvirtxml.StorageVolumeTarget{Format: &libvirtxml.StorageVolumeTargetFormat{Type: "qcow2"}},
@@ -91,7 +91,7 @@ func (v *qcow2Volume) Uuid() string {
 }
 
 func (v *qcow2Volume) Setup(volumeMap map[string]string) (*libvirtxml.DomainDisk, error) {
-	vol, err := v.createQCOW2Volume(v.volumeName(), uint64(v.capacity), v.capacityUnit)
+	vol, err := v.createQCOW2Volume(uint64(v.capacity), v.capacityUnit)
 	if err != nil {
 		return nil, fmt.Errorf("error during creation of volume '%s' with virtlet description %s: %v", v.volumeName(), v.name, err)
 	}

--- a/pkg/libvirttools/root_volumesource.go
+++ b/pkg/libvirttools/root_volumesource.go
@@ -38,7 +38,7 @@ func GetRootVolume(config *VMConfig, owner VolumeOwner) ([]VMVolume, error) {
 }
 
 func (v *rootVolume) cloneName() string {
-	return "root_" + v.config.DomainUUID
+	return "virtlet_root_" + v.config.DomainUUID
 }
 
 func (v *rootVolume) cloneVolume(name string, from virt.VirtStorageVolume) (virt.VirtStorageVolume, error) {

--- a/pkg/libvirttools/root_volumesource_test.go
+++ b/pkg/libvirttools/root_volumesource_test.go
@@ -35,7 +35,7 @@ func TestRootVolumeNaming(t *testing.T) {
 			nil,
 		},
 	}
-	expected := "root_" + testUuid
+	expected := "virtlet_root_" + testUuid
 
 	cloneName := v.cloneName()
 
@@ -48,7 +48,7 @@ func TestRootVolumeLifeCycle(t *testing.T) {
 	rec := fake.NewToplevelRecorder()
 
 	volumesPoolPath := "/fake/volumes/pool"
-	expectedRootVolumePath := volumesPoolPath + "/root_" + testUuid
+	expectedRootVolumePath := volumesPoolPath + "/virtlet_root_" + testUuid
 	spool := fake.NewFakeStoragePool(rec.Child("volumes"), "volumes", volumesPoolPath)
 	ipool := fake.NewFakeStoragePool(rec.Child("images"), "images", "/fake/images/pool")
 
@@ -85,7 +85,7 @@ func TestRootVolumeLifeCycle(t *testing.T) {
 		t.Errorf("Expected '%s' as root volume path, received: %s", vol.Source.File)
 	}
 
-	rec.Rec("root disk retuned by root_volumesource", vol)
+	rec.Rec("root disk retuned by virtlet_root_volumesource", vol)
 
 	if err := rootVol.Teardown(); err != nil {
 		t.Errorf("Teardown returned an error: %v", err)

--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -344,7 +344,7 @@ func (v *VirtualizationTool) CreateContainer(config *VMConfig, netNSPath, cniCon
 		vmLogLocation: vmLogLocation(),
 	}
 
-	cloneName := "root_" + settings.domainUUID
+	cloneName := "virtlet_root_" + settings.domainUUID
 	settings.vcpuNum = config.ParsedAnnotations.VCPUCount
 	settings.memory = int(config.MemoryLimitInBytes)
 	settings.cpuShares = uint(config.CpuShares)

--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -338,7 +338,7 @@ func (v *VirtualizationTool) CreateContainer(config *VMConfig, netNSPath, cniCon
 	config.DomainUUID = domainUUID
 	settings := domainSettings{
 		domainUUID:    domainUUID,
-		domainName:    domainUUID + "-" + config.Name,
+		domainName:    "virtlet-" + domainUUID + "-" + config.Name,
 		netNSPath:     netNSPath,
 		cniConfig:     cniConfig,
 		vmLogLocation: vmLogLocation(),

--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -337,8 +337,10 @@ func (v *VirtualizationTool) CreateContainer(config *VMConfig, netNSPath, cniCon
 	// FIXME: this field should be moved to VMStatus struct (to be added)
 	config.DomainUUID = domainUUID
 	settings := domainSettings{
-		domainUUID:    domainUUID,
-		domainName:    "virtlet-" + domainUUID + "-" + config.Name,
+		domainUUID: domainUUID,
+		// Note: using only first 13 characters because libvirt has an issue with handling
+		// long path names for qemu monitor socket
+		domainName:    "virtlet-" + domainUUID[:13] + "-" + config.Name,
 		netNSPath:     netNSPath,
 		cniConfig:     cniConfig,
 		vmLogLocation: vmLogLocation(),

--- a/pkg/libvirttools/virtualization_test.go
+++ b/pkg/libvirttools/virtualization_test.go
@@ -201,8 +201,8 @@ func (ct *containerTester) verifyContainerRootfsExists(container *kubeapi.Contai
 	}
 	// TODO: this is third place where rootfs volume name is calculated
 	// so there should be a func which will do it in consistent way there,
-	// in root_volumesource.go and in virtualization.go
-	_, err = storagePool.LookupVolumeByName("root_" + container.PodSandboxId)
+	// in virtlet_root_volumesource.go and in virtualization.go
+	_, err = storagePool.LookupVolumeByName("virtlet_root_" + container.PodSandboxId)
 	return err == nil
 }
 

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -90,6 +90,10 @@ func NewVirtletManager(libvirtUri, poolName, downloadProtocol, storageBackend, m
 		return nil, err
 	}
 
+	if err := libvirtVirtualizationTool.GarbageCollect(); err != nil {
+		glog.Warningf("Failure during garbage collection: %v", err)
+	}
+
 	cniClient, err := cni.NewClient(cniPluginsDir, cniConfigsDir)
 	if err != nil {
 		return nil, err

--- a/pkg/virt/domain_interface.go
+++ b/pkg/virt/domain_interface.go
@@ -101,4 +101,6 @@ type VirtDomain interface {
 	State() (DomainState, error)
 	// UUIDString() returns UUID string for this domain
 	UUIDString() (string, error)
+	// Name() returns the name of this domain
+	Name() (string, error)
 }

--- a/pkg/virt/fake/fake_domain.go
+++ b/pkg/virt/fake/fake_domain.go
@@ -247,6 +247,10 @@ func (d *FakeDomain) UUIDString() (string, error) {
 	return d.uuid, nil
 }
 
+func (d *FakeDomain) Name() (string, error) {
+	return d.name, nil
+}
+
 type FakeSecret struct {
 	rec       Recorder
 	dc        *FakeDomainConnection

--- a/tests/integration/container_create_test.go
+++ b/tests/integration/container_create_test.go
@@ -112,7 +112,7 @@ func TestContainerCleanup(t *testing.T) {
 	uuid := getDomainUUID(sandbox.Metadata.Uid)
 	// 1. Failure during adding/processing ephemerial and flexolumes
 	// Define in advance the volume name of one of described to cause error on CreateContainer "Storage volume already exists".
-	volumeName := uuid + "-vol3"
+	volumeName := "virtlet-" + uuid + "-vol3"
 	rmDummyVolume, err := defineDummyVolume("volumes", volumeName)
 	if err != nil {
 		t.Fatalf("Failed to define dummy volume to test cleanup: %v", err)
@@ -128,7 +128,7 @@ func TestContainerCleanup(t *testing.T) {
 
 	// 2. Failure on defining domain in libvirt
 	// Define dummy VM with the same name but other id to cause error on CreateContainer "Domain <name> already exists with uuid <uuid>".
-	domainName := "virtlet-" + uuid + "-" + container.Name
+	domainName := "virtlet-" + uuid[:13] + "-" + container.Name
 	if err := defineDummyDomainWithName(domainName); err != nil {
 		t.Errorf("Failed to define dummy domain to test cleanup: %v", err)
 	}
@@ -192,7 +192,7 @@ func TestContainerVolumes(t *testing.T) {
 		createResp := ct.createContainer(sandbox, ct.containers[idx], ct.imageSpecs[idx], mounts)
 		ct.startContainer(createResp.ContainerId)
 
-		vmName := createResp.ContainerId + "-" + ct.containers[idx].Name
+		vmName := "virtlet-" + createResp.ContainerId[:13] + "-" + ct.containers[idx].Name
 		cmd := fmt.Sprintf("virsh domblklist '%s' | grep '%s-vol.*' | wc -l", vmName, createResp.ContainerId)
 		verifyUsingShell(t, cmd, "attached ephemeral volumes", strconv.Itoa(volumeCounts[idx]))
 	}

--- a/tests/integration/container_create_test.go
+++ b/tests/integration/container_create_test.go
@@ -128,7 +128,7 @@ func TestContainerCleanup(t *testing.T) {
 
 	// 2. Failure on defining domain in libvirt
 	// Define dummy VM with the same name but other id to cause error on CreateContainer "Domain <name> already exists with uuid <uuid>".
-	domainName := uuid + "-" + container.Name
+	domainName := "virtlet-" + uuid + "-" + container.Name
 	if err := defineDummyDomainWithName(domainName); err != nil {
 		t.Errorf("Failed to define dummy domain to test cleanup: %v", err)
 	}

--- a/tests/integration/go.test
+++ b/tests/integration/go.test
@@ -16,6 +16,7 @@ mkdir -p /tmp/image_store
 pushd /tmp/image_store
 curl http://download.cirros-cloud.net/0.3.3/cirros-0.3.3-x86_64-disk.img -o cirros-0.3.3-x86_64-disk.img
 curl http://download.cirros-cloud.net/0.3.4/cirros-0.3.4-x86_64-disk.img -o cirros-0.3.4-x86_64-disk.img
+rm -rf copy
 ln -s . copy
 python -m SimpleHTTPServer 80 >/tmp/http_server.log &
 HTTP_SERVER_PID=$!


### PR DESCRIPTION
When something went wrong, or when host was restarted - we can leak some resources like nocloud iso images, domain definitions on libvirt side, or volumes leaved in same place.

This PR provides cleanup method, which is used during Virtlet startup. It checks metadata store for all defined sandboxes/containers (domains in our case) and tries to remove all things left behind during earlier runs, keeping intact things, which were probably created in other method than call from Virtlet.

todo:
- [ ] tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/377)
<!-- Reviewable:end -->
