### PR TITLE
Fix CRI object removal races

### DIFF
--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -448,8 +448,11 @@ func (v *VirtualizationTool) startContainer(containerId string) error {
 
 	return v.metadataStore.Container(containerId).Save(
 		func(c *metadata.ContainerInfo) (*metadata.ContainerInfo, error) {
-			c.State = kubeapi.ContainerState_CONTAINER_RUNNING
-			c.StartedAt = v.clock.Now().UnixNano()
+			// make sure the container is not removed during the call
+			if c != nil {
+				c.State = kubeapi.ContainerState_CONTAINER_RUNNING
+				c.StartedAt = v.clock.Now().UnixNano()
+			}
 			return c, nil
 		})
 }
@@ -523,7 +526,10 @@ func (v *VirtualizationTool) StopContainer(containerId string, timeout time.Dura
 	if err == nil {
 		err = v.metadataStore.Container(containerId).Save(
 			func(c *metadata.ContainerInfo) (*metadata.ContainerInfo, error) {
-				c.State = kubeapi.ContainerState_CONTAINER_EXITED
+				// make sure the container is not removed during the call
+				if c != nil {
+					c.State = kubeapi.ContainerState_CONTAINER_EXITED
+				}
 				return c, nil
 			})
 	}
@@ -726,7 +732,10 @@ func (v *VirtualizationTool) getContainerInfo(domain virt.VirtDomain, containerI
 	if containerInfo.State != containerState {
 		if err := v.metadataStore.Container(containerId).Save(
 			func(c *metadata.ContainerInfo) (*metadata.ContainerInfo, error) {
-				c.State = containerState
+				// make sure the container is not removed during the call
+				if c != nil {
+					c.State = containerState
+				}
 				return c, nil
 			},
 		); err != nil {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -261,7 +261,10 @@ func (v *VirtletManager) StopPodSandbox(ctx context.Context, in *kubeapi.StopPod
 	if status.State != kubeapi.PodSandboxState_SANDBOX_NOTREADY {
 		if err := sandbox.Save(
 			func(c *metadata.PodSandboxInfo) (*metadata.PodSandboxInfo, error) {
-				c.State = kubeapi.PodSandboxState_SANDBOX_NOTREADY
+				// make sure the pod is not removed during the call
+				if c != nil {
+					c.State = kubeapi.PodSandboxState_SANDBOX_NOTREADY
+				}
 				return c, nil
 			},
 		); err != nil {


### PR DESCRIPTION
`StopContainer()` was breaking in k8s 1.8 because `RemoveContainer()`
is called for the same container before it finished.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/486)
<!-- Reviewable:end -->
