### PR TITLE
Disable VNC

### DIFF
--- a/pkg/libvirttools/TestContainerLifecycle.json
+++ b/pkg/libvirttools/TestContainerLifecycle.json
@@ -355,33 +355,7 @@
             "Address": null
           }
         ],
-        "Graphics": [
-          {
-            "XMLName": {
-              "Space": "",
-              "Local": ""
-            },
-            "Type": "vnc",
-            "AutoPort": "",
-            "Port": -1,
-            "TLSPort": 0,
-            "WebSocket": 0,
-            "Listen": "",
-            "Socket": "",
-            "Keymap": "",
-            "Passwd": "",
-            "PasswdValidTo": "",
-            "Connected": "",
-            "SharePolicy": "",
-            "DefaultMode": "",
-            "Display": "",
-            "XAuth": "",
-            "FullScreen": "",
-            "ReplaceUser": "",
-            "MultiUser": "",
-            "Listeners": null
-          }
-        ],
+        "Graphics": null,
         "Videos": [
           {
             "XMLName": {

--- a/pkg/libvirttools/TestDomainDefinitions__ceph_flexvolume.json
+++ b/pkg/libvirttools/TestDomainDefinitions__ceph_flexvolume.json
@@ -437,33 +437,7 @@
             "Address": null
           }
         ],
-        "Graphics": [
-          {
-            "XMLName": {
-              "Space": "",
-              "Local": ""
-            },
-            "Type": "vnc",
-            "AutoPort": "",
-            "Port": -1,
-            "TLSPort": 0,
-            "WebSocket": 0,
-            "Listen": "",
-            "Socket": "",
-            "Keymap": "",
-            "Passwd": "",
-            "PasswdValidTo": "",
-            "Connected": "",
-            "SharePolicy": "",
-            "DefaultMode": "",
-            "Display": "",
-            "XAuth": "",
-            "FullScreen": "",
-            "ReplaceUser": "",
-            "MultiUser": "",
-            "Listeners": null
-          }
-        ],
+        "Graphics": null,
         "Videos": [
           {
             "XMLName": {

--- a/pkg/libvirttools/TestDomainDefinitions__cloud-init.json
+++ b/pkg/libvirttools/TestDomainDefinitions__cloud-init.json
@@ -351,33 +351,7 @@
             "Address": null
           }
         ],
-        "Graphics": [
-          {
-            "XMLName": {
-              "Space": "",
-              "Local": ""
-            },
-            "Type": "vnc",
-            "AutoPort": "",
-            "Port": -1,
-            "TLSPort": 0,
-            "WebSocket": 0,
-            "Listen": "",
-            "Socket": "",
-            "Keymap": "",
-            "Passwd": "",
-            "PasswdValidTo": "",
-            "Connected": "",
-            "SharePolicy": "",
-            "DefaultMode": "",
-            "Display": "",
-            "XAuth": "",
-            "FullScreen": "",
-            "ReplaceUser": "",
-            "MultiUser": "",
-            "Listeners": null
-          }
-        ],
+        "Graphics": null,
         "Videos": [
           {
             "XMLName": {

--- a/pkg/libvirttools/TestDomainDefinitions__cloud-init_with_user_data.json
+++ b/pkg/libvirttools/TestDomainDefinitions__cloud-init_with_user_data.json
@@ -351,33 +351,7 @@
             "Address": null
           }
         ],
-        "Graphics": [
-          {
-            "XMLName": {
-              "Space": "",
-              "Local": ""
-            },
-            "Type": "vnc",
-            "AutoPort": "",
-            "Port": -1,
-            "TLSPort": 0,
-            "WebSocket": 0,
-            "Listen": "",
-            "Socket": "",
-            "Keymap": "",
-            "Passwd": "",
-            "PasswdValidTo": "",
-            "Connected": "",
-            "SharePolicy": "",
-            "DefaultMode": "",
-            "Display": "",
-            "XAuth": "",
-            "FullScreen": "",
-            "ReplaceUser": "",
-            "MultiUser": "",
-            "Listeners": null
-          }
-        ],
+        "Graphics": null,
         "Videos": [
           {
             "XMLName": {

--- a/pkg/libvirttools/TestDomainDefinitions__plain_domain.json
+++ b/pkg/libvirttools/TestDomainDefinitions__plain_domain.json
@@ -351,33 +351,7 @@
             "Address": null
           }
         ],
-        "Graphics": [
-          {
-            "XMLName": {
-              "Space": "",
-              "Local": ""
-            },
-            "Type": "vnc",
-            "AutoPort": "",
-            "Port": -1,
-            "TLSPort": 0,
-            "WebSocket": 0,
-            "Listen": "",
-            "Socket": "",
-            "Keymap": "",
-            "Passwd": "",
-            "PasswdValidTo": "",
-            "Connected": "",
-            "SharePolicy": "",
-            "DefaultMode": "",
-            "Display": "",
-            "XAuth": "",
-            "FullScreen": "",
-            "ReplaceUser": "",
-            "MultiUser": "",
-            "Listeners": null
-          }
-        ],
+        "Graphics": null,
         "Videos": [
           {
             "XMLName": {

--- a/pkg/libvirttools/TestDomainDefinitions__raw_devices.json
+++ b/pkg/libvirttools/TestDomainDefinitions__raw_devices.json
@@ -400,33 +400,7 @@
             "Address": null
           }
         ],
-        "Graphics": [
-          {
-            "XMLName": {
-              "Space": "",
-              "Local": ""
-            },
-            "Type": "vnc",
-            "AutoPort": "",
-            "Port": -1,
-            "TLSPort": 0,
-            "WebSocket": 0,
-            "Listen": "",
-            "Socket": "",
-            "Keymap": "",
-            "Passwd": "",
-            "PasswdValidTo": "",
-            "Connected": "",
-            "SharePolicy": "",
-            "DefaultMode": "",
-            "Display": "",
-            "XAuth": "",
-            "FullScreen": "",
-            "ReplaceUser": "",
-            "MultiUser": "",
-            "Listeners": null
-          }
-        ],
+        "Graphics": null,
         "Videos": [
           {
             "XMLName": {

--- a/pkg/libvirttools/TestDomainDefinitions__vcpu_count.json
+++ b/pkg/libvirttools/TestDomainDefinitions__vcpu_count.json
@@ -351,33 +351,7 @@
             "Address": null
           }
         ],
-        "Graphics": [
-          {
-            "XMLName": {
-              "Space": "",
-              "Local": ""
-            },
-            "Type": "vnc",
-            "AutoPort": "",
-            "Port": -1,
-            "TLSPort": 0,
-            "WebSocket": 0,
-            "Listen": "",
-            "Socket": "",
-            "Keymap": "",
-            "Passwd": "",
-            "PasswdValidTo": "",
-            "Connected": "",
-            "SharePolicy": "",
-            "DefaultMode": "",
-            "Display": "",
-            "XAuth": "",
-            "FullScreen": "",
-            "ReplaceUser": "",
-            "MultiUser": "",
-            "Listeners": null
-          }
-        ],
+        "Graphics": null,
         "Videos": [
           {
             "XMLName": {

--- a/pkg/libvirttools/TestDomainDefinitions__virtio_disk_driver.json
+++ b/pkg/libvirttools/TestDomainDefinitions__virtio_disk_driver.json
@@ -351,33 +351,7 @@
             "Address": null
           }
         ],
-        "Graphics": [
-          {
-            "XMLName": {
-              "Space": "",
-              "Local": ""
-            },
-            "Type": "vnc",
-            "AutoPort": "",
-            "Port": -1,
-            "TLSPort": 0,
-            "WebSocket": 0,
-            "Listen": "",
-            "Socket": "",
-            "Keymap": "",
-            "Passwd": "",
-            "PasswdValidTo": "",
-            "Connected": "",
-            "SharePolicy": "",
-            "DefaultMode": "",
-            "Display": "",
-            "XAuth": "",
-            "FullScreen": "",
-            "ReplaceUser": "",
-            "MultiUser": "",
-            "Listeners": null
-          }
-        ],
+        "Graphics": null,
         "Videos": [
           {
             "XMLName": {

--- a/pkg/libvirttools/TestDomainDefinitions__volumes.json
+++ b/pkg/libvirttools/TestDomainDefinitions__volumes.json
@@ -609,33 +609,7 @@
             "Address": null
           }
         ],
-        "Graphics": [
-          {
-            "XMLName": {
-              "Space": "",
-              "Local": ""
-            },
-            "Type": "vnc",
-            "AutoPort": "",
-            "Port": -1,
-            "TLSPort": 0,
-            "WebSocket": 0,
-            "Listen": "",
-            "Socket": "",
-            "Keymap": "",
-            "Passwd": "",
-            "PasswdValidTo": "",
-            "Connected": "",
-            "SharePolicy": "",
-            "DefaultMode": "",
-            "Display": "",
-            "XAuth": "",
-            "FullScreen": "",
-            "ReplaceUser": "",
-            "MultiUser": "",
-            "Listeners": null
-          }
-        ],
+        "Graphics": null,
         "Videos": [
           {
             "XMLName": {

--- a/pkg/libvirttools/TestDomainForcedShutdown.json
+++ b/pkg/libvirttools/TestDomainForcedShutdown.json
@@ -351,33 +351,7 @@
             "Address": null
           }
         ],
-        "Graphics": [
-          {
-            "XMLName": {
-              "Space": "",
-              "Local": ""
-            },
-            "Type": "vnc",
-            "AutoPort": "",
-            "Port": -1,
-            "TLSPort": 0,
-            "WebSocket": 0,
-            "Listen": "",
-            "Socket": "",
-            "Keymap": "",
-            "Passwd": "",
-            "PasswdValidTo": "",
-            "Connected": "",
-            "SharePolicy": "",
-            "DefaultMode": "",
-            "Display": "",
-            "XAuth": "",
-            "FullScreen": "",
-            "ReplaceUser": "",
-            "MultiUser": "",
-            "Listeners": null
-          }
-        ],
+        "Graphics": null,
         "Videos": [
           {
             "XMLName": {

--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -86,9 +86,10 @@ func (ds *domainSettings) createDomain() *libvirtxml.Domain {
 			Inputs: []libvirtxml.DomainInput{
 				{Type: "tablet", Bus: "usb"},
 			},
-			Graphics: []libvirtxml.DomainGraphic{
-				{Type: "vnc", Port: -1},
-			},
+			// Disabling vnc console because of libvirt failure
+			// Graphics: []libvirtxml.DomainGraphic{
+			// 	{Type: "vnc", Port: -1},
+			// },
 			Videos: []libvirtxml.DomainVideo{
 				{Model: libvirtxml.DomainVideoModel{Type: "cirrus"}},
 			},

--- a/tests/e2e/basic_test.go
+++ b/tests/e2e/basic_test.go
@@ -155,18 +155,19 @@ var _ = Describe("Basic cirros tests", func() {
 		})
 	})
 
-	It("Should provide VNC interface", func(done Done) {
-		defer close(done)
-		pod, err := vm.VirtletPod()
-		Expect(err).NotTo(HaveOccurred())
+	// Disabling vnc because of libvirt failure
+	// It("Should provide VNC interface", func(done Done) {
+	// 	defer close(done)
+	// 	pod, err := vm.VirtletPod()
+	// 	Expect(err).NotTo(HaveOccurred())
 
-		virtletPodExecutor, err := pod.Container("virtlet")
-		Expect(err).NotTo(HaveOccurred())
+	// 	virtletPodExecutor, err := pod.Container("virtlet")
+	// 	Expect(err).NotTo(HaveOccurred())
 
-		display, err := vm.VirshCommand("vncdisplay", "<domain>")
-		Expect(err).NotTo(HaveOccurred())
+	// 	display, err := vm.VirshCommand("vncdisplay", "<domain>")
+	// 	Expect(err).NotTo(HaveOccurred())
 
-		By(fmt.Sprintf("Taking VNC display snapshot from %s", display))
-		do(framework.ExecSimple(virtletPodExecutor, "vncsnapshot", "-allowblank", display, "/vm.jpg"))
-	}, 60)
+	// 	By(fmt.Sprintf("Taking VNC display snapshot from %s", display))
+	// 	do(framework.ExecSimple(virtletPodExecutor, "vncsnapshot", "-allowblank", display, "/vm.jpg"))
+	// }, 60)
 })


### PR DESCRIPTION
... because of causing sig-segv inside of libvirt.

Libvirt fails on vnc/spice port allocation what leads to failure in starting VMs and even libvirt crash.
Upstream libvirt bug: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863266

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/432)
<!-- Reviewable:end -->
