### PR TITLE
Add git to the CircleCI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,14 +7,14 @@ jobs:
     environment:
       DOCKER_VERSION: "17.03.0-ce"
     steps:
-    - checkout
-    - setup_remote_docker
-
     - run:
         name: Ensure prerequisites
         command: |
           apt-get -qq update
-          apt-get install -y libxml2-utils jq curl ca-certificates openssh-client rsync socat wget
+          apt-get install -y libxml2-utils jq curl ca-certificates openssh-client rsync socat wget git
+
+    - checkout
+    - setup_remote_docker
 
     - run:
         name: Install Docker client


### PR DESCRIPTION
The image used in CircleCI doesn't have the `git` installed.
It displayed a warning:
```
Warning: Either git or ssh (required by git to clone through SSH) is not
installed in the image. Falling back to CircleCI's native git client but
this is still an experimental feature. We highly recommend using an
image that has official git and ssh installed.
```

It turned out that CircleCI's native git client doesn't support PRs from
fork repos. This commit does exactly what CircleCI recommends to do -
installs git before the sources checkout

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/416)
<!-- Reviewable:end -->
