### PR TITLE
[wip] nettools: Better support for old cni plugins

### DIFF
--- a/pkg/nettools/nettools.go
+++ b/pkg/nettools/nettools.go
@@ -725,26 +725,43 @@ func TeardownBridge(bridge netlink.Link, links []netlink.Link) error {
 }
 
 // ConfigureLink adds to link ip address and routes based on info.
-func ConfigureLink(link netlink.Link, linkNo int, info *cnicurrent.Result) error {
-	if len(info.IPs) < linkNo+1 {
-		return fmt.Errorf("cni result has %d addresses but expected at least %d", len(info.IPs), linkNo+1)
+func ConfigureLink(link netlink.Link, info *cnicurrent.Result) error {
+	linkNo := -1
+	linkMAC := link.Attrs().HardwareAddr.String()
+	for i, iface := range info.Interfaces {
+		if iface.Mac == linkMAC {
+			linkNo = i
+			break
+		}
+	}
+	if linkNo == -1 {
+		return fmt.Errorf("can not find link with MAC %q in saved cni result: %s", linkMAC, spew.Sdump(info))
 	}
 
-	addr := &netlink.Addr{IPNet: &info.IPs[linkNo].Address}
-	if err := netlink.AddrAdd(link, addr); err != nil {
-		return err
-	}
+	for _, addr := range info.IPs {
+		if addr.Interface == linkNo {
+			addr := &netlink.Addr{IPNet: &addr.Address}
+			if err := netlink.AddrAdd(link, addr); err != nil {
+				return err
+			}
 
-	// NOTE: this can fail with multiple interfaces
-	for _, route := range info.Routes {
-		err := netlink.RouteAdd(&netlink.Route{
-			LinkIndex: link.Attrs().Index,
-			Scope:     netlink.SCOPE_UNIVERSE,
-			Dst:       &route.Dst,
-			Gw:        route.GW,
-		})
-		if err != nil {
-			return err
+			for _, route := range info.Routes {
+				// TODO: that's too naive - if there are more than one interfaces which have this gw address
+				// in their subnet - same gw will be added on both of them
+				// in theory this should be ok, but there is can lead to configuration other than prepared
+				// by cni plugins
+				if addr.Contains(route.GW) {
+					err := netlink.RouteAdd(&netlink.Route{
+						LinkIndex: link.Attrs().Index,
+						Scope:     netlink.SCOPE_UNIVERSE,
+						Dst:       &route.Dst,
+						Gw:        route.GW,
+					})
+					if err != nil {
+						return err
+					}
+				}
+			}
 		}
 	}
 
@@ -807,7 +824,11 @@ func (csn *ContainerSideNetwork) Teardown() error {
 			return err
 		}
 
-		if err := ConfigureLink(contLink, i, csn.Result); err != nil {
+		rereadedLink, err := netlink.LinkByName(contLink.Attrs().Name)
+		if err != nil {
+			return err
+		}
+		if err := ConfigureLink(rereadedLink, csn.Result); err != nil {
 			return err
 		}
 	}

--- a/pkg/nettools/nettools.go
+++ b/pkg/nettools/nettools.go
@@ -318,37 +318,114 @@ func FindVeth(links []netlink.Link) (netlink.Link, error) {
 	return veth, nil
 }
 
-func findLink(links []netlink.Link, iface *cnicurrent.Interface) (netlink.Link, error) {
+func findLinkByAddress(links []netlink.Link, address net.IPNet) (netlink.Link, error) {
 	for _, link := range links {
-		if link.Attrs().Name == iface.Name {
+		addresses, err := netlink.AddrList(link, netlink.FAMILY_ALL)
+		if err != nil {
+			return nil, err
+		}
+		for _, addr := range addresses {
+			if addr.IPNet.String() == address.String() {
+				return link, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("interface with address %q not found in container namespace", address.String())
+}
+
+// ValidateAndfixCNIResult verifies that netConfig contains proper list of
+// ips, routes, interfaces and if something is missing it tries to complement
+// that using patch for Weave or for plugins which return their netConfig
+// in v0.2.0 version of CNI SPEC
+func ValidateAndfixCNIResult(netConfig *cnicurrent.Result) error {
+	allLinks, err := netlink.LinkList()
+	if err != nil {
+		return fmt.Errorf("error listing links: %v", err)
+	}
+
+	// If there are no routes provided, we consider it a broken
+	// config and extract interface config instead. That's the
+	// case with Weave CNI plugin.
+	if cni.GetPodIP(netConfig) == "" || len(netConfig.Routes) == 0 {
+		dnsInfo := netConfig.DNS
+
+		veth, err := FindVeth(allLinks)
+		if err != nil {
+			return err
+		}
+		if netConfig, err = ExtractLinkInfo(veth); err != nil {
+			return err
+		}
+
+		// extracted netConfig doesn't have DNS information, so
+		// still try to extract it from CNI-provided data
+		netConfig.DNS = dnsInfo
+
+		return nil
+	}
+
+	if len(netConfig.IPs) == 0 {
+		return fmt.Errorf("cni result does not have any IP addresses")
+	}
+
+	// If on list of interfaces are missing elements matching these mentioned
+	// by interface index in elements of ip list and for all elements
+	// of this list which have value -1 for interface index - add them to list
+	// of interfaces and fix its index in ip list entry
+	if len(netConfig.Interfaces) == 0 {
+		alreadyDefindeLinks, err := GetContainerLinks(netConfig.Interfaces)
+		if err != nil {
+			return err
+		}
+
+		for _, ipConfig := range netConfig.IPs {
+			link, err := findLinkByAddress(allLinks, ipConfig.Address)
+			if err != nil {
+				return err
+			}
+
+			found := false
+			for i, l := range alreadyDefindeLinks {
+				if l == link {
+					ipConfig.Interface = i
+					found = true
+					break
+				}
+			}
+			if !found {
+				netConfig.Interfaces = append(netConfig.Interfaces, &cnicurrent.Interface{
+					Name: link.Attrs().Name,
+					Mac:  link.Attrs().HardwareAddr.String(),
+				})
+				ipConfig.Interface = len(alreadyDefindeLinks)
+				alreadyDefindeLinks = append(alreadyDefindeLinks, link)
+			}
+		}
+	}
+
+	return nil
+}
+
+func findLinkByName(links []netlink.Link, name string) (netlink.Link, error) {
+	for _, link := range links {
+		if link.Attrs().Name == name {
 			return link, nil
 		}
 	}
-	return nil, fmt.Errorf("interface with name %q not found in container namespace", iface.Name)
+	return nil, fmt.Errorf("interface with name %q not found in container namespace", name)
 }
 
-// GetContainerInterfaces locates veth network links in the current network namespace.
-// If info is not nil and contains a non-empty list of network interfaces,
-// the resulting slice will contain a link for each entry in that list.
-// If info is nil or has no interfaces listed, the current network namespace
-// must contain exactly one veth network link.
-func GetContainerInterfaces(info *cnicurrent.Result) ([]netlink.Link, error) {
+// GetContainerLinks locates in container namespac enetwork links
+// for provided interfaces
+func GetContainerLinks(interfaces []*cnicurrent.Interface) ([]netlink.Link, error) {
 	allLinks, err := netlink.LinkList()
 	if err != nil {
 		return nil, fmt.Errorf("error listing links: %v", err)
 	}
 
-	if info == nil || len(info.Interfaces) == 0 {
-		link, err := FindVeth(allLinks)
-		if err != nil {
-			return nil, err
-		}
-		return []netlink.Link{link}, nil
-	}
-
 	var links []netlink.Link
-	for _, iface := range info.Interfaces {
-		link, err := findLink(allLinks, iface)
+	for _, iface := range interfaces {
+		link, err := findLinkByName(allLinks, iface.Name)
 		if err != nil {
 			return nil, err
 		}
@@ -517,38 +594,19 @@ type ContainerSideNetwork struct {
 }
 
 // SetupContainerSideNetwork sets up networking in container
-// namespace.  It does so by calling ExtractLinkInfo() first unless
-// non-nil info argument is provided and then preparing the following
+// namespace.  It does so by preparing the following
 // network interfaces in container ns:
-//     tap0      - tap interface for the VM
-//     br0       - a bridge that joins tap0 and original CNI veth
-// The bridge (br0) gets assigned a link-local address to be used
+//     tapX      - tap interface for the each interface to pass to VM
+//     brX       - a bridge that joins above tapX and original CNI interface
+// with X denoting an link index in info.Interfaces list.
+// Each bridge gets assigned a link-local address to be used
 // for dhcp server.
 // The function should be called from within container namespace.
 // Returns container network struct and an error, if any
 func SetupContainerSideNetwork(info *cnicurrent.Result) (*ContainerSideNetwork, error) {
-	contVeths, err := GetContainerInterfaces(info)
+	contLinks, err := GetContainerLinks(info.Interfaces)
 	if err != nil {
 		return nil, err
-	}
-	// If there are no routes provided, we consider it a broken
-	// config and extract interface config instead. That's the
-	// case with Weave CNI plugin.
-	if info == nil || cni.GetPodIP(info) == "" || len(info.Routes) == 0 {
-		var dnsInfo cnitypes.DNS
-		if info != nil {
-			dnsInfo = info.DNS
-		}
-		if len(contVeths) == 0 {
-			return nil, errors.New("can not find network interfaces in container namespace")
-		}
-		info, err = ExtractLinkInfo(contVeths[0])
-		if err != nil {
-			return nil, err
-		}
-		// extracted info doesn't have DNS information, so
-		// still try to extract it from CNI-provided data
-		info.DNS = dnsInfo
 	}
 
 	var (
@@ -556,14 +614,14 @@ func SetupContainerSideNetwork(info *cnicurrent.Result) (*ContainerSideNetwork, 
 		hwAddrs  []net.HardwareAddr
 	)
 
-	for i, contVeth := range contVeths {
-		hwAddr := contVeth.Attrs().HardwareAddr
+	for i, link := range contLinks {
+		hwAddr := link.Attrs().HardwareAddr
 		newHwAddr, err := GenerateMacAddress()
 		if err == nil {
-			err = SetHardwareAddr(contVeth, newHwAddr)
+			err = SetHardwareAddr(link, newHwAddr)
 		}
 		if err == nil {
-			err = StripLink(contVeth)
+			err = StripLink(link)
 		}
 		if err != nil {
 			return nil, err
@@ -574,7 +632,7 @@ func SetupContainerSideNetwork(info *cnicurrent.Result) (*ContainerSideNetwork, 
 			LinkAttrs: netlink.LinkAttrs{
 				Name:  tapInterfaceName,
 				Flags: net.FlagUp,
-				MTU:   contVeth.Attrs().MTU,
+				MTU:   link.Attrs().MTU,
 			},
 			Mode: netlink.TUNTAP_MODE_TAP,
 		}
@@ -587,7 +645,7 @@ func SetupContainerSideNetwork(info *cnicurrent.Result) (*ContainerSideNetwork, 
 		}
 
 		containerBridgeName := fmt.Sprintf(containerBridgeNameTemplate, i)
-		br, err := SetupBridge(containerBridgeName, []netlink.Link{contVeth, tap})
+		br, err := SetupBridge(containerBridgeName, []netlink.Link{link, tap})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create bridge: %v", err)
 		}
@@ -597,7 +655,7 @@ func SetupContainerSideNetwork(info *cnicurrent.Result) (*ContainerSideNetwork, 
 		}
 
 		// Add ebtables DHCP blocking rules
-		if err := updateEbTables(contVeth.Attrs().Name, "-A"); err != nil {
+		if err := updateEbTables(link.Attrs().Name, "-A"); err != nil {
 			return nil, err
 		}
 
@@ -695,14 +753,14 @@ func (csn *ContainerSideNetwork) Teardown() error {
 	for _, f := range csn.TapFiles {
 		f.Close()
 	}
-	contVeths, err := GetContainerInterfaces(csn.Result)
+	contLinks, err := GetContainerLinks(csn.Result.Interfaces)
 	if err != nil {
 		return err
 	}
 
-	for i, contVeth := range contVeths {
+	for i, contLink := range contLinks {
 		// Remove ebtables DHCP rules
-		if err := updateEbTables(contVeth.Attrs().Name, "-D"); err != nil {
+		if err := updateEbTables(contLink.Attrs().Name, "-D"); err != nil {
 			return nil
 		}
 
@@ -722,7 +780,7 @@ func (csn *ContainerSideNetwork) Teardown() error {
 			return err
 		}
 
-		if err := TeardownBridge(br, []netlink.Link{contVeth, tap}); err != nil {
+		if err := TeardownBridge(br, []netlink.Link{contLink, tap}); err != nil {
 			return err
 		}
 
@@ -738,11 +796,11 @@ func (csn *ContainerSideNetwork) Teardown() error {
 			return err
 		}
 
-		if err := SetHardwareAddr(contVeth, csn.HardwareAddrs[i]); err != nil {
+		if err := SetHardwareAddr(contLink, csn.HardwareAddrs[i]); err != nil {
 			return err
 		}
 
-		if err := ConfigureLink(contVeth, i, csn.Result); err != nil {
+		if err := ConfigureLink(contLink, i, csn.Result); err != nil {
 			return err
 		}
 	}

--- a/pkg/nettools/nettools.go
+++ b/pkg/nettools/nettools.go
@@ -692,6 +692,9 @@ func RecreateContainerSideNetwork(info *cnicurrent.Result) (*ContainerSideNetwor
 	)
 
 	for i, iface := range info.Interfaces {
+		if iface.Sandbox == "" {
+			continue
+		}
 		hwAddr, err := net.ParseMAC(iface.Mac)
 		if err != nil {
 			return nil, fmt.Errorf("invalid mac address %q: %v", iface.Mac, err)

--- a/pkg/nettools/nettools.go
+++ b/pkg/nettools/nettools.go
@@ -396,7 +396,7 @@ func ValidateAndfixCNIResult(netConfig *cnicurrent.Result, podNs string) error {
 				netConfig.Interfaces = append(netConfig.Interfaces, &cnicurrent.Interface{
 					Name:    link.Attrs().Name,
 					Mac:     link.Attrs().HardwareAddr.String(),
-					Sandbox: cni.PodNetNSPath(podNs),
+					Sandbox: podNs,
 				})
 				ipConfig.Interface = len(alreadyDefindeLinks)
 				alreadyDefindeLinks = append(alreadyDefindeLinks, link)
@@ -491,7 +491,7 @@ func ExtractLinkInfo(link netlink.Link, podNs string) (*cnicurrent.Result, error
 			{
 				Name:    link.Attrs().Name,
 				Mac:     link.Attrs().HardwareAddr.String(),
-				Sandbox: cni.PodNetNSPath(podNs),
+				Sandbox: podNs,
 			},
 		},
 		IPs: []*cnicurrent.IPConfig{

--- a/pkg/nettools/nettools_test.go
+++ b/pkg/nettools/nettools_test.go
@@ -41,7 +41,8 @@ var expectedExtractedLinkInfo = cnicurrent.Result{
 		{
 			Name: "eth0",
 			Mac:  innerHwAddr,
-			// TODO: Sandbox
+			// Sandbox is contNs dependent
+			// so it must be set in runtime
 		},
 	},
 	IPs: []*cnicurrent.IPConfig{
@@ -335,7 +336,14 @@ func TestStripLink(t *testing.T) {
 
 func TestExtractLinkInfo(t *testing.T) {
 	withFakeCNIVeth(t, func(hostNS, contNS ns.NetNS, origHostVeth, origContVeth netlink.Link) {
-		info, err := ExtractLinkInfo(origContVeth)
+		info, err := ExtractLinkInfo(origContVeth, contNS.Path())
+
+		// Sandbox is contNS dependent so it must be set there
+		// for each interface in expected info
+		for _, iface := range expectedExtractedLinkInfo.Interfaces {
+			iface.Sandbox = contNS.Path()
+		}
+
 		if err != nil {
 			log.Panicf("failed to grab interface info: %v", err)
 		}

--- a/pkg/nettools/nettools_test.go
+++ b/pkg/nettools/nettools_test.go
@@ -346,9 +346,9 @@ func TestExtractLinkInfo(t *testing.T) {
 	})
 }
 
-func verifyContainerSideNetwork(t *testing.T, origContVeth netlink.Link, info *cnicurrent.Result) {
+func verifyContainerSideNetwork(t *testing.T, origContVeth netlink.Link) {
 	origHwAddr := origContVeth.Attrs().HardwareAddr
-	csn, err := SetupContainerSideNetwork(info)
+	csn, err := SetupContainerSideNetwork(&expectedExtractedLinkInfo)
 	if err != nil {
 		log.Panicf("failed to set up container side network: %v", err)
 	}
@@ -389,24 +389,18 @@ func verifyContainerSideNetwork(t *testing.T, origContVeth netlink.Link, info *c
 	}
 }
 
-func TestSetUpContainerSideNetwork(t *testing.T) {
-	withFakeCNIVeth(t, func(hostNS, contNS ns.NetNS, origHostVeth, origContVeth netlink.Link) {
-		verifyContainerSideNetwork(t, origContVeth, nil)
-	})
-}
-
 func TestSetUpContainerSideNetworkWithInfo(t *testing.T) {
 	withFakeCNIVeth(t, func(hostNS, contNS ns.NetNS, origHostVeth, origContVeth netlink.Link) {
 		if err := StripLink(origContVeth); err != nil {
 			log.Panicf("StripLink() failed: %v", err)
 		}
-		verifyContainerSideNetwork(t, origContVeth, &expectedExtractedLinkInfo)
+		verifyContainerSideNetwork(t, origContVeth)
 	})
 }
 
 func TestLoopbackInterface(t *testing.T) {
 	withFakeCNIVeth(t, func(hostNS, contNS ns.NetNS, origHostVeth, origContVeth netlink.Link) {
-		verifyContainerSideNetwork(t, origContVeth, nil)
+		verifyContainerSideNetwork(t, origContVeth)
 		if out, err := exec.Command("ping", "-c", "1", "127.0.0.1").CombinedOutput(); err != nil {
 			log.Panicf("ping 127.0.0.1 failed:\n%s", out)
 		}

--- a/pkg/tapmanager/tapfdsource.go
+++ b/pkg/tapmanager/tapfdsource.go
@@ -158,7 +158,7 @@ func (s *TapFDSource) GetFDs(key string, data []byte) ([]int, []byte, error) {
 		if netConfig == nil {
 			netConfig = &cnicurrent.Result{}
 		}
-		if err := nettools.ValidateAndfixCNIResult(netConfig); err != nil {
+		if err := nettools.ValidateAndfixCNIResult(netConfig, pnd.PodNs); err != nil {
 			return nil, nil, fmt.Errorf("error in fixing cni configuration: %v", err)
 		}
 

--- a/pkg/tapmanager/tapfdsource.go
+++ b/pkg/tapmanager/tapfdsource.go
@@ -155,6 +155,13 @@ func (s *TapFDSource) GetFDs(key string, data []byte) ([]int, []byte, error) {
 		}
 		glog.V(3).Infof("CNI configuration for pod %s (%s): %s", pnd.PodName, pnd.PodId, spew.Sdump(netConfig))
 
+		if netConfig == nil {
+			netConfig = &cnicurrent.Result{}
+		}
+		if err := nettools.ValidateAndfixCNIResult(netConfig); err != nil {
+			return nil, nil, fmt.Errorf("error in fixing cni configuration: %v", err)
+		}
+
 		if payload.Description.DNS != nil {
 			netConfig.DNS.Nameservers = pnd.DNS.Nameservers
 			netConfig.DNS.Search = pnd.DNS.Search
@@ -205,13 +212,6 @@ func (s *TapFDSource) GetFDs(key string, data []byte) ([]int, []byte, error) {
 		if err != nil {
 			return err
 		}
-
-		// NOTE: older CNI plugins don't include the hardware address
-		// in Result, but it's needed for Cloud-Init based
-		// network setup, so we add it here if it's missing.
-		// Also, some of the plugins may skip adding routes
-		// to the CNI result, so we must add them, too
-		fixCNIResult(netConfig, csn)
 
 		dhcpServer, err = dhcp.NewServer(csn.Result)
 		if err != nil {
@@ -320,35 +320,6 @@ func (s *TapFDSource) GetInfo(key string) ([]byte, error) {
 		return nil, fmt.Errorf("interface descriptions marshaling error: %v", err)
 	}
 	return data, nil
-}
-
-func fixCNIResult(netConfig *cnicurrent.Result, csn *nettools.ContainerSideNetwork) {
-	// If there's no interface info in netConfig, we can assume that we're dealing
-	// with an old-style CNI plugin which only supports a single network interface
-	if len(netConfig.Interfaces) > 0 {
-		return
-	}
-
-	// TODO: get real interface name from links scan for matching mac add
-	// instead of generating fake one
-	for i, mac := range csn.HardwareAddrs {
-		name := fmt.Sprintf("cni%d", i)
-		iface := &cnicurrent.Interface{
-			Name: name,
-			Mac:  mac.String(),
-		}
-		netConfig.Interfaces = append(netConfig.Interfaces, iface)
-	}
-
-	// TODO: scan interfaces for matching ip addresses instead of setting first interface
-	// as the target for ip address
-	for _, IP := range netConfig.IPs {
-		IP.Interface = 0
-	}
-
-	if len(netConfig.Routes) == 0 {
-		netConfig.Routes = csn.Result.Routes
-	}
 }
 
 func netmaskForCalico() net.IPMask {

--- a/pkg/tapmanager/tapfdsource.go
+++ b/pkg/tapmanager/tapfdsource.go
@@ -178,7 +178,7 @@ func (s *TapFDSource) GetFDs(key string, data []byte) ([]int, []byte, error) {
 			return nil, nil, errors.New("didn't expect more than one IP config")
 		}
 		if netConfig.IPs[0].Version != "4" {
-			return nil, nil, errors.New("IPv3 config was expected")
+			return nil, nil, errors.New("IPv4 config was expected")
 		}
 		netConfig.IPs[0].Address.Mask = netmaskForCalico()
 		netConfig.IPs[0].Gateway = s.dummyGateway

--- a/tests/network/dhcp_test.go
+++ b/tests/network/dhcp_test.go
@@ -43,7 +43,8 @@ func TestDhcpServer(t *testing.T) {
 					{
 						Name: "eth0",
 						Mac:  clientMacAddress,
-						// TODO: Sandbox
+						// Sandbox is clientNS dependent
+						// so it must be set in runtime
 					},
 				},
 				IPs: []*cnicurrent.IPConfig{
@@ -111,6 +112,12 @@ func runDhcpTestCase(t *testing.T, testCase *dhcpTestCase) {
 		t.Fatalf("Failed to create ns for dhcp client: %v", err)
 	}
 	defer clientNS.Close()
+
+	// Sandbox is clientNS dependent so it needs to be set there on all interfaces
+	for _, iface := range testCase.info.Interfaces {
+		iface.Sandbox = clientNS.Path()
+	}
+
 	var clientVeth, serverVeth netlink.Link
 	if err := serverNS.Do(func(ns.NetNS) error {
 		serverVeth, clientVeth, err = nettools.CreateEscapeVethPair(clientNS, "veth0", 1500)

--- a/tests/network/vm_network_test.go
+++ b/tests/network/vm_network_test.go
@@ -72,9 +72,9 @@ func TestVmNetwork(t *testing.T) {
 	info := &cnicurrent.Result{
 		Interfaces: []*cnicurrent.Interface{
 			{
-				Name: "eth0",
-				Mac:  clientMacAddress,
-				// TODO: Sandbox
+				Name:    "eth0",
+				Mac:     clientMacAddress,
+				Sandbox: contNS.Path(),
 			},
 		},
 		IPs: []*cnicurrent.IPConfig{


### PR DESCRIPTION
After rethinking: that's based on wrong approach. Requires a new logic to extract info about network interfaces in container namespace (already coded in separate branch) and a method to correlate internal with external interfaces. 


---- 
This change should improve overal support for cni plugins returning [Result](https://github.com/containernetworking/cni/blob/master/SPEC.md#result)
in form compatible with v0.2.0 of cni specification.

E.g. of such plugin is `bridge` used in our e2e, but also [SR-IOV](https://github.com/hustcat/sriov-cni/issues/22).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/502)
<!-- Reviewable:end -->
