### PR TITLE
Fix path to image_skel/ in Dockerfil.virtlet

### DIFF
--- a/images/Dockerfile.virtlet
+++ b/images/Dockerfile.virtlet
@@ -6,7 +6,7 @@ MAINTAINER Ivan Shvedunov <ishvedunov@mirantis.com>
 
 LABEL virtlet.image="virtlet"
 
-COPY image_skel /.
+COPY images/image_skel /.
 COPY _output/flexvolume_driver /
 # Integration tests look for virtlet in $PATH
 # and we want it to be located in the same place both


### PR DESCRIPTION
The Dockerfile was recently moved to images/Dockerfile.virtlet, but some paths were not updated accordingly. With this commit we fix them in order to be able to build mirantis/virtlet container from project root using following command:

```
$ docker build -t mirantis/virtlet -f ./images/Dockerfile.virtlet .
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/425)
<!-- Reviewable:end -->
