### PR TITLE
Switch back to multi-worker DIND configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ By default, CNI bridge plugin is used for cluster networking. It's also possible
 CNI_PLUGIN=flannel ./demo.sh
 ```
 
+There's also an option to deploy Virtlet on master node of the DIND
+cluster, which can be handy e.g. if you don't want to use worker nodes
+(i.e. start the cluster with `NUM_NODES=0`):
+```
+VIRTLET_ON_MASTER=1 ./demo.sh
+```
+
 The demo script will check for KVM support on the host and will make Virtlet use KVM if it's available on Docker host. If KVM is not available, plain QEMU will be used.
 
 The demo is based on [kubeadm-dind-cluster](https://github.com/Mirantis/kubeadm-dind-cluster) project. **Docker btrfs storage driver is currently unsupported.** Please refer to `kubeadm-dind-cluster` documentation for more info.

--- a/build/cmd.sh
+++ b/build/cmd.sh
@@ -164,7 +164,7 @@ function copy_output {
 }
 
 function copy_dind {
-    if ! docker volume ls -q | grep -q '^kubeadm-dind-kube-master$'; then
+    if ! docker volume ls -q | grep -q '^kubeadm-dind-kube-node-1$'; then
         echo "No active or snapshotted kubeadm-dind-cluster" >&2
         exit 1
     fi
@@ -172,23 +172,23 @@ function copy_dind {
     cd "${project_dir}"
     docker run --rm \
            -v "virtlet_src:${remote_project_dir}" \
-           -v kubeadm-dind-kube-master:/dind \
+           -v kubeadm-dind-kube-node-1:/dind \
            --name ${tmp_container_name} \
            "${build_image}" \
            /bin/sh -c "cp -av _output/* /dind"
 }
 
 function kvm_ok {
-    # The check is done inside kube-master container because it has proper /lib/modules
+    # The check is done inside node-1 container because it has proper /lib/modules
     # from the docker host. Also, it'll have to use mirantis/virtlet image
     # later anyway.
-    if ! docker exec kube-master docker run --privileged --rm -v /lib/modules:/lib/modules mirantis/virtlet kvm-ok; then
+    if ! docker exec kube-node-1 docker run --privileged --rm -v /lib/modules:/lib/modules mirantis/virtlet kvm-ok; then
         return 1
     fi
 }
 
 function start_dind {
-    kubectl label node --overwrite kube-master extraRuntime=virtlet
+    kubectl label node --overwrite kube-node-1 extraRuntime=virtlet
     if kvm_ok; then
         kubectl convert -f "${project_dir}/deploy/virtlet-ds-dev.yaml" --local -o json |
             docker exec -i kube-master jq '.items[0].spec.template.spec.containers[0].env|=map(select(.name!="VIRTLET_DISABLE_KVM"))' |

--- a/deploy/demo.sh
+++ b/deploy/demo.sh
@@ -106,18 +106,17 @@ function demo::start-dind-cluster {
   echo "To clean up the cluster, use './dind-cluster-v1.7.sh clean'" >&2
   demo::ask-before-continuing
   "./${dind_script}" clean
-  # use zero-worker configuration for faster startup
-  NUM_NODES=0 "./${dind_script}" up
+  "./${dind_script}" up
 }
 
 function demo::inject-local-image {
-  demo::step "Copying local mirantis/virtlet image into kube-master container"
-  docker save mirantis/virtlet | docker exec -i kube-master docker load
+  demo::step "Copying local mirantis/virtlet image into kube-node-1 container"
+  docker save mirantis/virtlet | docker exec -i kube-node-1 docker load
 }
 
 function demo::label-node {
-  demo::step "Applying label to kube-master:" "extraRuntime=virtlet"
-  "${kubectl}" label node kube-master extraRuntime=virtlet
+  demo::step "Applying label to kube-node-1:" "extraRuntime=virtlet"
+  "${kubectl}" label node kube-node-1 extraRuntime=virtlet
 }
 
 function demo::pods-ready {
@@ -219,10 +218,10 @@ function demo::vm-ready {
 
 function demo::kvm-ok {
   demo::step "Checking for KVM support..."
-  # The check is done inside kube-master container because it has proper /lib/modules
+  # The check is done inside node-1 container because it has proper /lib/modules
   # from the docker host. Also, it'll have to use mirantis/virtlet image
   # later anyway.
-  if ! docker exec kube-master docker run --privileged --rm -v /lib/modules:/lib/modules "mirantis/virtlet:${virtlet_docker_tag}" kvm-ok; then
+  if ! docker exec kube-node-1 docker run --privileged --rm -v /lib/modules:/lib/modules "mirantis/virtlet:${virtlet_docker_tag}" kvm-ok; then
     return 1
   fi
 }

--- a/docs/devel/build-tool.md
+++ b/docs/devel/build-tool.md
@@ -36,14 +36,17 @@ current directory.
 
 ## copy-dind
 
-Copies the binaries into kube-node-1 of `kubeadm-dind-cluster`. You need to
-do `dind-cluster...sh up` to be able to use this command.
+Copies the binaries into kube-node-1 of `kubeadm-dind-cluster` (or
+kube-master if `VIRTLET_ON_MASTER` environment variable is set to a
+non-empty value). You need to do `dind-cluster...sh up` to be able to
+use this command.
 
 ## start-dind
 
-Copies the binaries into kube-node-1 of `kubeadm-dind-cluster`. You
-need to do `dind-cluster...sh up` and `build/cmd.sh copy-dind` to be
-able to use this command.
+Starts Virtlet on kube-node-1 of `kubeadm-dind-cluster` (or
+kube-master if `VIRTLET_ON_MASTER` environment variable is set to a
+non-empty value). You need to do `dind-cluster...sh up` and
+`build/cmd.sh copy-dind` to be able to use this command.
 
 ## vsh
 

--- a/docs/devel/build-tool.md
+++ b/docs/devel/build-tool.md
@@ -36,13 +36,13 @@ current directory.
 
 ## copy-dind
 
-Copies the binaries into kube-master of `kubeadm-dind-cluster`. You need to
-do `NUM_NODES=0 dind-cluster...sh up` to be able to use this command.
+Copies the binaries into kube-node-1 of `kubeadm-dind-cluster`. You need to
+do `dind-cluster...sh up` to be able to use this command.
 
 ## start-dind
 
-Copies the binaries into kube-master of `kubeadm-dind-cluster`. You
-need to do `NUM_NODES=0 dind-cluster...sh up` and `build/cmd.sh copy-dind` to be
+Copies the binaries into kube-node-1 of `kubeadm-dind-cluster`. You
+need to do `dind-cluster...sh up` and `build/cmd.sh copy-dind` to be
 able to use this command.
 
 ## vsh

--- a/docs/devel/running-local-environment.md
+++ b/docs/devel/running-local-environment.md
@@ -24,7 +24,7 @@ $ build/cmd.sh build
 $ # start DIND cluster
 $ ~/dind-cluster-v1.6.sh up
 
-$ # copy binaries to kube-master
+$ # copy binaries to kube-node-1
 $ build/cmd.sh copy-dind
 
 $ # start Virtlet daemonset
@@ -46,7 +46,7 @@ $ build/cmd.sh copy
 $ docker build -t mirantis/virtlet .
 
 $ # copy the image to the DIND node
-$ docker save mirantis/virtlet | docker exec -i kube-master docker load
+$ docker save mirantis/virtlet | docker exec -i kube-node-1 docker load
 ```
 
 You may use [flannel](https://github.com/coreos/flannel) instead of

--- a/tests/e2e/e2e.sh
+++ b/tests/e2e/e2e.sh
@@ -147,11 +147,11 @@ vmchat cirros-vm
 
 # test logging
 
-virshid=$($virsh list | grep "\-cirros-vm " | cut -f2 -d " ")
-logpath=$($virsh dumpxml $virshid | xmllint --xpath 'string(//serial[@type="file"]/source/@path)' -)
-filename=$(echo $logpath | sed -E 's#.+/##')
-sandboxid=$(echo $logpath | sed 's#/var/log/vms/##' | sed -E 's#/.+##')
-nodeid=$(docker ps | grep kube-node-1 | cut -f1 -d " ")
+virshid="$("${virsh}" list | grep "\-cirros-vm " | cut -f2 -d " ")"
+logpath="$("${virsh}" dumpxml $virshid | xmllint --xpath 'string(//serial[@type="file"]/source/@path)' -)"
+filename="$(echo $logpath | sed -E 's#.+/##')"
+sandboxid="$(echo $logpath | sed 's#/var/log/vms/##' | sed -E 's#/.+##')"
+nodeid="$(kubectl get pod -n kube-system -l runtime=virtlet -o jsonpath='{.items[0].spec.nodeName}')"
 
 count=$(docker exec -it ${nodeid} /bin/bash -c "cat /var/log/virtlet/vms/${sandboxid}/${filename}" | \
      grep "login as 'cirros' user. default password: 'cubswin:)'. use 'sudo' for root." | \

--- a/tests/e2e/e2e.sh
+++ b/tests/e2e/e2e.sh
@@ -151,7 +151,7 @@ virshid=$($virsh list | grep "\-cirros-vm " | cut -f2 -d " ")
 logpath=$($virsh dumpxml $virshid | xmllint --xpath 'string(//serial[@type="file"]/source/@path)' -)
 filename=$(echo $logpath | sed -E 's#.+/##')
 sandboxid=$(echo $logpath | sed 's#/var/log/vms/##' | sed -E 's#/.+##')
-nodeid=$(docker ps | grep kube-master | cut -f1 -d " ")
+nodeid=$(docker ps | grep kube-node-1 | cut -f1 -d " ")
 
 count=$(docker exec -it ${nodeid} /bin/bash -c "cat /var/log/virtlet/vms/${sandboxid}/${filename}" | \
      grep "login as 'cirros' user. default password: 'cubswin:)'. use 'sudo' for root." | \


### PR DESCRIPTION
Deploying Virtlet on master is still possible by setting `VIRTLET_ON_MASTER` environment variable to a non-empty value. This is supported by both `build/cmd.sh` and `deploy/demo.sh` and should work regardless of whether k-d-c was started with `NUM_NODES=0` or not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/389)
<!-- Reviewable:end -->
