### PR TITLE
libvirttools: Pass network configuration through cloud-init

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -46,16 +46,18 @@ pair with one end belonging to the pod network namespace.
 1. On `RunPodSandBox` request Virtlet requests `tapmanager` process to
    set up the networking for the VM by sending it a command over its
    Unix domain socket
-2. `tapmanager` sets up the network according to the above diagram
+1. `tapmanager` sets up the network according to the above diagram
    (see below for more details)
-3. When the VM is started, Virtlet wraps the emulator using `vmwrapper` program
+1. `tapmanager` returns network configuration info which is used
+   by Virtlet to set up Cloud-Init network config
+1. When the VM is started, Virtlet wraps the emulator using `vmwrapper` program
    which it passes `VIRTLET_NET_KEY` environment variable containing the key
    the was used by `tapmanager` to set up the network.
-4. `vmwrapper` uses the key to ask `tapmanager` to send it the file
+1. `vmwrapper` uses the key to ask `tapmanager` to send it the file
    descriptor for the tap interface over `tapmanager`'s Unix domain
    socket. It then extends emulator command line arguments to make it
    use the tap device and then `exec`s the emulator.
-5. Upon `StopPodSandbox`, Virtlet requests `tapmanager` to tear down
+1. Upon `StopPodSandbox`, Virtlet requests `tapmanager` to tear down
    the VM network.
 
 The rationale for having separate `tapmanager` process is

--- a/pkg/libvirttools/TestContainerLifecycle.json
+++ b/pkg/libvirttools/TestContainerLifecycle.json
@@ -114,6 +114,7 @@
     "name": "domain conn: iso image",
     "data": {
       "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\"}",
+      "network-config": "version: 1\nconfig: null\n",
       "user-data": "#cloud-config\n"
     }
   },

--- a/pkg/libvirttools/TestDomainDefinitions__ceph_flexvolume.json
+++ b/pkg/libvirttools/TestDomainDefinitions__ceph_flexvolume.json
@@ -133,6 +133,7 @@
     "name": "domain conn: iso image",
     "data": {
       "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\"}",
+      "network-config": "version: 1\nconfig: null\n",
       "user-data": "#cloud-config\nmounts:\n- - /dev/sdb1\n  - /var/lib/whatever\n"
     }
   },

--- a/pkg/libvirttools/TestDomainDefinitions__cloud-init.json
+++ b/pkg/libvirttools/TestDomainDefinitions__cloud-init.json
@@ -110,6 +110,7 @@
     "name": "domain conn: iso image",
     "data": {
       "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\",\"public-keys\":[\"key1\",\"key2\"]}",
+      "network-config": "version: 1\nconfig: null\n",
       "user-data": "#cloud-config\n"
     }
   },

--- a/pkg/libvirttools/TestDomainDefinitions__cloud-init_with_user_data.json
+++ b/pkg/libvirttools/TestDomainDefinitions__cloud-init_with_user_data.json
@@ -110,6 +110,7 @@
     "name": "domain conn: iso image",
     "data": {
       "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\",\"public-keys\":[\"key1\",\"key2\"]}",
+      "network-config": "version: 1\nconfig: null\n",
       "user-data": "#cloud-config\nusers:\n- name: cloudy\n"
     }
   },

--- a/pkg/libvirttools/TestDomainDefinitions__plain_domain.json
+++ b/pkg/libvirttools/TestDomainDefinitions__plain_domain.json
@@ -110,6 +110,7 @@
     "name": "domain conn: iso image",
     "data": {
       "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\"}",
+      "network-config": "version: 1\nconfig: null\n",
       "user-data": "#cloud-config\n"
     }
   },

--- a/pkg/libvirttools/TestDomainDefinitions__raw_devices.json
+++ b/pkg/libvirttools/TestDomainDefinitions__raw_devices.json
@@ -110,6 +110,7 @@
     "name": "domain conn: iso image",
     "data": {
       "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\"}",
+      "network-config": "version: 1\nconfig: null\n",
       "user-data": "#cloud-config\n"
     }
   },

--- a/pkg/libvirttools/TestDomainDefinitions__vcpu_count.json
+++ b/pkg/libvirttools/TestDomainDefinitions__vcpu_count.json
@@ -110,6 +110,7 @@
     "name": "domain conn: iso image",
     "data": {
       "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\"}",
+      "network-config": "version: 1\nconfig: null\n",
       "user-data": "#cloud-config\n"
     }
   },

--- a/pkg/libvirttools/TestDomainDefinitions__virtio_disk_driver.json
+++ b/pkg/libvirttools/TestDomainDefinitions__virtio_disk_driver.json
@@ -110,6 +110,7 @@
     "name": "domain conn: iso image",
     "data": {
       "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\"}",
+      "network-config": "version: 1\nconfig: null\n",
       "user-data": "#cloud-config\n"
     }
   },

--- a/pkg/libvirttools/TestDomainDefinitions__volumes.json
+++ b/pkg/libvirttools/TestDomainDefinitions__volumes.json
@@ -221,6 +221,7 @@
     "name": "domain conn: iso image",
     "data": {
       "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\"}",
+      "network-config": "version: 1\nconfig: null\n",
       "user-data": "#cloud-config\n"
     }
   },

--- a/pkg/libvirttools/TestDomainForcedShutdown.json
+++ b/pkg/libvirttools/TestDomainForcedShutdown.json
@@ -110,6 +110,7 @@
     "name": "domain conn: iso image",
     "data": {
       "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\"}",
+      "network-config": "version: 1\nconfig: null\n",
       "user-data": "#cloud-config\n"
     }
   },

--- a/pkg/libvirttools/cloudinit.go
+++ b/pkg/libvirttools/cloudinit.go
@@ -127,6 +127,7 @@ func (g *CloudInitGenerator) generateNetworkConfiguration() ([]byte, error) {
 
 	var config []map[string]interface{}
 
+	// physical interfaces
 	for i, iface := range cniResult.Interfaces {
 		interfaceConf := map[string]interface{}{
 			"type":        "physical",
@@ -135,6 +136,16 @@ func (g *CloudInitGenerator) generateNetworkConfiguration() ([]byte, error) {
 			"subnets":     g.getSubnetsForNthInterface(i, cniResult),
 		}
 		config = append(config, interfaceConf)
+	}
+
+	// routes
+	for _, cniRoute := range cniResult.Routes {
+		route := map[string]interface{}{
+			"type":        "route",
+			"destination": cniRoute.Dst.String(),
+			"gateway":     cniRoute.GW.String(),
+		}
+		config = append(config, route)
 	}
 
 	r, err := yaml.Marshal(map[string]interface{}{
@@ -177,7 +188,6 @@ func (g *CloudInitGenerator) getSubnetsForNthInterface(interfaceNo int, cniResul
 		})
 	}
 
-	// TODO: parse cniResult.Routes and add them to correct subnet configuration
 	return subnets
 }
 

--- a/pkg/libvirttools/cloudinit.go
+++ b/pkg/libvirttools/cloudinit.go
@@ -119,18 +119,22 @@ func (g *CloudInitGenerator) generateNetworkConfiguration() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	if cniResult == nil {
+		// This can only happen during integration tests
+		// where a dummy sandbox is used
+		return []byte("version: 1\n"), nil
+	}
+
 	var config []map[string]interface{}
 
-	if len(cniResult.Interfaces) > 0 {
-		for i, iface := range cniResult.Interfaces {
-			interfaceConf := map[string]interface{}{
-				"type":        "physical",
-				"name":        iface.Name,
-				"mac_address": iface.Mac,
-				"subnets":     g.getSubnetsForNthInterface(i, cniResult),
-			}
-			config = append(config, interfaceConf)
+	for i, iface := range cniResult.Interfaces {
+		interfaceConf := map[string]interface{}{
+			"type":        "physical",
+			"name":        iface.Name,
+			"mac_address": iface.Mac,
+			"subnets":     g.getSubnetsForNthInterface(i, cniResult),
 		}
+		config = append(config, interfaceConf)
 	}
 
 	r, err := yaml.Marshal(map[string]interface{}{

--- a/pkg/libvirttools/cloudinit.go
+++ b/pkg/libvirttools/cloudinit.go
@@ -27,11 +27,14 @@ import (
 	"path/filepath"
 	"strings"
 
+	cnicurrent "github.com/containernetworking/cni/pkg/types/current"
 	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
 	libvirtxml "github.com/libvirt/libvirt-go-xml"
 
+	"github.com/Mirantis/virtlet/pkg/cni"
 	"github.com/Mirantis/virtlet/pkg/flexvolume"
+	"github.com/Mirantis/virtlet/pkg/metadata"
 	"github.com/Mirantis/virtlet/pkg/utils"
 )
 
@@ -40,13 +43,21 @@ const (
 )
 
 type CloudInitGenerator struct {
-	config    *VMConfig
-	volumeMap map[string]string
-	isoDir    string
+	config         *VMConfig
+	podSandboxInfo *metadata.PodSandboxInfo
+	volumeMap      map[string]string
+	isoDir         string
 }
 
-func NewCloudInitGenerator(config *VMConfig, volumeMap map[string]string, isoDir string) *CloudInitGenerator {
-	return &CloudInitGenerator{config: config, volumeMap: volumeMap, isoDir: isoDir}
+func NewCloudInitGenerator(config *VMConfig, volumeMap map[string]string,
+	isoDir string, podSandboxInfo *metadata.PodSandboxInfo) *CloudInitGenerator {
+
+	return &CloudInitGenerator{
+		config:         config,
+		podSandboxInfo: podSandboxInfo,
+		volumeMap:      volumeMap,
+		isoDir:         isoDir,
+	}
 }
 
 func (g *CloudInitGenerator) generateMetaData() ([]byte, error) {
@@ -103,6 +114,69 @@ func (g *CloudInitGenerator) generateUserData() ([]byte, error) {
 	return []byte("#cloud-config\n" + string(r)), nil
 }
 
+func (g *CloudInitGenerator) generateNetworkConfiguration() ([]byte, error) {
+	cniResult, err := cni.BytesToResult([]byte(g.podSandboxInfo.CNIConfig))
+	if err != nil {
+		return nil, err
+	}
+	var config []map[string]interface{}
+
+	if len(cniResult.Interfaces) > 0 {
+		for i, iface := range cniResult.Interfaces {
+			interfaceConf := map[string]interface{}{
+				"type":        "physical",
+				"name":        iface.Name,
+				"mac_address": iface.Mac,
+				"subnets":     g.getSubnetsForNthInterface(i, cniResult),
+			}
+			config = append(config, interfaceConf)
+		}
+	}
+
+	r, err := yaml.Marshal(map[string]interface{}{
+		"config": config,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return []byte("version: 1\n" + string(r)), nil
+}
+
+func (g *CloudInitGenerator) getSubnetsForNthInterface(interfaceNo int, cniResult *cnicurrent.Result) []map[string]interface{} {
+	var subnets []map[string]interface{}
+	for _, ipConfig := range cniResult.IPs {
+		if ipConfig.Interface == interfaceNo {
+			subnet := map[string]interface{}{
+				"type":    "static",
+				"address": ipConfig.Address.String(),
+			}
+			if !ipConfig.Gateway.IsUnspecified() {
+				subnet["gateway"] = ipConfig.Gateway.String()
+			}
+			// Cloud Init requires dns settings on the subnet level (yeah, I know...)
+			// while we get just one setting for all the IP configurations from CNI,
+			// so as a workaround we're adding it to all subnets configurations
+			if cniResult.DNS.Nameservers != nil {
+				subnet["dns_nameservers"] = cniResult.DNS.Nameservers
+			}
+			if cniResult.DNS.Search != nil {
+				subnet["dns_search"] = cniResult.DNS.Search
+			}
+			subnets = append(subnets, subnet)
+		}
+	}
+
+	// fallback to dhcp - should never happen, we always should have IPs
+	if subnets == nil {
+		subnets = append(subnets, map[string]interface{}{
+			"type": "dhcp",
+		})
+	}
+
+	// TODO: parse cniResult.Routes and add them to correct subnet configuration
+	return subnets
+}
+
 func (g *CloudInitGenerator) IsoPath() string {
 	return filepath.Join(g.isoDir, fmt.Sprintf("nocloud-%s.iso", g.config.DomainUUID))
 }
@@ -114,18 +188,22 @@ func (g *CloudInitGenerator) GenerateDisk() (*libvirtxml.DomainDisk, error) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	var metaData, userData []byte
+	var metaData, userData, networkConfiguration []byte
 	metaData, err = g.generateMetaData()
 	if err == nil {
 		userData, err = g.generateUserData()
+	}
+	if err == nil {
+		networkConfiguration, err = g.generateNetworkConfiguration()
 	}
 	if err != nil {
 		return nil, err
 	}
 
 	if err := utils.WriteFiles(tmpDir, map[string][]byte{
-		"user-data": userData,
-		"meta-data": metaData,
+		"user-data":      userData,
+		"meta-data":      metaData,
+		"network-config": networkConfiguration,
 	}); err != nil {
 		return nil, fmt.Errorf("can't write user-data: %v", err)
 	}
@@ -275,6 +353,9 @@ func (m *WriteFilesManipulator) AddFileLikeMounts() {
 			"permissions": "0644",
 		}}
 	})
+}
+
+func (m *WriteFilesManipulator) AddNetworkConfiguration() {
 }
 
 func (m *WriteFilesManipulator) addFilesForVolumeType(suffix, permissions string) {

--- a/pkg/libvirttools/cloudinit_test.go
+++ b/pkg/libvirttools/cloudinit_test.go
@@ -43,19 +43,19 @@ func init() {
   "interfaces": [
       {
           "name": "cni0",
-	  "mac": "00:11:22:33:44:55",
+	  "mac": "00:11:22:33:44:55"
       }
   ],
   "ips": [
       {
           "version": "4",
-          "address": "<ip-and-prefix-in-CIDR>",
-          "gateway": "<ip-address-of-the-gateway>",
+          "address": "1.1.1.1/8",
+          "gateway": "1.2.3.4",
           "interface": 0
-      },
+      }
   ],
   "dns": {
-    "nameservers": ["1.2.3.4"]
+    "nameservers": ["1.2.3.4"],
     "search": ["some", "search"]
   }
 }`
@@ -383,8 +383,9 @@ func TestGenerateDisk(t *testing.T) {
 		t.Fatalf("IsoToMap(): %v", err)
 	}
 	if !reflect.DeepEqual(m, map[string]interface{}{
-		"meta-data": "{\"instance-id\":\"foo.default\",\"local-hostname\":\"foo\"}",
-		"user-data": "#cloud-config\n",
+		"meta-data":      "{\"instance-id\":\"foo.default\",\"local-hostname\":\"foo\"}",
+		"network-config": "version: 1\nconfig:\n- mac_address: \"00:11:22:33:44:55\"\n  name: cni0\n  subnets:\n  - address: 1.1.1.1/8\n    dns_nameservers:\n    - 1.2.3.4\n    dns_search:\n    - some\n    - search\n    gateway: 1.2.3.4\n    type: static\n  type: physical\n",
+		"user-data":      "#cloud-config\n",
 	}) {
 		t.Errorf("Bad iso content:\n%s", spew.Sdump(m))
 	}

--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -964,5 +964,6 @@ func (v *VirtualizationTool) ContainerStatus(containerId string) (*kubeapi.Conta
 func (v *VirtualizationTool) StoragePool() virt.VirtStoragePool           { return v.volumePool }
 func (v *VirtualizationTool) DomainConnection() virt.VirtDomainConnection { return v.domainConn }
 func (v *VirtualizationTool) ImageManager() ImageManager                  { return v.imageManager }
+func (v *VirtualizationTool) MetadataStore() metadata.MetadataStore       { return v.metadataStore }
 func (v *VirtualizationTool) RawDevices() []string                        { return v.rawDevices }
 func (v *VirtualizationTool) KubeletRootDir() string                      { return v.kubeletRootDir }

--- a/pkg/libvirttools/volumes.go
+++ b/pkg/libvirttools/volumes.go
@@ -19,6 +19,7 @@ package libvirttools
 import (
 	libvirtxml "github.com/libvirt/libvirt-go-xml"
 
+	"github.com/Mirantis/virtlet/pkg/metadata"
 	"github.com/Mirantis/virtlet/pkg/virt"
 )
 
@@ -34,6 +35,7 @@ type VolumeOwner interface {
 	StoragePool() virt.VirtStoragePool
 	DomainConnection() virt.VirtDomainConnection
 	ImageManager() ImageManager
+	MetadataStore() metadata.MetadataStore
 	RawDevices() []string
 	KubeletRootDir() string
 }

--- a/tests/integration/nocloud_test.go
+++ b/tests/integration/nocloud_test.go
@@ -27,8 +27,9 @@ import (
 )
 
 const (
-	noCloudMetaData = "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\"}"
-	noCloudUserData = "#cloud-config\n"
+	noCloudMetaData      = "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\"}"
+	noCloudUserData      = "#cloud-config\n"
+	noCloudNetworkConfig = "version: 1\n"
 )
 
 func TestCloudInitNoCloud(t *testing.T) {
@@ -51,8 +52,9 @@ func TestCloudInitNoCloud(t *testing.T) {
 		t.Fatalf("isoToMap() on %q: %v", isoPath, err)
 	}
 	expectedFiles := map[string]interface{}{
-		"meta-data": noCloudMetaData,
-		"user-data": noCloudUserData,
+		"meta-data":      noCloudMetaData,
+		"network-config": noCloudNetworkConfig,
+		"user-data":      noCloudUserData,
 	}
 	if !reflect.DeepEqual(files, expectedFiles) {
 		t.Errorf("bad nocloud metadata iso:\n%s\n-- instead of --\n%s", utils.MapToJson(files), utils.MapToJson(expectedFiles))


### PR DESCRIPTION
Network configuration prepared according to http://cloudinit.readthedocs.io/en/latest/topics/network-config-format-v1.html#network-config-v1
Can not be verified by cirros image (it simply do not uses nocloud network configuration).
Works best with CNI plugins which returns new type or [Result](https://github.com/containernetworking/cni/blob/master/SPEC.md#parameters) which contains list of interfaces (with their mac addresses).
Should work well with plugins returning multiple network addresses, even if we don't support yet that from interfaces passing level (vmwrapper passes only single interface) so it's ready for future.
Needs more testing in any way, manual, unittests, but probably using our own cirros image/ubuntu image.

TODO:
- [x] update tests
- [x] fix "legacy" interface

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/412)
<!-- Reviewable:end -->
