### PR TITLE
e2e test for virtlet container restarting

### DIFF
--- a/tests/e2e/framework/pod_interface.go
+++ b/tests/e2e/framework/pod_interface.go
@@ -84,9 +84,16 @@ func (pi *PodInterface) Wait(timing ...time.Duration) error {
 			return err
 		}
 		pi.Pod = podUpdated
+
 		phase := v1.PodRunning
 		if podUpdated.Status.Phase != phase {
 			return fmt.Errorf("pod %s is not %s phase: %s", podUpdated.Name, phase, podUpdated.Status.Phase)
+		}
+
+		for _, cs := range podUpdated.Status.ContainerStatuses {
+			if cs.State.Running == nil {
+				return fmt.Errorf("container %s in pod %s is not running", cs.Name, podUpdated.Name)
+			}
 		}
 		return nil
 	}, timeout, pollPeriond, consistencyPeriod)

--- a/tests/e2e/restart_virtlet_test.go
+++ b/tests/e2e/restart_virtlet_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2017 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/Mirantis/virtlet/tests/e2e/framework"
+	. "github.com/Mirantis/virtlet/tests/e2e/ginkgo-ext"
+)
+
+var _ = Describe("Virtlet restart", func() {
+	var (
+		vm    *framework.VMInterface
+		vmPod *framework.PodInterface
+	)
+
+	BeforeAll(func() {
+		vm = controller.VM("cirros-vm")
+		vm.Create(VMOptions{}.applyDefaults(), time.Minute*5, nil)
+		var err error
+		vmPod, err = vm.Pod()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterAll(func() {
+		deleteVM(vm)
+	})
+
+	It("Should allow to ssh to VM after virtlet pod and vm restart [Conformance]", func() {
+		pod, err := vm.VirtletPod()
+		Expect(err).NotTo(HaveOccurred())
+
+		virtletPodExecutor, err := pod.Container("virtlet")
+		Expect(err).NotTo(HaveOccurred())
+
+		do(framework.ExecSimple(virtletPodExecutor, "pkill", "-9", "virtlet"))
+		Expect(pod.Wait()).NotTo(HaveOccurred())
+
+		_, err = vm.VirshCommand("reboot", "<domain>")
+		Expect(err).NotTo(HaveOccurred())
+
+		waitSSH(vm)
+	}, 3*60)
+})


### PR DESCRIPTION
This test verifies that if we have a VM started and we will restart virtlet container - VM will still have a possibility to query dhcp server and will work properly after its internal reboot.

That means - it tests virtlet container restart pod what also includes recovering network namespace after that restart.