### PR TITLE
Get rid of false volume teardown error messages

### DIFF
--- a/pkg/libvirttools/libvirt_storage.go
+++ b/pkg/libvirttools/libvirt_storage.go
@@ -191,10 +191,14 @@ func (pool *LibvirtStoragePool) ImageToVolume(def *libvirtxml.StorageVolume, sou
 
 func (pool *LibvirtStoragePool) RemoveVolumeByName(name string) error {
 	vol, err := pool.LookupVolumeByName(name)
-	if err != nil {
+	switch {
+	case err == virt.ErrStorageVolumeNotFound:
+		return nil
+	case err != nil:
 		return err
+	default:
+		return vol.Remove()
 	}
-	return vol.Remove()
 }
 
 type LibvirtStorageVolume struct {

--- a/pkg/libvirttools/nocloud_volumesource.go
+++ b/pkg/libvirttools/nocloud_volumesource.go
@@ -60,8 +60,7 @@ func (v *nocloudVolume) Setup(volumeMap map[string]string) (*libvirtxml.DomainDi
 
 func (v *nocloudVolume) Teardown() error {
 	isoPath := NewCloudInitGenerator(v.config, nil, nocloudIsoDir, nil).IsoPath()
-	// don't fail to remove the pod if the file cannot be removed, just warn
-	if err := os.Remove(isoPath); err != nil {
+	if err := os.Remove(isoPath); err != nil && !os.IsNotExist(err) {
 		glog.Warningf("Cannot remove temporary nocloud file %q: %v", isoPath, err)
 	}
 	return nil


### PR DESCRIPTION
Volume teardown is called for both StopContainer and RemoveContainer,
which is okay. However, since usually both are called the volumes
teardown happens twice. This causes false error messages due
to attempts to delete things that were already deleted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/484)
<!-- Reviewable:end -->
