### PR TITLE
 Use real file mode for cloud-init mounted Secrets/CMs

### DIFF
--- a/deploy/virtlet-ds.yaml
+++ b/deploy/virtlet-ds.yaml
@@ -312,6 +312,19 @@ rules:
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: virtlet-userdata-reader
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: kubelet-node-binding
@@ -323,6 +336,19 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: system:nodes
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: vm-userdata-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: virtlet-userdata-reader
+subjects:
+- kind: ServiceAccount
+  name: virtlet
+  namespace: kube-system
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/pkg/criproxy/bootstrap.go
+++ b/pkg/criproxy/bootstrap.go
@@ -42,7 +42,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api/v1"
-	"k8s.io/client-go/rest"
+
+	"github.com/Mirantis/virtlet/pkg/utils"
 )
 
 const (
@@ -277,17 +278,11 @@ func (b *Bootstrap) installCriProxyContainer(dockerEndpoint, endpointToPass stri
 }
 
 func (b *Bootstrap) initClientset() error {
-	var err error
-	var config *rest.Config
-	if b.config.ApiServerHost == "" {
-		config, err = rest.InClusterConfig()
-		if err != nil {
-			return fmt.Errorf("failed to get REST client config: %v", err)
-		}
-	} else {
-		config = &rest.Config{Host: b.config.ApiServerHost}
+	config, err := utils.GetK8sClientConfig(b.config.ApiServerHost)
+	if err != nil {
+		return fmt.Errorf("failed to get REST client config: %v", err)
 	}
-	b.clientset, err = kubernetes.NewForConfig(config)
+	b.clientset, err = utils.GetK8sClientset(config)
 	if err != nil {
 		return fmt.Errorf("failed to create ClientSet: %v", err)
 	}

--- a/pkg/libvirttools/annotations_test.go
+++ b/pkg/libvirttools/annotations_test.go
@@ -140,7 +140,7 @@ func TestVirtletAnnotations(t *testing.T) {
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			va, err := LoadAnnotations(testCase.annotations)
+			va, err := LoadAnnotations("", testCase.annotations)
 			switch {
 			case testCase.va == nil && err == nil:
 				t.Errorf("invalid annotations considered valid:\n%#v", testCase.annotations)

--- a/pkg/libvirttools/cloudinit_test.go
+++ b/pkg/libvirttools/cloudinit_test.go
@@ -408,22 +408,23 @@ func TestEnvDataGeneration(t *testing.T) {
 func TestAddingSecrets(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "")
 	if err != nil {
-		t.Fatal("Can't create temp dir: %v", err)
+		t.Fatalf("Can't create temp dir: %v", err)
 	}
 	defer os.RemoveAll(tmpDir)
 
 	location := filepath.Join(tmpDir, "volumes/kubernetes.io~secret/test-volume")
 	if err := os.MkdirAll(location, 0755); err != nil {
-		t.Fatal("Can't create secrets directory in temp dir: %v", err)
+		t.Fatalf("Can't create secrets directory in temp dir: %v", err)
 	}
 
 	f, err := os.Create(filepath.Join(location, "file"))
 	if err != nil {
-		t.Fatal("Can't create sample file in temp directory: %v", err)
+		t.Fatalf("Can't create sample file in temp directory: %v", err)
 	}
+	f.Chmod(0640)
 	defer f.Close()
 	if _, err := f.WriteString("test content"); err != nil {
-		t.Fatal("Error during write to test file: %v", err)
+		t.Fatalf("Error during write to test file: %v", err)
 	}
 
 	userData := make(map[string]interface{})
@@ -439,7 +440,7 @@ func TestAddingSecrets(t *testing.T) {
 				"path":        "/container/file",
 				"content":     "dGVzdCBjb250ZW50",
 				"encoding":    "b64",
-				"permissions": "0600",
+				"permissions": "0640",
 			},
 		},
 	}

--- a/pkg/libvirttools/virtualization_test.go
+++ b/pkg/libvirttools/virtualization_test.go
@@ -31,12 +31,12 @@ import (
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 
 	"github.com/Mirantis/virtlet/pkg/flexvolume"
+	"github.com/Mirantis/virtlet/pkg/imagetranslation"
 	"github.com/Mirantis/virtlet/pkg/metadata"
 	"github.com/Mirantis/virtlet/pkg/utils"
 	"github.com/Mirantis/virtlet/pkg/virt/fake"
 	"github.com/Mirantis/virtlet/tests/criapi"
 	"github.com/Mirantis/virtlet/tests/gm"
-	"github.com/Mirantis/virtlet/pkg/imagetranslation"
 )
 
 const (

--- a/pkg/libvirttools/vmconfig.go
+++ b/pkg/libvirttools/vmconfig.go
@@ -73,7 +73,7 @@ type VMConfig struct {
 // LoadAnnotations parses pod annotations in the VM config an
 // populates the ParsedAnnotations field.
 func (c *VMConfig) LoadAnnotations() error {
-	ann, err := LoadAnnotations(c.PodAnnotations)
+	ann, err := LoadAnnotations(c.PodNamespace, c.PodAnnotations)
 	if err != nil {
 		return err
 	}

--- a/pkg/utils/k8s_client.go
+++ b/pkg/utils/k8s_client.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2017 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"os"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// GetK8sClientConfig returns config that is needed to access k8s
+func GetK8sClientConfig(host string) (*rest.Config, error) {
+	if host == "" {
+		url, exists := os.LookupEnv("KUBERNETES_CLUSTER_URL")
+		if !exists {
+			return rest.InClusterConfig()
+		}
+		host = url
+	}
+	return &rest.Config{Host: host}, nil
+}
+
+// GetK8sClientset returns clientset for standard k8s APIs
+func GetK8sClientset(config *rest.Config) (*kubernetes.Clientset, error) {
+	if config == nil {
+		var err error
+		config, err = GetK8sClientConfig("")
+		if err != nil {
+			return nil, err
+		}
+	}
+	return kubernetes.NewForConfig(config)
+}
+
+// GetK8sRestClient returns k8s ReST client that for the giver API group-version/subset
+func GetK8sRestClient(cfg *rest.Config, scheme *runtime.Scheme, groupVersion *schema.GroupVersion) (*rest.RESTClient, error) {
+	config := *cfg
+	config.GroupVersion = groupVersion
+	config.APIPath = "/apis"
+	config.ContentType = runtime.ContentTypeJSON
+	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: serializer.NewCodecFactory(scheme)}
+
+	client, err := rest.RESTClientFor(&config)
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}

--- a/pkg/utils/merge.go
+++ b/pkg/utils/merge.go
@@ -1,0 +1,115 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+The code to recursively merge JSON-like data structures (maps, slices, values)
+Based on go-merge library (https://github.com/divideandconquer/go-merge) with some major changes
+*/
+
+package utils
+
+import (
+	"reflect"
+)
+
+// Merge will take two data sets and merge them together - returning a new data set
+func Merge(base, override interface{}) interface{} {
+	//reflect and recurse
+	b := reflect.ValueOf(base)
+	o := reflect.ValueOf(override)
+	ret := mergeRecursive(b, o)
+	if !ret.IsValid() {
+		return nil
+	}
+
+	return ret.Interface()
+}
+
+func mergeRecursive(base, override reflect.Value) reflect.Value {
+	if !override.IsValid() || !base.IsValid() || base.Type() != override.Type() {
+		return override
+	}
+	var result reflect.Value
+
+	switch base.Kind() {
+	case reflect.Ptr:
+		switch base.Elem().Kind() {
+		case reflect.Ptr:
+			fallthrough
+		case reflect.Slice:
+			fallthrough
+		case reflect.Map:
+			// Pointers to complex types should recurse if they aren't nil
+			if base.IsNil() {
+				result = override
+			} else if override.IsNil() {
+				result = base
+			} else {
+				result = mergeRecursive(base.Elem(), override.Elem())
+
+			}
+		default:
+			// Pointers to basic types should just override
+			result = override
+		}
+
+	case reflect.Interface:
+		// Interfaces should just be unwrapped and recursed through
+		result = mergeRecursive(base.Elem(), override.Elem())
+
+	case reflect.Map:
+
+		// For Maps we copy the base data, and then replace it with merged data
+		// We use two for loops to make sure all map keys from base and all keys from
+		// override exist in the result just in case one of the maps is sparse.
+		elementsAreValues := base.Type().Elem().Kind() != reflect.Ptr
+
+		result = reflect.MakeMap(base.Type())
+		// Copy from base first
+		for _, key := range base.MapKeys() {
+			result.SetMapIndex(key, base.MapIndex(key))
+		}
+
+		// Override with values from override if they exist
+		if override.Kind() == reflect.Map {
+			for _, key := range override.MapKeys() {
+				overrideVal := override.MapIndex(key)
+				baseVal := base.MapIndex(key)
+				if !overrideVal.IsValid() {
+					continue
+				}
+
+				// if there is no base value, just set the override
+				if !baseVal.IsValid() {
+					result.SetMapIndex(key, overrideVal)
+					continue
+				}
+
+				// Merge the values and set in the result
+				newVal := mergeRecursive(baseVal, overrideVal)
+				if elementsAreValues && newVal.Kind() == reflect.Ptr {
+					result.SetMapIndex(key, newVal.Elem())
+
+				} else {
+					result.SetMapIndex(key, newVal)
+				}
+			}
+		}
+	case reflect.Slice:
+		result = reflect.AppendSlice(base, override)
+	default:
+		result = override
+	}
+	return result
+}

--- a/pkg/utils/merge_test.go
+++ b/pkg/utils/merge_test.go
@@ -1,0 +1,95 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This is mostly a copy of https://github.com/divideandconquer/go-merge/blob/master/merge/merge_test.go
+// with minimal number of changes to reflect the different approach taken to slice merging (+ different package name)
+// Original test function names are retained
+
+package utils
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMerge(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		a    interface{}
+		b    interface{}
+		r    interface{}
+	}{
+		{
+			name: "non-overlapping maps",
+			a:    map[string]string{"a": "X"},
+			b:    map[string]string{"b": "Y"},
+			r:    map[string]string{"a": "X", "b": "Y"},
+		},
+		{
+			name: "overlapping maps",
+			a:    map[string]string{"a": "X", "b": "Y"},
+			b:    map[string]string{"c": "Z", "b": "Q"},
+			r:    map[string]string{"a": "X", "c": "Z", "b": "Q"},
+		},
+		{
+			name: "slices",
+			a:    []int{1, 2},
+			b:    []int{2, 3},
+			r:    []int{1, 2, 2, 3},
+		},
+		{
+			name: "slice-maps",
+			a:    map[string][]int{"a": {1, 2}},
+			b:    map[string][]int{"a": {3, 4}},
+			r:    map[string][]int{"a": {1, 2, 3, 4}},
+		},
+		{
+			name: "scalars",
+			a:    3,
+			b:    0,
+			r:    0,
+		},
+		{
+			name: "incompatible types",
+			a:    []string{"a", "b"},
+			b:    []int{1, 2},
+			r:    []int{1, 2},
+		},
+		{
+			name: "nil-slice",
+			a:    []int{1, 2},
+			b:    []int(nil),
+			r:    []int{1, 2},
+		},
+		{
+			name: "double nil-slice",
+			a:    []int(nil),
+			b:    []int(nil),
+			r:    []int(nil),
+		},
+		{
+			name: "nils",
+			a:    nil,
+			b:    nil,
+			r:    nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := Merge(tc.a, tc.b)
+			if !reflect.DeepEqual(r, tc.r) {
+				t.Errorf("expected: %v, actual: %v", tc.r, r)
+			}
+		})
+	}
+}

--- a/tests/e2e/cloudinit_test.go
+++ b/tests/e2e/cloudinit_test.go
@@ -1,0 +1,262 @@
+/*
+Copyright 2017 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"time"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/pkg/api/v1"
+
+	"github.com/Mirantis/virtlet/tests/e2e/framework"
+	. "github.com/Mirantis/virtlet/tests/e2e/ginkgo-ext"
+)
+
+var _ = Describe("Cloud-init related tests", func() {
+	Context("VM with SSH key from implicit key of ConfigMap", func() {
+		var vm *framework.VMInterface
+
+		BeforeAll(func() {
+			cm := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cm-ssh-key-impl",
+				},
+				Data: map[string]string{
+					"authorized_keys": sshPublicKey,
+				},
+			}
+			_, err := controller.ConfigMaps().Create(cm)
+			Expect(err).NotTo(HaveOccurred())
+
+			vm = controller.VM("ssh-from-cm-impl")
+			vm.Create(VMOptions{
+				SSHKeySource: "configmap/cm-ssh-key-impl",
+			}.applyDefaults(), time.Minute*5, nil)
+		})
+
+		AfterAll(func() {
+			deleteVM(vm)
+			controller.ConfigMaps().Delete("cm-ssh-key-impl", nil)
+		})
+
+		It("Should have SSH accessible", func() {
+			waitSSH(vm)
+		})
+	})
+
+	Context("VM with SSH key from explicit key of ConfigMap", func() {
+		var vm *framework.VMInterface
+
+		BeforeAll(func() {
+			cm := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cm-ssh-key-expl",
+				},
+				Data: map[string]string{
+					"myKey": sshPublicKey,
+				},
+			}
+			_, err := controller.ConfigMaps().Create(cm)
+			Expect(err).NotTo(HaveOccurred())
+
+			vm = controller.VM("ssh-from-cm-expl")
+			vm.Create(VMOptions{
+				SSHKeySource: "configmap/cm-ssh-key-expl/myKey",
+			}.applyDefaults(), time.Minute*5, nil)
+		})
+
+		AfterAll(func() {
+			deleteVM(vm)
+			controller.ConfigMaps().Delete("cm-ssh-key-expl", nil)
+		})
+
+		It("Should have SSH accessible", func() {
+			waitSSH(vm)
+		})
+	})
+
+	Context("VM with SSH key from implicit key of Secret", func() {
+		var vm *framework.VMInterface
+
+		BeforeAll(func() {
+			secret := &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "secret-ssh-key-impl",
+				},
+				StringData: map[string]string{
+					"authorized_keys": sshPublicKey,
+				},
+			}
+			_, err := controller.Secrets().Create(secret)
+			Expect(err).NotTo(HaveOccurred())
+
+			vm = controller.VM("ssh-from-secret-impl")
+			vm.Create(VMOptions{
+				SSHKeySource: "secret/secret-ssh-key-impl",
+			}.applyDefaults(), time.Minute*5, nil)
+		})
+
+		AfterAll(func() {
+			deleteVM(vm)
+			controller.Secrets().Delete("secret-ssh-key-impl", nil)
+		})
+
+		It("Should have SSH accessible", func() {
+			waitSSH(vm)
+		})
+	})
+
+	Context("VM with SSH key from explicit key of Secret", func() {
+		var vm *framework.VMInterface
+
+		BeforeAll(func() {
+			secret := &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "secret-ssh-key-expl",
+				},
+				StringData: map[string]string{
+					"myKey": sshPublicKey,
+				},
+			}
+			_, err := controller.Secrets().Create(secret)
+			Expect(err).NotTo(HaveOccurred())
+
+			vm = controller.VM("ssh-from-secret-expl")
+			vm.Create(VMOptions{
+				SSHKeySource: "secret/secret-ssh-key-expl/myKey",
+			}.applyDefaults(), time.Minute*5, nil)
+		})
+
+		AfterAll(func() {
+			deleteVM(vm)
+			controller.Secrets().Delete("secret-ssh-key-expl", nil)
+		})
+
+		It("Should have SSH accessible", func() {
+			waitSSH(vm)
+		})
+	})
+
+	Context("User-data from ConfigMap", func() {
+		var vm *framework.VMInterface
+
+		const fileConf = `[{"content": "Hello world!", "path": "/tmp/test-file"}]`
+
+		BeforeAll(func() {
+			cm := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cm-userdata",
+				},
+				Data: map[string]string{
+					"write_files": fileConf,
+				},
+			}
+			_, err := controller.ConfigMaps().Create(cm)
+			Expect(err).NotTo(HaveOccurred())
+
+			vm = controller.VM("userdata-cm")
+			vm.Create(VMOptions{
+				UserDataSource: "configmap/cm-userdata",
+			}.applyDefaults(), time.Minute*5, nil)
+		})
+
+		AfterAll(func() {
+			deleteVM(vm)
+			controller.ConfigMaps().Delete("cm-userdata", nil)
+		})
+
+		It("Must be processed", func() {
+			requireCloudInit()
+			ssh := waitSSH(vm)
+			Expect(framework.ExecSimple(ssh, "cat", "/tmp/test-file")).To(Equal("Hello world!"))
+		})
+	})
+
+	Context("User-data from Secret", func() {
+		var vm *framework.VMInterface
+
+		const fileConf = `[{"content": "Hello world!", "path": "/tmp/test-file"}]`
+
+		BeforeAll(func() {
+			secret := &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "secret-userdata",
+				},
+				StringData: map[string]string{
+					"write_files": fileConf,
+				},
+			}
+			_, err := controller.Secrets().Create(secret)
+			Expect(err).NotTo(HaveOccurred())
+
+			vm = controller.VM("userdata-secret")
+			vm.Create(VMOptions{
+				UserDataSource: "secret/secret-userdata",
+			}.applyDefaults(), time.Minute*5, nil)
+		})
+
+		AfterAll(func() {
+			deleteVM(vm)
+			controller.Secrets().Delete("secret-userdata", nil)
+		})
+
+		It("Must be processed", func() {
+			requireCloudInit()
+			ssh := waitSSH(vm)
+			Expect(framework.ExecSimple(ssh, "cat", "/tmp/test-file")).To(Equal("Hello world!"))
+		})
+	})
+
+	Context("User-data merged from two sources", func() {
+		var vm *framework.VMInterface
+
+		const fileConf = `[{"content": "Hello ", "path": "/tmp/test-file1"}]`
+		const userData = `{"write_files": [{"content": "world!", "path": "/tmp/test-file2"}]}`
+
+		BeforeAll(func() {
+			cm := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cm-userdata",
+				},
+				Data: map[string]string{
+					"write_files": fileConf,
+				},
+			}
+			_, err := controller.ConfigMaps().Create(cm)
+			Expect(err).NotTo(HaveOccurred())
+
+			vm = controller.VM("userdata-cm-merge")
+			vm.Create(VMOptions{
+				UserDataSource: "configmap/cm-userdata",
+				UserData:       userData,
+			}.applyDefaults(), time.Minute*5, nil)
+		})
+
+		AfterAll(func() {
+			deleteVM(vm)
+			controller.ConfigMaps().Delete("cm-userdata", nil)
+		})
+
+		It("Must be processed", func() {
+			requireCloudInit()
+			ssh := waitSSH(vm)
+			Expect(framework.ExecSimple(ssh, "cat", "/tmp/test-file1", "/tmp/test-file2")).To(Equal("Hello world!"))
+		})
+	})
+
+})

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -121,7 +121,7 @@ func (o VMOptions) applyDefaults() framework.VMOptions {
 	if res.Image == "" {
 		res.Image = *vmImageLocation
 	}
-	if res.SSHKey == "" {
+	if res.SSHKey == "" && res.SSHKeySource == "" {
 		res.SSHKey = sshPublicKey
 	}
 	if res.VCPUCount == 0 {
@@ -138,4 +138,10 @@ func (o VMOptions) applyDefaults() framework.VMOptions {
 	}
 
 	return res
+}
+
+func requireCloudInit() {
+	if !*includeCloudInitTests {
+		Skip("Cloud-Init tests are not enabled")
+	}
 }

--- a/tests/e2e/framework/controller.go
+++ b/tests/e2e/framework/controller.go
@@ -133,6 +133,16 @@ func (c *Controller) PersistentVolumeClaimsClient() typedv1.PersistentVolumeClai
 	return c.client.PersistentVolumeClaims(c.namespace.Name)
 }
 
+// ConfigMaps returns interface for ConfigMap objects
+func (c *Controller) ConfigMaps() typedv1.ConfigMapInterface {
+	return c.client.ConfigMaps(c.namespace.Name)
+}
+
+// Secrets returns interface for Secret objects
+func (c *Controller) Secrets() typedv1.SecretInterface {
+	return c.client.Secrets(c.namespace.Name)
+}
+
 // VM returns interface for operations on virtlet VM pods
 func (c *Controller) VM(name string) *VMInterface {
 	return newVMInterface(c, name)

--- a/tests/e2e/framework/vm_interface.go
+++ b/tests/e2e/framework/vm_interface.go
@@ -42,12 +42,14 @@ type VMOptions struct {
 	Image             string
 	VCPUCount         int
 	SSHKey            string
+	SSHKeySource      string
 	CloudInitScript   string
 	DiskDriver        string
 	Limits            map[string]string
 	UserData          string
 	OverwriteUserData bool
 	UserDataScript    string
+	UserDataSource    string
 	NodeName          string
 }
 
@@ -137,8 +139,14 @@ func (vmi *VMInterface) buildVMPod(options VMOptions) *v1.Pod {
 	if options.SSHKey != "" {
 		annotations["VirtletSSHKeys"] = options.SSHKey
 	}
+	if options.SSHKeySource != "" {
+		annotations["VirtletSSHKeySource"] = options.SSHKeySource
+	}
 	if options.UserData != "" {
 		annotations["VirtletCloudInitUserData"] = options.UserData
+	}
+	if options.UserDataSource != "" {
+		annotations["VirtletCloudInitUserDataSource"] = options.UserDataSource
 	}
 	if options.UserDataScript != "" {
 		annotations["VirtletCloudInitUserDataScript"] = options.UserDataScript

--- a/tests/e2e/volume_mount_test.go
+++ b/tests/e2e/volume_mount_test.go
@@ -116,9 +116,7 @@ func makeVolumeMountVM(flexvolOptions map[string]string, nodeName string) *frame
 
 func itShouldBeMounted(ssh *framework.Executor) {
 	It("Should be handled inside the VM", func() {
-		if !*includeCloudInitTests {
-			Skip("Cloud-Init tests not enabled")
-		}
+		requireCloudInit()
 		Eventually(func() (string, error) {
 			return framework.ExecSimple(*ssh, "ls -l /foo")
 		}, 60).Should(ContainSubstring("lost+found"))


### PR DESCRIPTION
ConfigMap/Secret files were mounted with hardcoded file permissions.
However, the file mode can be passed in the volume mount spec and
it shouldn't be silently ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/477)
<!-- Reviewable:end -->
