### PR TITLE
Retake network namespaces and restart dhcp servers after virtlet restart.

### DIFF
--- a/pkg/libvirttools/recovernetns.go
+++ b/pkg/libvirttools/recovernetns.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2017 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package libvirttools
+
+import (
+	"fmt"
+
+	"github.com/Mirantis/virtlet/pkg/cni"
+	"github.com/Mirantis/virtlet/pkg/tapmanager"
+)
+
+// RecoverNetworkNamespaces scans metadata store for all defined sandboxes
+// and tries to recreate their network configuration (with dhcp server in it)
+func (v *VirtualizationTool) RecoverNetworkNamespaces(fdManager tapmanager.FDManager) (allErrors []error) {
+	sandboxes, err := v.metadataStore.ListPodSandboxes(nil)
+	if err != nil {
+		allErrors = append(allErrors, err)
+		return
+	}
+
+	for _, s := range sandboxes {
+		psi, err := s.Retrieve()
+		if err != nil {
+			allErrors = append(allErrors, fmt.Errorf("can not retrieve PodSandboxInfo for sandbox id %q: %v", s.GetID(), err))
+			continue
+		}
+
+		cniConfig, err := cni.BytesToResult([]byte(psi.CNIConfig))
+		if err != nil {
+			allErrors = append(allErrors, fmt.Errorf("incorrect cni configuration in sandbox %q: %v", s.GetID(), err))
+			continue
+		}
+
+		if _, err := fdManager.AddFD(
+			s.GetID(),
+			tapmanager.GetFDPayload{
+				CNIConfig: cniConfig,
+				Description: &tapmanager.PodNetworkDesc{
+					PodId:   s.GetID(),
+					PodNs:   psi.Metadata.GetNamespace(),
+					PodName: psi.Metadata.GetName(),
+				},
+			},
+		); err != nil {
+			allErrors = append(allErrors, fmt.Errorf("error regaining netns for %q pod: %v", s.GetID(), err))
+		}
+	}
+	return
+}

--- a/pkg/libvirttools/recovernetns.go
+++ b/pkg/libvirttools/recovernetns.go
@@ -23,8 +23,9 @@ import (
 	"github.com/Mirantis/virtlet/pkg/tapmanager"
 )
 
-// RecoverNetworkNamespaces scans metadata store for all defined sandboxes
-// and tries to recreate their network configuration (with dhcp server in it)
+// RecoverNetworkNamespaces recovers all the active VM network namespaces
+// from previous Virtlet run by scanning the metadata store and starting
+// dhcp server for each namespace that's still active
 func (v *VirtualizationTool) RecoverNetworkNamespaces(fdManager tapmanager.FDManager) (allErrors []error) {
 	sandboxes, err := v.metadataStore.ListPodSandboxes(nil)
 	if err != nil {
@@ -41,7 +42,7 @@ func (v *VirtualizationTool) RecoverNetworkNamespaces(fdManager tapmanager.FDMan
 
 		cniConfig, err := cni.BytesToResult([]byte(psi.CNIConfig))
 		if err != nil {
-			allErrors = append(allErrors, fmt.Errorf("incorrect cni configuration in sandbox %q: %v", s.GetID(), err))
+			allErrors = append(allErrors, fmt.Errorf("sanbox %q has incorrect cni configuration: %v", s.GetID(), err))
 			continue
 		}
 
@@ -56,7 +57,7 @@ func (v *VirtualizationTool) RecoverNetworkNamespaces(fdManager tapmanager.FDMan
 				},
 			},
 		); err != nil {
-			allErrors = append(allErrors, fmt.Errorf("error regaining netns for %q pod: %v", s.GetID(), err))
+			allErrors = append(allErrors, fmt.Errorf("error recovering netns for %q pod: %v", s.GetID(), err))
 		}
 	}
 	return

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -99,14 +99,14 @@ func NewVirtletManager(libvirtUri, poolName, downloadProtocol, storageBackend, m
 	}
 
 	if errors := libvirtVirtualizationTool.RecoverNetworkNamespaces(fdManager); errors != nil {
-		glog.Warning("During regaining network namespaces encountered above errors:")
+		glog.Warning("The following errors were encountered while recovering the VM network namespaces:")
 		for _, err := range errors {
 			glog.Warningf("* %q", err)
 		}
 	}
 
 	if errors := libvirtVirtualizationTool.GarbageCollect(); errors != nil {
-		glog.Warning("During garbage collecting encountered above errors:")
+		glog.Warning("The following errors were encountered while garbage collection process:")
 		for _, err := range errors {
 			glog.Warningf("* %q", err)
 		}

--- a/pkg/nettools/nettools.go
+++ b/pkg/nettools/nettools.go
@@ -567,8 +567,8 @@ func SetupContainerSideNetwork(info *cnicurrent.Result) (*ContainerSideNetwork, 
 	return &ContainerSideNetwork{info, tapFile, hwAddr}, nil
 }
 
-// RecreateContainerSideNetwork tries to recreate
-// ContainerSideNetwork structure for already configured environment
+// RecreateContainerSideNetwork tries to populate ContainerSideNetwork
+// structure based on a network namespace that was already adjusted for Virtlet
 func RecreateContainerSideNetwork(info *cnicurrent.Result) (*ContainerSideNetwork, error) {
 	if len(info.Interfaces) == 0 {
 		return nil, fmt.Errorf("wrong cni configuration - missing interfaces list: %v", spew.Sdump(info))

--- a/pkg/tapmanager/tapfdsource.go
+++ b/pkg/tapmanager/tapfdsource.go
@@ -46,8 +46,8 @@ type PodNetworkDesc struct {
 }
 
 // GetFDPayload contains the data that are required by TapFDSource
-// to regain already configured tap device, or create new one if CNIConfig
-// is nil
+// to recover the tap device that was already configured, or create a new one
+// if CNIConfig is nil
 type GetFDPayload struct {
 	// Description specifies pod network description for already
 	// prepared network configuration
@@ -95,9 +95,9 @@ func (s *TapFDSource) GetFD(key string, data []byte) (int, []byte, error) {
 	}
 	pnd := payload.Description
 
-	regain := payload.CNIConfig != nil
+	recover := payload.CNIConfig != nil
 
-	if !regain {
+	if !recover {
 		if err := cni.CreateNetNS(pnd.PodId); err != nil {
 			return 0, nil, fmt.Errorf("error creating new netns for pod %s (%s): %v", pnd.PodName, pnd.PodId, err)
 		}
@@ -129,27 +129,24 @@ func (s *TapFDSource) GetFD(key string, data []byte) (int, []byte, error) {
 	doneCh := make(chan error)
 	if err := vmNS.Do(func(ns.NetNS) error {
 		var err error
-		if regain {
-			csn, err = nettools.RecreateContainerSideNetwork(payload.CNIConfig)
+		if recover {
+			csn, err = nettools.RecreateContainerSideNetwork(netConfig)
 		} else {
 			csn, err = nettools.SetupContainerSideNetwork(netConfig)
 		}
 		if err != nil {
 			return err
 		}
-		if regain {
-			// NOTE: we have info about interface hardware address, which
-			// is needed by Cloud Init support, but old cni plugins do not
-			// return it in `Result` - so we can fix it.
-			if len(netConfig.Interfaces) == 0 {
-				fixNetConfigForOldCNIPlugins(netConfig, csn)
-			}
-		}
+
+		// NOTE: older CNI plugins don't include the hardware address
+		// in Result, but it's needed for Cloud-Init based
+		// network setup, so we add it here if it's missing
+		ensureCNIInterfaceHwAddress(netConfig, csn)
 
 		// TODO: now CNIConfig should always contain interface mac address, so there
 		// is no reason to pass it as separate field in dhcp.Config,
 		// dhcp.NewServer should need only CNIConfig, instead of dhcp.Config
-		// TODO: make dhcp server working for all defined in CNIConfig interfaces
+		// TODO: set up DHCP server for all the interfaces defined in CNIConfig
 		dhcpConfg := &dhcp.Config{
 			CNIResult:           *csn.Result,
 			PeerHardwareAddress: csn.HardwareAddr,
@@ -238,9 +235,13 @@ func (s *TapFDSource) GetInfo(key string) ([]byte, error) {
 	return pn.csn.HardwareAddr, nil
 }
 
-func fixNetConfigForOldCNIPlugins(netConfig *cnicurrent.Result, csn *nettools.ContainerSideNetwork) {
-	// If there is no info about interfaces, we can assume that this is
-	// old style cni plugin, which support just one interface
+func ensureCNIInterfaceHwAddress(netConfig *cnicurrent.Result, csn *nettools.ContainerSideNetwork) {
+	// If there's no interface info in netConfig, we can assume that we're dealing
+	// with an old-style CNI plugin which only supports a single network interface
+	if len(netConfig.Interfaces) > 0 {
+		return
+	}
+
 	iface := &cnicurrent.Interface{
 		Name: "cni0",
 		Mac:  csn.HardwareAddr.String(),

--- a/pkg/tapmanager/tapfdsource.go
+++ b/pkg/tapmanager/tapfdsource.go
@@ -45,6 +45,18 @@ type PodNetworkDesc struct {
 	DNS *cnitypes.DNS
 }
 
+// GetFDPayload contains the data that are required by TapFDSource
+// to regain already configured tap device, or create new one if CNIConfig
+// is nil
+type GetFDPayload struct {
+	// Description specifies pod network description for already
+	// prepared network configuration
+	Description *PodNetworkDesc `json:"podNetworkDesc"`
+	// CNIConfig specifies CNI configuration used to configure retaken
+	// environment
+	CNIConfig *cnicurrent.Result `json:"cniConfig"`
+}
+
 type podNetwork struct {
 	pnd        PodNetworkDesc
 	csn        *nettools.ContainerSideNetwork
@@ -77,29 +89,36 @@ func NewTapFDSource(cniPluginsDir, cniConfigsDir string) (*TapFDSource, error) {
 
 // GetFD implements GetFD method of FDSource interface
 func (s *TapFDSource) GetFD(key string, data []byte) (int, []byte, error) {
-	var pnd PodNetworkDesc
-	if err := json.Unmarshal(data, &pnd); err != nil {
-		return 0, nil, fmt.Errorf("error unmarshalling pod network desc: %v", err)
+	var payload GetFDPayload
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return 0, nil, fmt.Errorf("error unmarshalling GetFD payload: %v", err)
+	}
+	pnd := payload.Description
+
+	regain := payload.CNIConfig != nil
+
+	if !regain {
+		if err := cni.CreateNetNS(pnd.PodId); err != nil {
+			return 0, nil, fmt.Errorf("error creating new netns for pod %s (%s): %v", pnd.PodName, pnd.PodId, err)
+		}
+
+		netConfig, err := s.cniClient.AddSandboxToNetwork(pnd.PodId, pnd.PodName, pnd.PodNs)
+		if err != nil {
+			return 0, nil, fmt.Errorf("error adding pod %s (%s) to CNI network: %v", pnd.PodName, pnd.PodId, err)
+		}
+		glog.V(3).Infof("CNI configuration for pod %s (%s): %s", pnd.PodName, pnd.PodId, spew.Sdump(netConfig))
+
+		if payload.Description.DNS != nil {
+			netConfig.DNS.Nameservers = pnd.DNS.Nameservers
+			netConfig.DNS.Search = pnd.DNS.Search
+			netConfig.DNS.Options = pnd.DNS.Options
+		}
+		payload.CNIConfig = netConfig
 	}
 
-	if err := cni.CreateNetNS(pnd.PodId); err != nil {
-		return 0, nil, fmt.Errorf("error creating new netns for pod %s (%s): %v", pnd.PodName, pnd.PodId, err)
-	}
-
-	netConfig, err := s.cniClient.AddSandboxToNetwork(pnd.PodId, pnd.PodName, pnd.PodNs)
-	if err != nil {
-		return 0, nil, fmt.Errorf("error adding pod %s (%s) to CNI network: %v", pnd.PodName, pnd.PodId, err)
-	}
-	glog.V(3).Infof("CNI configuration for pod %s (%s): %s", pnd.PodName, pnd.PodId, spew.Sdump(netConfig))
-
-	if pnd.DNS != nil {
-		netConfig.DNS.Nameservers = pnd.DNS.Nameservers
-		netConfig.DNS.Search = pnd.DNS.Search
-		netConfig.DNS.Options = pnd.DNS.Options
-	}
+	netConfig := payload.CNIConfig
 
 	netNSPath := cni.PodNetNSPath(pnd.PodId)
-
 	vmNS, err := ns.GetNS(netNSPath)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed to open network namespace at %q: %v", netNSPath, err)
@@ -110,16 +129,27 @@ func (s *TapFDSource) GetFD(key string, data []byte) (int, []byte, error) {
 	doneCh := make(chan error)
 	if err := vmNS.Do(func(ns.NetNS) error {
 		var err error
-		csn, err = nettools.SetupContainerSideNetwork(netConfig)
+		if regain {
+			csn, err = nettools.RecreateContainerSideNetwork(payload.CNIConfig)
+		} else {
+			csn, err = nettools.SetupContainerSideNetwork(netConfig)
+		}
 		if err != nil {
 			return err
 		}
-		// NOTE: we have info about interface hardware address, which
-		// is needed by Cloud Init support, but old cni plugins do not
-		// return it in `Result` - so we can fix it.
-		if len(netConfig.Interfaces) == 0 {
-			fixNetConfigForOldCNIPlugins(netConfig, csn)
+		if regain {
+			// NOTE: we have info about interface hardware address, which
+			// is needed by Cloud Init support, but old cni plugins do not
+			// return it in `Result` - so we can fix it.
+			if len(netConfig.Interfaces) == 0 {
+				fixNetConfigForOldCNIPlugins(netConfig, csn)
+			}
 		}
+
+		// TODO: now CNIConfig should always contain interface mac address, so there
+		// is no reason to pass it as separate field in dhcp.Config,
+		// dhcp.NewServer should need only CNIConfig, instead of dhcp.Config
+		// TODO: make dhcp server working for all defined in CNIConfig interfaces
 		dhcpConfg := &dhcp.Config{
 			CNIResult:           *csn.Result,
 			PeerHardwareAddress: csn.HardwareAddr,
@@ -152,7 +182,7 @@ func (s *TapFDSource) GetFD(key string, data []byte) (int, []byte, error) {
 	}
 
 	s.fdMap[key] = &podNetwork{
-		pnd:        pnd,
+		pnd:        *pnd,
 		csn:        csn,
 		dhcpServer: dhcpServer,
 		doneCh:     doneCh,


### PR DESCRIPTION
Fix for netConfig is borrowed from #412.
TODO:
- [x] func on tapmanager allowing to restart dhcp/retake configured env for running vm or for it's cleanup
- [x] ~~invocation of above func at the start of new virtualization tool for sandboxes found during gc~~
- [x] ~~call networking teardown during gc for sandboxes not found in metadata store~~
- [x] invocation of above func at the start of virtlet manager for sanboxes found in metadata store

We don't have a method to gather all required information from sandbox which can not be found in metadata store, simply because they are only saved to metadata store, in pod sandbox description. Because of that we cannot cleanup pod sandboxes for sandboxes found by looking to filesystem - what should be not a big issue - because such situation (remains of sandbox with configured ns, but not stored in metadata store) seems to be extremely unusual and will be fixed by simple host node restart. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/419)
<!-- Reviewable:end -->
