### PR TITLE
Change runtime name to virtlet.cloud

### DIFF
--- a/cmd/criproxy/criproxy.go
+++ b/cmd/criproxy/criproxy.go
@@ -143,7 +143,7 @@ func installCriProxy(execPath, nodeInfoPath string) error {
 			"3",
 			"-alsologtostderr",
 			"-connect",
-			"docker,virtlet:/run/virtlet.sock",
+			"docker,virtlet.cloud:/run/virtlet.sock",
 		},
 		ProxySocketPath: "/run/criproxy.sock",
 		NodeInfo:        ni,

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -89,7 +89,7 @@ docker run -d --privileged \
        nsenter --mount=/proc/1/ns/mnt -- \
        /opt/criproxy/bin/criproxy \
        -v 3 -alsologtostderr \
-       -connect docker,virtlet:/run/virtlet.sock
+       -connect docker,virtlet.cloud:/run/virtlet.sock
 ```
 
 `-v` option of `criproxy` controls the verbosity here. 0-1 means some

--- a/deploy/real-cluster.md
+++ b/deploy/real-cluster.md
@@ -118,7 +118,7 @@ the following content (you can also use `systemctl --force edit criproxy.service
 Description=CRI Proxy
 
 [Service]
-ExecStart=/usr/local/bin/criproxy -v 3 -alsologtostderr -connect /var/run/dockershim.sock,virtlet:/run/virtlet.sock -listen /run/criproxy.sock
+ExecStart=/usr/local/bin/criproxy -v 3 -alsologtostderr -connect /var/run/dockershim.sock,virtlet.cloud:/run/virtlet.sock -listen /run/criproxy.sock
 Restart=always
 StartLimitInterval=0
 RestartSec=10

--- a/docs/cloud-init-data-generation.md
+++ b/docs/cloud-init-data-generation.md
@@ -30,7 +30,7 @@ kind: Pod
 metadata:
   name: ubuntu-vm
   annotations:
-    kubernetes.io/target-runtime: virtlet
+    kubernetes.io/target-runtime: virtlet.cloud
 
     # override some fields in cloud-init meta-data
     VirtletCloudInitMetaData: |
@@ -84,7 +84,7 @@ spec:
 
   containers:
   - name: ubuntu-vm
-    image: virtlet/cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
+    image: virtlet.cloud/cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
     volumeMounts:
 
     # this will write configmap contents using the `write_file` cloud-init module

--- a/docs/criproxy.md
+++ b/docs/criproxy.md
@@ -16,14 +16,14 @@ image name / pod id / container id prefixes.
 
 Let's say CRI proxy is started as follows:
 ```
-/usr/local/bin/criproxy -v 3 -alsologtostderr -connect docker,virtlet:/run/virtlet.sock
+/usr/local/bin/criproxy -v 3 -alsologtostderr -connect docker,virtlet.cloud:/run/virtlet.sock
 ```
 
 `-v 3 -alsologtostderr` options here may be quite useful for
 debugging, because they make CRI proxy log detailed info about every
 CRI request going through it, including any errors and the result.
 
-`-connect docker,virtlet:/run/virtlet.sock` specifies the list of
+`-connect docker,virtlet.cloud:/run/virtlet.sock` specifies the list of
 runtimes that the proxy passes requests to.
 
 The `docker` part is a special case, meaning that `criproxy` must
@@ -33,25 +33,25 @@ installations `dockershim` runs as a separate process, although using
 same `criproxy` binary).  It's also possible to specify other primary
 runtime instead, e.g. `/run/some-other-runtime.sock`.
 
-`virtlet:/run/virtlet.sock` denotes an alternative runtime
+`virtlet.cloud:/run/virtlet.sock` denotes an alternative runtime
 socket. This means that image service requests that include image
-names starting with `virtlet/` must be directed to the CRI
+names starting with `virtlet.cloud/` must be directed to the CRI
 implementation listening on a Unix domain socket at
-`/run/virtlet.sock`. Pods that need to run on `virtlet` runtime must
-have `virtlet` as the value of `kubernetes.io/target-runtime`
+`/run/virtlet.sock`. Pods that need to run on `virtlet.cloud` runtime must
+have `virtlet.cloud` as the value of `kubernetes.io/target-runtime`
 annotation.
 
 There can be any number of runtimes, although probably using more than
 a couple of runtimes is a rare use case.
 
-Here's an example of a pod that needs to run on `virtlet` runtime:
+Here's an example of a pod that needs to run on `virtlet.cloud` runtime:
 ```
 apiVersion: v1
 kind: Pod
 metadata:
   name: cirros-vm
   annotations:
-    kubernetes.io/target-runtime: virtlet
+    kubernetes.io/target-runtime: virtlet.cloud
     scheduler.alpha.kubernetes.io/affinity: >
       {
         "nodeAffinity": {
@@ -73,19 +73,19 @@ metadata:
 spec:
   containers:
     - name: cirros-vm
-      image: virtlet/image-service/cirros
+      image: virtlet.cloud/image-service/cirros
 ```
 
-First of all, there's `kubernetes.io/target-runtime: virtlet`
-annotation that directs `RunPodSandbox` requests to `virtlet` runtime.
+First of all, there's `kubernetes.io/target-runtime: virtlet.cloud`
+annotation that directs `RunPodSandbox` requests to `virtlet.cloud` runtime.
 
 There's also `nodeAffinity` spec that makes the pod run only on the
 nodes that have `extraRuntime=virtlet` label. This is not required
 by CRI proxy mechanism itself and is related to deployment mechanism
 being used (more on this in CRI Proxy bootstrap section below).
 
-Another important part is `virtlet/image-service/cirros` image name.
-It means that the image is handled by `virtlet` runtime and actual
+Another important part is `virtlet.cloud/image-service/cirros` image name.
+It means that the image is handled by `virtlet.cloud` runtime and actual
 image name passed to the runtime is `image-service/cirros`. In case of
 virtlet this means downloading QCOW2 image from
 `http://image-service/cirros`.

--- a/docs/image-name-translation.md
+++ b/docs/image-name-translation.md
@@ -12,9 +12,9 @@ To overcome these limitations, Virtlet provides a mechanism for image name trans
 The idea is that image can be identified by some abstract ID rather than URL. Virtlet then will map this ID
 to arbitrary URL using special translation table that specifies rules for image name translation.
 
-Thus instead of `virtlet/example.net/path/to/my.qcow2` one would use `virtlet/my-image` and put a mapping that says that
+Thus instead of `virtlet.cloud/example.net/path/to/my.qcow2` one would use `virtlet.cloud/my-image` and put a mapping that says that
 `my-image` must be translated to `http://example.net/path/to/my.qcow2` into translation table.
-Here and below I assume that `CRI Proxy` is used. Otherwise, the `virtlet/` prefix is not needed.
+Here and below I assume that `CRI Proxy` is used. Otherwise, the `virtlet.cloud/` prefix is not needed.
 
 ## Translation configs
 
@@ -34,13 +34,13 @@ translations:
 ```
 
 The prefix is optional and may be omitted. In example above the image name
-`virtlet/my-prefix/cirros` is going to be translated into `https://download.cirros-cloud.net/0.3.5/cirros-0.3.5-x86_64-disk.img`,
-but `virtlet/cirros` won't be unless there is also a translation config without a prefix (or with empty string prefix).
+`virtlet.cloud/my-prefix/cirros` is going to be translated into `https://download.cirros-cloud.net/0.3.5/cirros-0.3.5-x86_64-disk.img`,
+but `virtlet.cloud/cirros` won't be unless there is also a translation config without a prefix (or with empty string prefix).
 In the later case, the `cirros` part will be treated as an URL (the default behavior without translations).
 
 There are two types of translations: those that map a fixed image name and those that map set of names identified by regexp expression.
 In the later case, URL can be generalized by using regexp sub-matches through the `$n` syntax.
-In example above, `virtlet/my-prefix/centos/7-01` is going to be translated to
+In example above, `virtlet.cloud/my-prefix/centos/7-01` is going to be translated to
 `https://cloud.centos.org/centos/$1/images/CentOS-7-x86_64-GenericCloud-01.qcow2`.
 
 The regexp translations are only available when Virtlet is run with `IMAGE_REGEXP_TRANSLATION` environment variable set to a

--- a/docs/images.md
+++ b/docs/images.md
@@ -14,7 +14,7 @@ Virtlet supports QCOW2 format for VM images.
       image: download.cirros-cloud.net/0.3.4/cirros-0.3.4-x86_64-disk.img
 ```
 
-**Note:** You need to specify url without `scheme://`. In case you are using [instructions](../deploy/README.md) in `deploy/` directory to deploy Virtlet, you need to add `virtlet/` prefix to the url.
+**Note:** You need to specify url without `scheme://`. In case you are using [instructions](../deploy/README.md) in `deploy/` directory to deploy Virtlet, you need to add `virtlet.cloud/` prefix to the url.
 
 Also see [Image Name Translation](image-name-translation.md) for another way of providing image URL.
 

--- a/docs/volumes.md
+++ b/docs/volumes.md
@@ -14,7 +14,7 @@ kind: Pod
 metadata:
   name: cirros-vm
   annotations:
-    kubernetes.io/target-runtime: virtlet
+    kubernetes.io/target-runtime: virtlet.cloud
     VirtletDiskDriver: virtio
 ```
 
@@ -119,7 +119,7 @@ kind: Pod
 metadata:
   name: test-vm-pod
   annotations:
-    kubernetes.io/target-runtime: virtlet
+    kubernetes.io/target-runtime: virtlet.cloud
 spec:
   affinity:
     nodeAffinity:
@@ -193,7 +193,7 @@ kind: Pod
 metadata:
   name: cirros-vm-rbd
   annotations:
-    kubernetes.io/target-runtime: virtlet
+    kubernetes.io/target-runtime: virtlet.cloud
 spec:
   affinity:
     nodeAffinity:
@@ -206,7 +206,7 @@ spec:
             - virtlet
   containers:
     - name: cirros-vm-rbd
-      image: virtlet/image-service.kube-system/cirros
+      image: virtlet.cloud/image-service.kube-system/cirros
   volumes:
     - name: test
       flexVolume:
@@ -259,7 +259,7 @@ kind: Pod
 metadata:
   name: cirros-vm-rbd
   annotations:
-    kubernetes.io/target-runtime: virtlet
+    kubernetes.io/target-runtime: virtlet.cloud
 spec:
   affinity:
     nodeAffinity:
@@ -272,7 +272,7 @@ spec:
             - virtlet
   containers:
     - name: cirros-vm-rbd
-      image: virtlet/image-service.kube-system/cirros
+      image: virtlet.cloud/image-service.kube-system/cirros
   volumes:
     - name: test
       persistentVolumeClaim:
@@ -302,7 +302,7 @@ kind: Pod
 metadata:
   name: test-vm-pod
   annotations:
-    kubernetes.io/target-runtime: virtlet
+    kubernetes.io/target-runtime: virtlet.cloud
 spec:
   affinity:
     nodeAffinity:
@@ -367,7 +367,7 @@ spec:
 ...
   containers:
   - name: ubuntu-vm
-    image: virtlet/cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
+    image: virtlet.cloud/cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
     volumeMounts:
     - name: docker
       mountPath: /var/lib/docker

--- a/examples/cirros-vm-raw-device.yaml
+++ b/examples/cirros-vm-raw-device.yaml
@@ -3,7 +3,7 @@ kind: Pod
 metadata:
   name: cirros-vm
   annotations:
-    kubernetes.io/target-runtime: virtlet
+    kubernetes.io/target-runtime: virtlet.cloud
 spec:
   affinity:
     nodeAffinity:
@@ -17,7 +17,7 @@ spec:
   containers:
     - name: cirros-vm
       imagePullPolicy: IfNotPresent
-      image: virtlet/image-service/cirros
+      image: virtlet.cloud/image-service/cirros
       # tty and stdin required for `kubectl attach -t` to work
       tty: true
       stdin: true

--- a/examples/cirros-vm-rbd-pv-volume.yaml.tmpl
+++ b/examples/cirros-vm-rbd-pv-volume.yaml.tmpl
@@ -34,7 +34,7 @@ kind: Pod
 metadata:
   name: cirros-vm-rbd-pv
   annotations:
-    kubernetes.io/target-runtime: virtlet
+    kubernetes.io/target-runtime: virtlet.cloud
     VirtletSSHKeys: |
       ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaJEcFDXEK2ZbX0ZLS1EIYFZRbDAcRfuVjpstSc0De8+sV1aiu+dePxdkuDRwqFtCyk6dEZkssjOkBXtri00MECLkir6FcH3kKOJtbJ6vy3uaJc9w1ERo+wyl6SkAh/+JTJkp7QRXj8oylW5E20LsbnA/dIwWzAF51PPwF7A7FtNg9DnwPqMkxFo1Th/buOMKbP5ZA1mmNNtmzbMpMfJATvVyiv3ccsSJKOiyQr6UG+j7sc/7jMVz5Xk34Vd0l8GwcB0334MchHckmqDB142h/NCWTr8oLakDNvkfC1YneAfAO41hDkUbxPtVBG5M/o7P4fxoqiHEX+ZLfRxDtHB53 me@localhost
 spec:
@@ -49,7 +49,7 @@ spec:
             - virtlet
   containers:
   - name: cirros-vm-rbd-pv
-    image: virtlet/image-service.kube-system/cirros
+    image: virtlet.cloud/image-service.kube-system/cirros
     # tty and stdin required for `kubectl attach -t` to work
     tty: true
     stdin: true

--- a/examples/cirros-vm-rbd-volume.yaml.tmpl
+++ b/examples/cirros-vm-rbd-volume.yaml.tmpl
@@ -3,7 +3,7 @@ kind: Pod
 metadata:
   name: cirros-vm-rbd
   annotations:
-    kubernetes.io/target-runtime: virtlet
+    kubernetes.io/target-runtime: virtlet.cloud
     # CirrOS doesn't load nocloud data from SCSI CD-ROM for some reason
     VirtletDiskDriver: virtio
     VirtletSSHKeys: |
@@ -20,7 +20,7 @@ spec:
             - virtlet
   containers:
   - name: cirros-vm-rbd
-    image: virtlet/image-service.kube-system/cirros
+    image: virtlet.cloud/image-service.kube-system/cirros
     imagePullPolicy: IfNotPresent
     resources:
       limits:

--- a/examples/cirros-vm.yaml
+++ b/examples/cirros-vm.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cirros-vm
   annotations:
     # This tells CRI Proxy that this pod belongs to Virtlet runtime
-    kubernetes.io/target-runtime: virtlet
+    kubernetes.io/target-runtime: virtlet.cloud
     # An optional annotation specifying the count of virtual CPUs.
     # Note that annotation values must always be strings,
     # thus numeric values need to be quoted.
@@ -36,9 +36,9 @@ spec:
   containers:
   - name: cirros-vm
     # This specifies the image to use.
-    # virtlet/ prefix is used by CRI proxy, the remaining part
+    # virtlet.cloud/ prefix is used by CRI proxy, the remaining part
     # of the image name is prepended with https:// and used to download the image
-    image: virtlet/cirros
+    image: virtlet.cloud/cirros
     # Virtlet currently ignores image tags, but their meaning may change
     # in future, so it’s better not to set them for VM pods. If there’s no tag
     # provided in the image specification kubelet defaults to

--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -25,7 +25,7 @@ spec:
       labels:
         app: inner-k8s
       annotations:
-        kubernetes.io/target-runtime: virtlet
+        kubernetes.io/target-runtime: virtlet.cloud
         VirtletCloudInitUserData: |
           write_files:
           - path: /etc/systemd/system/docker.service.d/env.conf
@@ -98,7 +98,7 @@ spec:
                 - virtlet
       containers:
       - name: ubuntu-vm
-        image: virtlet/cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
+        image: virtlet.cloud/cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
         imagePullPolicy: IfNotPresent
         # tty and stdin required for `kubectl attach -t` to work
         tty: true

--- a/examples/ubuntu-vm.yaml
+++ b/examples/ubuntu-vm.yaml
@@ -3,7 +3,7 @@ kind: Pod
 metadata:
   name: ubuntu-vm
   annotations:
-    kubernetes.io/target-runtime: virtlet
+    kubernetes.io/target-runtime: virtlet.cloud
     VirtletCloudInitUserData: |
       ssh_pwauth: True
       users:
@@ -32,7 +32,7 @@ spec:
   terminationGracePeriodSeconds: 120
   containers:
   - name: ubuntu-vm
-    image: virtlet/cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
+    image: virtlet.cloud/cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
     imagePullPolicy: IfNotPresent
     # tty and stdin required for `kubectl attach -t` to work
     tty: true

--- a/tests/e2e/framework/vm_interface.go
+++ b/tests/e2e/framework/vm_interface.go
@@ -132,7 +132,7 @@ func (vmi *VMInterface) VirtletPod() (*PodInterface, error) {
 
 func (vmi *VMInterface) buildVMPod(options VMOptions) *v1.Pod {
 	annotations := map[string]string{
-		"kubernetes.io/target-runtime":      "virtlet",
+		"kubernetes.io/target-runtime":      "virtlet.cloud",
 		"VirtletDiskDriver":                 options.DiskDriver,
 		"VirtletCloudInitUserDataOverwrite": strconv.FormatBool(options.OverwriteUserData),
 	}
@@ -198,7 +198,7 @@ func (vmi *VMInterface) buildVMPod(options VMOptions) *v1.Pod {
 			Containers: []v1.Container{
 				{
 					Name:  vmi.Name,
-					Image: "virtlet/" + options.Image,
+					Image: "virtlet.cloud/" + options.Image,
 					Resources: v1.ResourceRequirements{
 						Limits: limits,
 					},


### PR DESCRIPTION
This change is needed for supporting k8s 1.8
(kubelet 1.8 prepends docker.io to image name if it doesn't have a dot in the first part of its name)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/485)
<!-- Reviewable:end -->
