### PR TITLE
Fix incorrect CRI connection error handling

### DIFF
--- a/pkg/criproxy/proxy.go
+++ b/pkg/criproxy/proxy.go
@@ -126,7 +126,10 @@ func (c *apiClient) connectNonLocked() chan error {
 			return err
 		}); err != nil {
 			glog.Errorf("Failed to find the socket: %v", err)
-			errCh <- fmt.Errorf("failed to find the socket: %v", err)
+			err = fmt.Errorf("failed to find the socket: %v", err)
+			for _, ch := range c.connectErrChs {
+				ch <- err
+			}
 			return
 		}
 
@@ -137,7 +140,9 @@ func (c *apiClient) connectNonLocked() chan error {
 		c.ImageServiceClient = runtimeapi.NewImageServiceClient(c.conn)
 		c.state = clientStateConnected
 
-		errCh <- nil
+		for _, ch := range c.connectErrChs {
+			ch <- nil
+		}
 	}()
 	return errCh
 }


### PR DESCRIPTION
Sometimes initial `Version()` requests were hanging, making kubelet freeze.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/462)
<!-- Reviewable:end -->
