### PR TITLE
Fix docker-shim flag handling

### DIFF
--- a/pkg/dockershim/dockershim.go
+++ b/pkg/dockershim/dockershim.go
@@ -100,6 +100,7 @@ func doRunDockershim(c *componentconfig.KubeletConfiguration, r *options.Contain
 		MTU:               int(r.NetworkPluginMTU),
 		LegacyRuntimeHost: nh,
 	}
+	glog.V(3).Infof("Docker plugin settings: %s", spew.Sdump(pluginSettings))
 
 	// Initialize streaming configuration. (Not using TLS now)
 	streamingConfig := &streaming.Config{
@@ -154,6 +155,8 @@ func NewKubeletWrapper(arguments []string) *KubeletWrapper {
 func (k *KubeletWrapper) RunDockershim() {
 	logs.InitLogs()
 	defer logs.FlushLogs()
+	glog.V(3).Infof("RunDockershim(): Kubelet config: %s", spew.Sdump(k.s.KubeletConfiguration))
+
 	if err := doRunDockershim(&k.s.KubeletConfiguration, &k.s.ContainerRuntimeOptions); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)

--- a/pkg/dockershim/dockershim.go
+++ b/pkg/dockershim/dockershim.go
@@ -43,6 +43,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/golang/glog"
 	"github.com/spf13/pflag"
 
@@ -131,12 +132,11 @@ func doRunDockershim(c *componentconfig.KubeletConfiguration, r *options.Contain
 	return http.ListenAndServe(streamingConfig.Addr, ds)
 }
 
-// InitFlags normalizes, parses, then logs the command line flags
+// initFlags normalizes, parses, then logs the command line flags
 func initFlags(arguments []string) {
 	pflag.CommandLine.SetNormalizeFunc(flag.WordSepNormalizeFunc)
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	pflag.CommandLine.Parse(arguments)
-	pflag.Parse()
 	pflag.VisitAll(func(flag *pflag.Flag) {
 		glog.V(4).Infof("FLAG: --%s=%q", flag.Name, flag.Value)
 	})
@@ -149,6 +149,7 @@ type KubeletWrapper struct {
 func NewKubeletWrapper(arguments []string) *KubeletWrapper {
 	s := options.NewKubeletServer()
 	s.AddFlags(pflag.CommandLine)
+	initFlags(arguments)
 	return &KubeletWrapper{s}
 }
 


### PR DESCRIPTION
This problem was causing CNI misconfiguration and consequently Virtlet failure on multi-node clusters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/384)
<!-- Reviewable:end -->
