### PR TITLE
virsh.sh script improvements

### DIFF
--- a/examples/vmssh.sh
+++ b/examples/vmssh.sh
@@ -26,7 +26,7 @@ shift
 
 namespace_opts=""
 if [[ ${namespace} ]]; then
-  namespace_opts="-o ${namespace}"
+  namespace_opts="-n ${namespace}"
 fi
 
 read pod_ip node_name pod_namespace <<<$(kubectl get pod ${namespace_opts} "${pod_name}" -o jsonpath="{.status.podIP} {.spec.nodeName} {.metadata.namespace}")


### PR DESCRIPTION
* virsh works correctly where there are >1 virtlet pod
* prints error if there are no virtlet pods [on needed node] exist
* if there are more than one virtlet pod matches given criteria
  (for example, if no `@domain` was specified), run command on all
  virtlet pods
* better error handling
* use interactive session if virsh.sh was run without parameters
* fixed incorrect flan name in vmssh.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/387)
<!-- Reviewable:end -->
