### PR TITLE
Fix restarting e2e/integration jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,18 @@ restore_images_and_vendor: &restore_images_and_vendor
       docker exec -i virtlet-build tar -C /go/src/github.com/Mirantis/virtlet -xv <_output/vendor.tar
     fi
 
+extract_binaries_from_the_image: &extract_binaries_from_the_image
+  name: Extract binaries from the image (in non-workflow case)
+  command: |
+    if [[ -f _output/vmwrapper ]]; then
+      exit 0
+    fi
+    tag="$(echo "${CIRCLE_TAG:-${CIRCLE_BRANCH}}"|tr / _)"
+    image="mirantis/virtlet:${tag}"
+    echo "Extracting binaries from ${image}"
+    mkdir -p _output/
+    docker run "${image}" tar -C / -c vmwrapper virtlet-e2e-tests | tar -C _output/ -xv
+
 push_images: &push_images
   <<: *defaults
   steps:
@@ -125,9 +137,13 @@ e2e: &e2e
   - attach_workspace:
       at: _output
   - run:
+      <<: *extract_binaries_from_the_image
+  - run:
       name: Restore virtlet image
       command: |
-        docker load -i _output/virtlet.tar
+        if [[ -f _output/virtlet.tar ]]; then
+          docker load -i _output/virtlet.tar
+        fi
   - run:
       name: Start the demo
       command: |
@@ -271,6 +287,8 @@ jobs:
         <<: *restore_images_and_vendor
     - attach_workspace:
         at: _output
+    - run:
+        <<: *extract_binaries_from_the_image
     - run:
         name: Run tests
         command: |


### PR DESCRIPTION
Make CircleCI job reuse the previously pushed image for branch/tag if it can't attach workspace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/448)
<!-- Reviewable:end -->
