### PR TITLE
logging: Fix various logging issues

### DIFF
--- a/cmd/criproxy/criproxy.go
+++ b/cmd/criproxy/criproxy.go
@@ -90,7 +90,7 @@ func runCriProxy(connect, listen, nodeInfoPath string) error {
 		if shouldClean {
 			shouldClean = false
 			if err := criproxy.RemoveKubernetesContainers(ni.DockerEndpoint); err != nil {
-				glog.Warningf("failed to clean up old containers: %v", err)
+				glog.Warningf("Failed to clean up old containers: %v", err)
 			}
 		}
 	})
@@ -174,7 +174,7 @@ func main() {
 		case *install:
 			execPath, err := os.Executable()
 			if err != nil {
-				glog.Error("Can't get criproxy executable path: %v", err)
+				glog.Errorf("Can't get criproxy executable path: %v", err)
 				os.Exit(1)
 			}
 			err = installCriProxy(execPath, *nodeInfoPath)

--- a/pkg/libvirttools/cloudinit.go
+++ b/pkg/libvirttools/cloudinit.go
@@ -136,7 +136,7 @@ func (g *CloudInitGenerator) GenerateDisk() (*libvirtxml.DomainDisk, error) {
 
 	if err := utils.GenIsoImage(g.IsoPath(), "cidata", tmpDir); err != nil {
 		if rmErr := os.Remove(g.IsoPath()); rmErr != nil {
-			glog.Warning("Error removing iso file %s: %v", g.IsoPath(), rmErr)
+			glog.Warningf("Error removing iso file %s: %v", g.IsoPath(), rmErr)
 		}
 		return nil, fmt.Errorf("error generating iso image: %v", err)
 	}
@@ -173,7 +173,7 @@ func (g *CloudInitGenerator) addEnvVarsFileToWriteFiles(userData map[string]inte
 		var ok bool
 		oldWriteFiles, ok = oldWriteFilesRaw.([]interface{})
 		if !ok {
-			glog.Warning("malformed write_files entry in user-data, can't add env vars")
+			glog.Warning("Malformed write_files entry in user-data, can't add env vars")
 			return
 		}
 	}

--- a/pkg/libvirttools/nocloud_volumesource.go
+++ b/pkg/libvirttools/nocloud_volumesource.go
@@ -57,7 +57,7 @@ func (v *nocloudVolume) Teardown() error {
 	isoPath := NewCloudInitGenerator(v.config, nil, nocloudIsoDir).IsoPath()
 	// don't fail to remove the pod if the file cannot be removed, just warn
 	if err := os.Remove(isoPath); err != nil {
-		glog.Warning("Cannot remove temporary nocloud file %q: %v", isoPath, err)
+		glog.Warningf("Cannot remove temporary nocloud file %q: %v", isoPath, err)
 	}
 	return nil
 }

--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -239,7 +239,7 @@ func (v *VirtualizationTool) setupVolumes(config *VMConfig, domainDef *libvirtxm
 			// try to tear down volumes that were already set up
 			for _, vmVol := range vmVols[:n] {
 				if err := vmVol.Teardown(); err != nil {
-					glog.Warning("failed to tear down a volume on error: %v", err)
+					glog.Warningf("Failed to tear down a volume on error: %v", err)
 				}
 			}
 			return err
@@ -482,7 +482,7 @@ func (v *VirtualizationTool) StartContainer(containerId string) error {
 		// and cleaning it all up upon failure, but for now we just remove the VM
 		// so the next `CreateContainer()` call succeeds.
 		if rmErr := v.RemoveContainer(containerId); rmErr != nil {
-			return fmt.Errorf("Container start error: %v \n+ container removal error: %v", err, rmErr)
+			return fmt.Errorf("container start error: %v \n+ container removal error: %v", err, rmErr)
 		}
 
 		return err
@@ -657,7 +657,7 @@ func (v *VirtualizationTool) removeDomain(containerId string, config *VMConfig, 
 		if disallowVolumesTeardownFailure {
 			return err
 		} else {
-			glog.Warning("Error during volumes teardown for container %s: %v", containerId, err)
+			glog.Warningf("Error during volumes teardown for container %s: %v", containerId, err)
 		}
 	}
 
@@ -874,7 +874,7 @@ func (v *VirtualizationTool) ListContainers(filter *kubeapi.ContainerFilter) ([]
 				}
 				if containerInfo == nil {
 					// There's no such container - looks like it's already removed, but still is mentioned in sandbox
-					return nil, fmt.Errorf("Container metadata not found, but it's still mentioned in sandbox %s", filter.PodSandboxId)
+					return nil, fmt.Errorf("container metadata not found, but it's still mentioned in sandbox %s", filter.PodSandboxId)
 				}
 
 				container, err := v.getContainer(domain)

--- a/pkg/metadata/sandboxes.go
+++ b/pkg/metadata/sandboxes.go
@@ -126,7 +126,7 @@ func getSandboxBucket(tx *bolt.Tx, podID string, create, optional bool) (*bolt.B
 	}
 	bucket := tx.Bucket([]byte(key))
 	if bucket == nil && !optional {
-		return nil, fmt.Errorf("Pod sandbox %q does not exist", podID)
+		return nil, fmt.Errorf("pod sandbox %q does not exist", podID)
 	}
 	return bucket, nil
 }

--- a/pkg/nettools/nettools.go
+++ b/pkg/nettools/nettools.go
@@ -103,7 +103,7 @@ func OpenTAP(devName string) (*os.File, error) {
 	copy(req.Name[:15], "tap0")
 	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, tapFile.Fd(), uintptr(syscall.TUNSETIFF), uintptr(unsafe.Pointer(&req)))
 	if errno != 0 {
-		return nil, fmt.Errorf("Tuntap IOCTL TUNSETIFF failed, errno %v", errno)
+		return nil, fmt.Errorf("tuntap IOCTL TUNSETIFF failed, errno %v", errno)
 	}
 	return tapFile, nil
 }

--- a/tests/gm/data.go
+++ b/tests/gm/data.go
@@ -72,7 +72,7 @@ func DataFileDiffers(filename string, v interface{}) (bool, error) {
 
 	var curData interface{}
 	if err := json.Unmarshal(content, &curData); err != nil {
-		glog.Warning("failed to unmarshal %q to JSON: %v", filename, err)
+		glog.Warningf("Failed to unmarshal %q to JSON: %v", filename, err)
 		return true, nil
 	}
 

--- a/tests/gm/git.go
+++ b/tests/gm/git.go
@@ -39,7 +39,7 @@ func GitDiff(path string) (string, error) {
 	}
 	defer func() {
 		if err := os.Chdir(origWd); err != nil {
-			glog.Warning("can't chdir back to the old work dir: %v", err)
+			glog.Warningf("Can't chdir back to the old work dir: %v", err)
 		}
 	}()
 	fileDir := filepath.Dir(absPath)


### PR DESCRIPTION
Fixes:
* when there is format string - use `Errorf`/`Warningf`/`Infof`
* if message goes to output - uppercase first character
* if an error is returned to other scope - use lowercase as first
  character

`criproxy.go` is skipped for third bullet, because it outputs all returned
errors without enclosing it in message which would be started with
uppercase.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/383)
<!-- Reviewable:end -->
