### PR TITLE
Fixes a bug that prevented virtlet to download images from github

### DIFF
--- a/pkg/libvirttools/image.go
+++ b/pkg/libvirttools/image.go
@@ -85,7 +85,7 @@ func (i *ImageTool) PullRemoteImageToVolume(imageName, volumeName string, nameTr
 	imageName = stripTagFromImageName(imageName)
 	endpoint := nameTranslator.Translate(imageName)
 	if endpoint.Url == "" {
-		endpoint = utils.Endpoint{Url: imageName}
+		endpoint = utils.Endpoint{Url: imageName, MaxRedirects: -1}
 		glog.V(1).Infof("Using URL %q without translation", imageName)
 	} else {
 		glog.V(1).Infof("URL %q was translated to %q", imageName, endpoint.Url)


### PR DESCRIPTION
Due to a bug, HTTP redirects were disabled for default imange name scheme
(i.e. without image name translation).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/463)
<!-- Reviewable:end -->
