### PR TITLE
Use separate container for VMs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && \
     apt-get install -y libvirt-bin libguestfs0 libguestfs-tools genisoimage \
                        openssl qemu-kvm qemu-system-x86 python-libvirt \
-                       netbase iproute2 iptables ebtables vncsnapshot && \
+                       netbase iproute2 iptables ebtables vncsnapshot sudo && \
     apt-get clean
 
 RUN mkdir -p /var/lib/virtlet/volumes /opt/cni/bin && \

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -60,3 +60,6 @@ RUN mkdir -p ~/.ssh && \
     ln -s /go/src/github.com/Mirantis/virtlet/_output/vmwrapper /vmwrapper
 
 COPY image_skel /.
+# this conf file runs the emulator as root which is ok for
+# testing purposes
+COPY qemu-build.conf /etc/libvirt/qemu.conf

--- a/cmd/virtlet/virtlet.go
+++ b/cmd/virtlet/virtlet.go
@@ -24,10 +24,11 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/golang/glog"
+
+	"github.com/Mirantis/virtlet/pkg/libvirttools"
 	"github.com/Mirantis/virtlet/pkg/manager"
 	"github.com/Mirantis/virtlet/pkg/tapmanager"
-
-	"github.com/golang/glog"
 )
 
 var (
@@ -96,6 +97,9 @@ func runTapManager() {
 	if err = s.Serve(); err != nil {
 		glog.Errorf("FD server returned error: %v", err)
 		os.Exit(1)
+	}
+	if err := libvirttools.ChownForEmulator(*fdServerSocketPath); err != nil {
+		glog.Warningf("couldn't set tapmanager socket permissions: %v", err)
 	}
 	for {
 		time.Sleep(1000 * time.Hour)

--- a/deploy/virtlet-ds-dev.yaml
+++ b/deploy/virtlet-ds-dev.yaml
@@ -158,6 +158,18 @@ spec:
               name: virtlet-config
               key: loglevel
               optional: true
+      - name: vms
+        image: mirantis/virtlet
+        imagePullPolicy: IfNotPresent
+        command:
+        - /vms.sh
+        volumeMounts:
+        - mountPath: /var/lib/virtlet
+          name: virtlet
+        - mountPath: /var/lib/libvirt
+          name: libvirt
+        - name: dev
+          mountPath: /dev
       volumes:
       # /dev is needed for host raw device access.
       # In case of 'logless' mode, it's also used

--- a/deploy/virtlet-ds.yaml
+++ b/deploy/virtlet-ds.yaml
@@ -176,6 +176,20 @@ spec:
           value: "/virtlet-log"
         - name: KUBERNETES_POD_LOGS
           value: "/kubernetes-log"
+      - name: vms
+        image: mirantis/virtlet
+        imagePullPolicy: IfNotPresent
+        command:
+        - /vms.sh
+        volumeMounts:
+        - mountPath: /var/lib/virtlet
+          name: virtlet
+        - mountPath: /var/lib/libvirt
+          name: libvirt
+        - name: vms-log
+          mountPath: /var/log/vms
+        - name: dev
+          mountPath: /dev
       volumes:
       # /dev is needed for host raw device access
       - hostPath:

--- a/examples/virsh.sh
+++ b/examples/virsh.sh
@@ -78,5 +78,5 @@ for pod in ${pods[*]}; do
   if [[ ${#pods[*]} > 1 ]]; then
     printf "${pod} ($(kubectl get pod -nkube-system "${pod}" -o jsonpath="{.spec.nodeName}")):\n\n"
   fi
-  kubectl exec ${opts} -n kube-system "${pod}" -c virtlet -- virsh ${args[@]+"${args[@]}"}
+  kubectl exec ${opts} -n kube-system "${pod}" -c libvirt -- virsh ${args[@]+"${args[@]}"}
 done

--- a/image_skel/etc/libvirt/libvirtd.conf
+++ b/image_skel/etc/libvirt/libvirtd.conf
@@ -2,5 +2,5 @@ listen_tcp = 1
 auth_tcp = "none"
 ca_file = ""
 log_level = 3
-log_outputs = "x:stderr"
+log_outputs = "1:stderr"
 listen_addr = "0.0.0.0"

--- a/image_skel/etc/libvirt/qemu.conf
+++ b/image_skel/etc/libvirt/qemu.conf
@@ -1,12 +1,1 @@
 stdio_handler = "file"
-user = "root"
-group = "root"
-# we need to do network management stuff in vmwrapper
-clear_emulator_capabilities = 0
-
-cgroup_device_acl = [
-         "/dev/null", "/dev/full", "/dev/zero",
-         "/dev/random", "/dev/urandom",
-         "/dev/ptmx", "/dev/kvm", "/dev/kqemu",
-         "/dev/rtc", "/dev/hpet", "/dev/net/tun",
-     ]

--- a/image_skel/libvirt.sh
+++ b/image_skel/libvirt.sh
@@ -56,4 +56,13 @@ if [[ ! ${VIRTLET_DISABLE_KVM:-} ]]; then
   chown root:kvm /dev/kvm
 fi
 
+# Set up sudoers file only in libvirt container so as to
+# avoid introducing a vulnerability
+
+mkdir -p /etc/sudoers.d/
+echo -e "Defaults closefrom_override\nlibvirt-qemu\tALL=(ALL)\tNOPASSWD: ALL" >/etc/sudoers.d/virtlet-qemu
+
+# export LIBVIRT_LOG_FILTERS="1:qemu.qemu_process 1:qemu.qemu_command 1:qemu.qemu_domain"
+# export LIBVIRT_DEBUG=1
+
 /usr/sbin/libvirtd --listen $daemon

--- a/image_skel/qemu.sh
+++ b/image_skel/qemu.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+nspid="$1"
+shift
+exec sudo -C 10000 nsenter -t ${nspid} -m -u -i -n sudo -C 10000 -u libvirt-qemu "$@"

--- a/image_skel/vms.sh
+++ b/image_skel/vms.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+if lsmod | grep '\<kvm\>' > /dev/null &&
+   ! ([[ -e /dev/kvm ]] || mknod /dev/kvm c 10 $(grep '\<kvm\>' /proc/misc | cut -d" " -f1)); then
+  echo >&2 "warning: can't create /dev/kvm"
+elif [[ -e /dev/kvm ]]; then
+  chown libvirt-qemu.kvm /dev/kvm
+fi
+
+echo 'Defaults closefrom_override' > /etc/sudoers.d/virtlet-qemu
+
+# rm the following (tmp fix):
+chown -R root.root /etc/sudoers.d/
+
+# mount --bind /hostdev /dev
+
+echo "$$ $(cut -d' ' -f22 /proc/$$/stat)" >/var/lib/virtlet/vms.procfile
+sleep Infinity

--- a/pkg/libvirttools/TestContainerLifecycle.json
+++ b/pkg/libvirttools/TestContainerLifecycle.json
@@ -133,9 +133,7 @@
       },
       "CurrentMemory": null,
       "MaximumMemory": null,
-      "MemoryBacking": {
-        "Locked": {}
-      },
+      "MemoryBacking": null,
       "VCPU": {
         "Placement": "",
         "CPUSet": "",

--- a/pkg/libvirttools/TestDomainDefinitions__ceph_flexvolume.json
+++ b/pkg/libvirttools/TestDomainDefinitions__ceph_flexvolume.json
@@ -152,9 +152,7 @@
       },
       "CurrentMemory": null,
       "MaximumMemory": null,
-      "MemoryBacking": {
-        "Locked": {}
-      },
+      "MemoryBacking": null,
       "VCPU": {
         "Placement": "",
         "CPUSet": "",

--- a/pkg/libvirttools/TestDomainDefinitions__cloud-init.json
+++ b/pkg/libvirttools/TestDomainDefinitions__cloud-init.json
@@ -129,9 +129,7 @@
       },
       "CurrentMemory": null,
       "MaximumMemory": null,
-      "MemoryBacking": {
-        "Locked": {}
-      },
+      "MemoryBacking": null,
       "VCPU": {
         "Placement": "",
         "CPUSet": "",

--- a/pkg/libvirttools/TestDomainDefinitions__cloud-init_with_user_data.json
+++ b/pkg/libvirttools/TestDomainDefinitions__cloud-init_with_user_data.json
@@ -129,9 +129,7 @@
       },
       "CurrentMemory": null,
       "MaximumMemory": null,
-      "MemoryBacking": {
-        "Locked": {}
-      },
+      "MemoryBacking": null,
       "VCPU": {
         "Placement": "",
         "CPUSet": "",

--- a/pkg/libvirttools/TestDomainDefinitions__plain_domain.json
+++ b/pkg/libvirttools/TestDomainDefinitions__plain_domain.json
@@ -129,9 +129,7 @@
       },
       "CurrentMemory": null,
       "MaximumMemory": null,
-      "MemoryBacking": {
-        "Locked": {}
-      },
+      "MemoryBacking": null,
       "VCPU": {
         "Placement": "",
         "CPUSet": "",

--- a/pkg/libvirttools/TestDomainDefinitions__raw_devices.json
+++ b/pkg/libvirttools/TestDomainDefinitions__raw_devices.json
@@ -129,9 +129,7 @@
       },
       "CurrentMemory": null,
       "MaximumMemory": null,
-      "MemoryBacking": {
-        "Locked": {}
-      },
+      "MemoryBacking": null,
       "VCPU": {
         "Placement": "",
         "CPUSet": "",

--- a/pkg/libvirttools/TestDomainDefinitions__vcpu_count.json
+++ b/pkg/libvirttools/TestDomainDefinitions__vcpu_count.json
@@ -129,9 +129,7 @@
       },
       "CurrentMemory": null,
       "MaximumMemory": null,
-      "MemoryBacking": {
-        "Locked": {}
-      },
+      "MemoryBacking": null,
       "VCPU": {
         "Placement": "",
         "CPUSet": "",

--- a/pkg/libvirttools/TestDomainDefinitions__virtio_disk_driver.json
+++ b/pkg/libvirttools/TestDomainDefinitions__virtio_disk_driver.json
@@ -129,9 +129,7 @@
       },
       "CurrentMemory": null,
       "MaximumMemory": null,
-      "MemoryBacking": {
-        "Locked": {}
-      },
+      "MemoryBacking": null,
       "VCPU": {
         "Placement": "",
         "CPUSet": "",

--- a/pkg/libvirttools/TestDomainDefinitions__volumes.json
+++ b/pkg/libvirttools/TestDomainDefinitions__volumes.json
@@ -240,9 +240,7 @@
       },
       "CurrentMemory": null,
       "MaximumMemory": null,
-      "MemoryBacking": {
-        "Locked": {}
-      },
+      "MemoryBacking": null,
       "VCPU": {
         "Placement": "",
         "CPUSet": "",

--- a/pkg/libvirttools/TestDomainForcedShutdown.json
+++ b/pkg/libvirttools/TestDomainForcedShutdown.json
@@ -129,9 +129,7 @@
       },
       "CurrentMemory": null,
       "MaximumMemory": null,
-      "MemoryBacking": {
-        "Locked": {}
-      },
+      "MemoryBacking": null,
       "VCPU": {
         "Placement": "",
         "CPUSet": "",

--- a/pkg/libvirttools/fileownership.go
+++ b/pkg/libvirttools/fileownership.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2017 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package libvirttools
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"strconv"
+	"sync"
+)
+
+const (
+	emulatorUserName = "libvirt-qemu"
+)
+
+var emulatorUser struct {
+	sync.Mutex
+	initialized bool
+	uid, gid    int
+}
+
+// ChownForEmulator makes a file or directory owned by the emulator user.
+func ChownForEmulator(filePath string) error {
+	emulatorUser.Lock()
+	defer emulatorUser.Unlock()
+	if !emulatorUser.initialized {
+		u, err := user.Lookup(emulatorUserName)
+		if err != nil {
+			return fmt.Errorf("can't find user %q: %v", emulatorUserName, err)
+		}
+		emulatorUser.uid, err = strconv.Atoi(u.Uid)
+		if err != nil {
+			return fmt.Errorf("bad uid %q for user %q: %v", u.Uid, emulatorUserName, err)
+		}
+		emulatorUser.gid, err = strconv.Atoi(u.Gid)
+		if err != nil {
+			return fmt.Errorf("bad gid %q for user %q: %v", u.Gid, emulatorUserName, err)
+		}
+	}
+	if err := os.Chown(filePath, emulatorUser.uid, emulatorUser.gid); err != nil {
+		return fmt.Errorf("can't set the owner of tapmanager socket: %v", err)
+	}
+	return nil
+}

--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -299,8 +299,11 @@ func (v *VirtualizationTool) addSerialDevicesToDomain(sandboxId, containerName s
 
 		// Prepare directory where libvirt will store log file to.
 		if _, err := os.Stat(logDir); os.IsNotExist(err) {
-			if err := os.Mkdir(logDir, 0644); err != nil {
-				return fmt.Errorf("failed to create vmLogDir '%s': %s", logDir, err.Error())
+			if err := os.Mkdir(logDir, 0755); err != nil {
+				return fmt.Errorf("failed to create vmLogDir %q: %v", logDir, err)
+			}
+			if err := ChownForEmulator(logDir); err != nil {
+				return fmt.Errorf("failed to chown vmLogDir %q: %v", err)
 			}
 		}
 

--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -138,7 +138,15 @@ func (ds *domainSettings) createDomain() *libvirtxml.Domain {
 			Period: &libvirtxml.DomainCPUTunePeriod{Value: ds.cpuPeriod},
 			Quota:  &libvirtxml.DomainCPUTuneQuota{Value: ds.cpuQuota},
 		},
-		MemoryBacking: &libvirtxml.DomainMemoryBacking{Locked: &libvirtxml.DomainMemoryBackingLocked{}},
+		// This causes '"qemu: qemu_thread_create: Resource temporarily unavailable"' QEMU errors
+		// when Virtlet is run as a non-privileged user.
+		// Under strace, it looks like a bunch of mmap()s failing with EAGAIN
+		// which happens due to mlockall() call somewhere above that.
+		// This could be worked around using setrlimit() but really
+		// swap handling is not needed here because it's incorrect
+		// to have swap enabled on the nodes of a real Kubernetes cluster.
+
+		// MemoryBacking: &libvirtxml.DomainMemoryBacking{Locked: &libvirtxml.DomainMemoryBackingLocked{}},
 
 		QEMUCommandline: &libvirtxml.DomainQEMUCommandline{
 			Envs: []libvirtxml.DomainQEMUCommandlineEnv{

--- a/pkg/libvirttools/virtualization_test.go
+++ b/pkg/libvirttools/virtualization_test.go
@@ -549,10 +549,4 @@ func TestDomainResourceConstraints(t *testing.T) {
 	} else if domain.Memory.Value != uint(memoryLimit) || domain.Memory.Unit != "b" {
 		t.Errorf("unexpected memory limitvalue: expected %vb, got %v%s", memoryLimit, domain.Memory.Value, domain.Memory.Unit)
 	}
-
-	if domain.MemoryBacking == nil {
-		t.Error("Memory backing is not set")
-	} else if domain.MemoryBacking.Locked == nil {
-		t.Error("Domain memory is not locked")
-	}
 }

--- a/pkg/tapmanager/tapfdsource.go
+++ b/pkg/tapmanager/tapfdsource.go
@@ -31,11 +31,17 @@ import (
 	"github.com/Mirantis/virtlet/pkg/nettools"
 )
 
+// PodNetworkDesc contains the data that are required by TapFDSource
+// to set up a tap device for a VM
 type PodNetworkDesc struct {
-	PodId   string `json:"podId"`
-	PodNs   string `json:"podNs"`
+	// PodId specifies the id of the pod
+	PodId string `json:"podId"`
+	// PodNs specifies the namespace of the pod
+	PodNs string `json:"podNs"`
+	// PodName specifies the name of the pod
 	PodName string `json:"podName"`
-	DNS     *cnitypes.DNS
+	// DNS specifies DNS settings for the pod
+	DNS *cnitypes.DNS
 }
 
 type podNetwork struct {
@@ -179,7 +185,7 @@ func (s *TapFDSource) Release(key string) error {
 	}
 
 	if err := cni.DestroyNetNS(pn.pnd.PodId); err != nil {
-		return fmt.Errorf("Error when removing network namespace for pod sandbox %q: %v", pn.pnd.PodId, err)
+		return fmt.Errorf("error when removing network namespace for pod sandbox %q: %v", pn.pnd.PodId, err)
 	}
 
 	delete(s.fdMap, key)

--- a/pkg/utils/waitproc.go
+++ b/pkg/utils/waitproc.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2017 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/jonboulle/clockwork"
+)
+
+const (
+	waitProcRetryPeriod = 200 * time.Millisecond
+	waitProcTimeout     = 30 * time.Second
+)
+
+func readProcFile(procFile string) (int, uint64, error) {
+	content, err := ioutil.ReadFile(procFile)
+	if err != nil {
+		return 0, 0, fmt.Errorf("reading procfile %q: %v", procFile, err)
+	}
+	parts := strings.Split(strings.TrimSpace(string(content)), " ")
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("procfile %q is malformed: wrong number of fields", procFile)
+	}
+	pid, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("procfile %q is malformed: bad pid field", procFile)
+	}
+	startTime, err := strconv.ParseUint(parts[1], 10, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("procfile %q is malformed: bad start time field", procFile)
+	}
+	return pid, startTime, nil
+}
+
+func getProcessStartTime(pid int) (uint64, error) {
+	statPath := fmt.Sprintf("/proc/%d/stat", pid)
+	content, err := ioutil.ReadFile(statPath)
+	if err != nil {
+		return 0, fmt.Errorf("error reading %q: %v", statPath, err)
+	}
+	text := string(content)
+	// avoid problems due to spaces and parens in the executable name
+	parenPos := strings.LastIndex(text, ")")
+	if parenPos == -1 {
+		return 0, fmt.Errorf("can't parse %q: no closing paren after executable filename", statPath)
+	}
+	parts := strings.Split(text[parenPos:], " ")
+	if len(parts) < 21 {
+		return 0, fmt.Errorf("can't parse %q: insufficient number of fields", statPath)
+	}
+	startTime, err := strconv.ParseUint(parts[20], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("can't parse %q: bad start time field", statPath)
+	}
+	return startTime, nil
+}
+
+// WaitForProcess waits for the following conditions to be true
+// at the same time:
+// * the specified procFile is readable and contains two numeric values separated by space,
+//   PID and start time in jiffies (field 22 in /proc/PID/stat, starting from 1)
+// * the process with the PID read from procFile exists and has start time
+//   equal to the start time read from procFile
+// This avoids possible problems with stale procFile that could happen
+// if only PID was stored there.
+// The command can be used in shell script to generate the "procfile"
+// for the current shell:
+// /bin/sh -c 'echo "$$ `cut -d" " -f22 /proc/$$/stat`"'
+func WaitForProcess(procFile string) (int, error) {
+	var pid int
+	err := WaitLoop(func() (bool, error) {
+		var expectedStartTime uint64
+		var err error
+		pid, expectedStartTime, err = readProcFile(procFile)
+		if err != nil {
+			glog.V(3).Infof("procfile %q not ready yet: %v", procFile, err)
+			return false, nil
+		}
+		startTime, err := getProcessStartTime(pid)
+		if err != nil {
+			glog.V(3).Infof("procfile %q: can't get process start time for pid %d yet: %v", procFile, pid, err)
+			return false, nil
+		}
+		if startTime != expectedStartTime {
+			glog.V(3).Infof("procfile %q is stale: start time for pid %d is %d instead of %d", procFile, pid, startTime, expectedStartTime)
+			return false, nil
+		}
+		return true, nil
+	}, waitProcRetryPeriod, waitProcTimeout, clockwork.NewRealClock())
+	if err != nil {
+		return 0, err
+	}
+	return pid, nil
+}

--- a/pkg/utils/waitproc_test.go
+++ b/pkg/utils/waitproc_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2017 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func verifyWaitProc(t *testing.T, tmpDir string) {
+	procFile := filepath.Join(tmpDir, "sample.proc")
+	cmd := exec.Command("/bin/sh", "-c",
+		fmt.Sprintf("sleep 0.5 && echo \"$$ `cut -d' ' -f22 /proc/$$/stat`\" > '%s' && sleep 1000", procFile))
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("couldn't run command: %v", err)
+	}
+	defer func() {
+		if err := cmd.Process.Kill(); err != nil {
+			t.Fatalf("couldn't kill the process")
+		}
+		cmd.Wait()
+	}()
+
+	pid, err := WaitForProcess(procFile)
+	if err != nil {
+		t.Fatalf("WaitForProcess(): %v", err)
+	} else if pid != cmd.Process.Pid {
+		t.Errorf("bad pid returned by WaitForProcess: %d instead of %d", pid, cmd.Process.Pid)
+	}
+}
+
+func TestWaitProc(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "waitproc-test")
+	if err != nil {
+		t.Fatalf("ioutil.TempDir(): %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	for i := 0; i < 3; i++ {
+		verifyWaitProc(t, tmpDir)
+	}
+}

--- a/qemu-build.conf
+++ b/qemu-build.conf
@@ -1,0 +1,10 @@
+stdio_handler = "file"
+user = "root"
+group = "root"
+
+cgroup_device_acl = [
+         "/dev/null", "/dev/full", "/dev/zero",
+         "/dev/random", "/dev/urandom",
+         "/dev/ptmx", "/dev/kvm", "/dev/kqemu",
+         "/dev/rtc", "/dev/hpet", "/dev/net/tun",
+     ]

--- a/tests/integration/manager.go
+++ b/tests/integration/manager.go
@@ -65,6 +65,9 @@ func (v *VirtletManager) Run() {
 	}
 
 	v.manager, err = manager.NewVirtletManager(localLibvirtUri, "default", "http", "dir", dbFilename, "loop*", &fakeFDManager{})
+	if err != nil {
+		v.t.Fatalf("Failed to create VirtletManager: %v", err)
+	}
 	v.doneCh = make(chan struct{})
 	go func() {
 		if err := v.manager.Serve(virtletSocket); err != nil {


### PR DESCRIPTION
This PR makes Virtlet run VMs in a separate container (except that it still uses libvirt cgroups).
Also, the VMs are now run as a non-root user.

Temporarily including commits from #393

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/398)
<!-- Reviewable:end -->
