### PR TITLE
Add support for SR-IOV cni plugin

### DIFF
--- a/cmd/vmwrapper/vmwrapper.go
+++ b/cmd/vmwrapper/vmwrapper.go
@@ -21,11 +21,13 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"syscall"
 
 	"github.com/golang/glog"
 
+	"github.com/Mirantis/virtlet/pkg/nettools"
 	"github.com/Mirantis/virtlet/pkg/tapmanager"
 	"github.com/Mirantis/virtlet/pkg/utils"
 )
@@ -118,6 +120,19 @@ const (
 	vmsProcFile     = "/var/lib/virtlet/vms.procfile"
 )
 
+func extractLastUsedPCIAddress(args []string) int {
+	var lastUsed int
+	for _, arg := range args {
+		i := strings.LastIndex(arg, "addr=0x")
+		if i < 0 {
+			continue
+		}
+		parsed, _ := strconv.ParseInt(arg[i+7:], 16, 32)
+		lastUsed = int(parsed)
+	}
+	return lastUsed
+}
+
 func main() {
 	// configure glog (apparently no better way to do it ...)
 	flag.CommandLine.Parse([]string{"-v=3", "-alsologtostderr=true"})
@@ -151,6 +166,8 @@ func main() {
 		emulator = defaultEmulator
 	} else {
 		netFdKey := os.Getenv(netKeyEnvVar)
+		nextToUsePCIAddress := extractLastUsedPCIAddress(os.Args[1:]) + 1
+		nextToUseHostdevNo := 0
 
 		if netFdKey != "" {
 			c := tapmanager.NewFDClient(fdSocketPath)
@@ -158,7 +175,7 @@ func main() {
 				glog.Errorf("Can't connect to fd server: %v", err)
 				os.Exit(1)
 			}
-			tapFds, marshaledData, err := c.GetFDs(netFdKey)
+			fds, marshaledData, err := c.GetFDs(netFdKey)
 			if err != nil {
 				glog.Errorf("Failed to obtain tap fds for key %q: %v", netFdKey, err)
 				os.Exit(1)
@@ -171,13 +188,30 @@ func main() {
 			}
 
 			for i, desc := range descriptions {
-				if desc.Type == tapmanager.InterfaceTypeTap {
+				switch desc.Type {
+				case nettools.InterfaceTypeTap:
 					netArgs = append(netArgs,
 						"-netdev",
-						fmt.Sprintf("tap,id=tap%d,fd=%d", desc.TapFdIndex, tapFds[desc.TapFdIndex]),
+						fmt.Sprintf("tap,id=tap%d,fd=%d", desc.FdIndex, fds[desc.FdIndex]),
 						"-device",
-						fmt.Sprintf("virtio-net-pci,netdev=tap%d,id=net%d,mac=%s", desc.TapFdIndex, i, desc.HardwareAddr),
+						fmt.Sprintf("virtio-net-pci,netdev=tap%d,id=net%d,mac=%s", desc.FdIndex, i, desc.HardwareAddr),
 					)
+				case nettools.InterfaceTypeVF:
+					netArgs = append(netArgs,
+						"-device",
+						fmt.Sprintf("pci-assign,configfd=%d,host=%s,id=hostdev%d,bus=pci.0,addr=0x%x",
+							desc.FdIndex,
+							desc.PCIAddress,
+							nextToUseHostdevNo,
+							nextToUsePCIAddress,
+						),
+					)
+					nextToUseHostdevNo += 1
+					nextToUsePCIAddress += 1
+				default:
+					// Impssible situation when tapmanager is built from other sources than vmwrapper
+					glog.Errorf("Received unknown interface type: %d", int(desc.Type))
+					os.Exit(1)
 				}
 			}
 		}

--- a/images/image_skel/vms.sh
+++ b/images/image_skel/vms.sh
@@ -11,5 +11,8 @@ elif [[ -e /dev/kvm ]]; then
   chown libvirt-qemu.kvm /dev/kvm
 fi
 
+# FIXME: temporary hack for sr-iov
+chmod u+s /usr/bin/qemu-system-x86_64
+
 echo "$$ $(cut -d' ' -f22 /proc/$$/stat)" >/var/lib/virtlet/vms.procfile
 sleep Infinity

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -330,7 +330,7 @@ func (v *VirtletManager) PodSandboxStatus(ctx context.Context, in *kubeapi.PodSa
 
 func (v *VirtletManager) ListPodSandbox(ctx context.Context, in *kubeapi.ListPodSandboxRequest) (*kubeapi.ListPodSandboxResponse, error) {
 	filter := in.GetFilter()
-	glog.V(3).Infof("Listing sandboxes with filter: %s", spew.Sdump(filter))
+	glog.V(4).Infof("Listing sandboxes with filter: %s", spew.Sdump(filter))
 	sandboxes, err := v.metadataStore.ListPodSandboxes(filter)
 	if err != nil {
 		glog.Errorf("Error when listing (with filter: %s) pod sandboxes: %v", spew.Sdump(filter), err)
@@ -347,7 +347,7 @@ func (v *VirtletManager) ListPodSandbox(ctx context.Context, in *kubeapi.ListPod
 		}
 	}
 	response := &kubeapi.ListPodSandboxResponse{Items: podSandboxList}
-	glog.V(3).Infof("ListPodSandbox response: %s", spew.Sdump(response))
+	glog.V(4).Infof("ListPodSandbox response: %s", spew.Sdump(response))
 	return response, nil
 }
 
@@ -448,15 +448,15 @@ func (v *VirtletManager) RemoveContainer(ctx context.Context, in *kubeapi.Remove
 
 func (v *VirtletManager) ListContainers(ctx context.Context, in *kubeapi.ListContainersRequest) (*kubeapi.ListContainersResponse, error) {
 	filter := in.GetFilter()
-	glog.V(3).Infof("Listing containers with filter: %s", spew.Sdump(filter))
-	glog.V(3).Infof("ListContainers: %s", spew.Sdump(in))
+	glog.V(4).Infof("Listing containers with filter: %s", spew.Sdump(filter))
+	glog.V(4).Infof("ListContainers: %s", spew.Sdump(in))
 	containers, err := v.libvirtVirtualizationTool.ListContainers(filter)
 	if err != nil {
 		glog.Errorf("Error when listing containers with filter %s: %v", spew.Sdump(filter), err)
 		return nil, err
 	}
 	response := &kubeapi.ListContainersResponse{Containers: containers}
-	glog.V(3).Infof("ListContainers response:\n%s\n", spew.Sdump(response))
+	glog.V(4).Infof("ListContainers response:\n%s\n", spew.Sdump(response))
 	return response, nil
 }
 
@@ -583,7 +583,7 @@ func (v *VirtletManager) ListImages(ctx context.Context, in *kubeapi.ListImagesR
 	}
 
 	response := &kubeapi.ListImagesResponse{Images: images}
-	glog.V(3).Infof("ListImages response: %s", spew.Sdump(response))
+	glog.V(4).Infof("ListImages response: %s", spew.Sdump(response))
 	return response, err
 }
 

--- a/pkg/nettools/nettools.go
+++ b/pkg/nettools/nettools.go
@@ -41,6 +41,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"syscall"
 	"unsafe"
 
@@ -63,6 +64,14 @@ const (
 
 	SizeOfIfReq = 40
 	IFNAMSIZ    = 16
+)
+
+// InterfaceType presents type of network interface instance
+type InterfaceType int
+
+const (
+	InterfaceTypeTap InterfaceType = iota
+	InterfaceTypeVF
 )
 
 // Had to duplicate ifReq here as it's not exported
@@ -417,7 +426,7 @@ func findLinkByName(links []netlink.Link, name string) (netlink.Link, error) {
 	return nil, fmt.Errorf("interface with name %q not found in container namespace", name)
 }
 
-// GetContainerLinks locates in container namespac enetwork links
+// GetContainerLinks locates in container namespace network links
 // for provided interfaces
 func GetContainerLinks(interfaces []*cnicurrent.Interface) ([]netlink.Link, error) {
 	allLinks, err := netlink.LinkList()
@@ -427,6 +436,7 @@ func GetContainerLinks(interfaces []*cnicurrent.Interface) ([]netlink.Link, erro
 
 	var links []netlink.Link
 	for _, iface := range interfaces {
+		// if Sandbox is empty interface is on host, not in container netns
 		if iface.Sandbox == "" {
 			continue
 		}
@@ -604,10 +614,67 @@ type ContainerSideNetwork struct {
 	NsPath string
 	// TapFiles contains a list of open File objects pointing to tap
 	// devices inside the network namespace
-	TapFiles []*os.File
+	Fds []*os.File
 	// HardwareAddrs contains a list of original hardware addresses of
 	// CNI-created veth links
 	HardwareAddrs []net.HardwareAddr
+	// InterfaceTypes contains a list of interface types corresponding to
+	// list of hardware addresses
+	InterfaceTypes []InterfaceType
+	// PCIAddresses contains a list of pci addresses for sr-iov vf interfaces
+	// or empty strings for other types of interfaces
+	PCIAddresses []string
+	// InterfaceNames contains a list of interfaces names for sr-iov interfaces
+	InterfaceNames []string
+}
+
+// verify if device is pci virtual function (in the same way as does
+// that libvirt (src/util/virpci.c:virPCIIsVirtualFunction)
+func isSriovVf(link netlink.Link) bool {
+	_, err := os.Stat(filepath.Join("/sys/class/net", link.Attrs().Name, "device/physfn"))
+	return err == nil
+}
+
+func openVfConfigFile(devName string) (*os.File, error) {
+	return os.OpenFile(filepath.Join("/sys/bus/pci/devices", devName, "config"), os.O_RDWR, 0644)
+}
+
+func getPCIAddressOfVF(devName string) (string, error) {
+	linkDestination, err := os.Readlink(filepath.Join("/sys/class/net", devName, "device"))
+	if err != nil {
+		return "", err
+	}
+	if linkDestination[:13] != "../../../0000" {
+		return "", fmt.Errorf("unknown address as device symlink: %q", linkDestination)
+	}
+	// we need pci address without leading "0000:"
+	return linkDestination[9:], nil
+}
+
+func writeStringToFile(s, path string, mode os.FileMode) error {
+	f, err := os.OpenFile(path, os.O_WRONLY, mode)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.WriteString(s)
+	return err
+}
+
+func unbindDriverFromDevice(devName string) error {
+	return writeStringToFile(
+		devName,
+		filepath.Join("/sys/bus/pci/devices", devName, "driver/unbind"),
+		0200,
+	)
+}
+
+func rebindDriverToDevice(devName string) error {
+	return writeStringToFile(
+		devName,
+		"/sys/bus/pci/drivers_probe",
+		0200,
+	)
 }
 
 // SetupContainerSideNetwork sets up networking in container
@@ -618,8 +685,9 @@ type ContainerSideNetwork struct {
 // with X denoting an link index in info.Interfaces list.
 // Each bridge gets assigned a link-local address to be used
 // for dhcp server.
+// For SR-IOV VFs this function only prepares device to pass it to VM.
 // The function should be called from within container namespace.
-// Returns container network struct and an error, if any
+// Returns container network struct and an error, if any.
 func SetupContainerSideNetwork(info *cnicurrent.Result, nsPath string) (*ContainerSideNetwork, error) {
 	contLinks, err := GetContainerLinks(info.Interfaces)
 	if err != nil {
@@ -627,18 +695,56 @@ func SetupContainerSideNetwork(info *cnicurrent.Result, nsPath string) (*Contain
 	}
 
 	var (
-		tapFiles []*os.File
-		hwAddrs  []net.HardwareAddr
+		fds          []*os.File
+		hwAddrs      []net.HardwareAddr
+		ifaceTypes   []InterfaceType
+		pciAddresses []string
+		ifaceNames   []string
 	)
 
 	for i, link := range contLinks {
 		hwAddr := link.Attrs().HardwareAddr
+		hwAddrs = append(hwAddrs, hwAddr)
+
+		if isSriovVf(link) {
+			if err := StripLink(link); err != nil {
+				return nil, err
+			}
+
+			devName := link.Attrs().Name
+
+			pciAddress, err := getPCIAddressOfVF(devName)
+			if err != nil {
+				return nil, err
+			}
+
+			fd, err := openVfConfigFile(pciAddress)
+			if err != nil {
+				return nil, err
+			}
+			fds = append(fds, fd)
+
+			if err := unbindDriverFromDevice(pciAddress); err != nil {
+				return nil, err
+			}
+
+			pciAddresses = append(pciAddresses, pciAddress)
+			ifaceNames = append(ifaceNames, link.Attrs().Name)
+
+			ifaceTypes = append(ifaceTypes, InterfaceTypeVF)
+			glog.V(3).Infof("Adding interface %q as VF on %s address", link.Attrs().Name, pciAddresses)
+
+			continue
+		}
+		pciAddresses = append(pciAddresses, "")
+		ifaceNames = append(ifaceNames, "")
+
 		newHwAddr, err := GenerateMacAddress()
 		if err == nil {
-			err = SetHardwareAddr(link, newHwAddr)
+			err = StripLink(link)
 		}
 		if err == nil {
-			err = StripLink(link)
+			err = SetHardwareAddr(link, newHwAddr)
 		}
 		if err != nil {
 			return nil, err
@@ -692,12 +798,13 @@ func SetupContainerSideNetwork(info *cnicurrent.Result, nsPath string) (*Contain
 		if err != nil {
 			return nil, fmt.Errorf("failed to open tap: %v", err)
 		}
+		glog.V(3).Infof("Adding interface %q as %q", link.Attrs().Name, tapInterfaceName)
 
-		hwAddrs = append(hwAddrs, hwAddr)
-		tapFiles = append(tapFiles, tapFile)
+		fds = append(fds, tapFile)
+		ifaceTypes = append(ifaceTypes, InterfaceTypeTap)
 	}
 
-	return &ContainerSideNetwork{info, nsPath, tapFiles, hwAddrs}, nil
+	return &ContainerSideNetwork{info, nsPath, fds, hwAddrs, ifaceTypes, pciAddresses, ifaceNames}, nil
 }
 
 // RecreateContainerSideNetwork tries to populate ContainerSideNetwork
@@ -707,31 +814,56 @@ func RecreateContainerSideNetwork(info *cnicurrent.Result, nsPath string) (*Cont
 		return nil, fmt.Errorf("wrong cni configuration - missing interfaces list: %v", spew.Sdump(info))
 	}
 
-	var (
-		tapFiles []*os.File
-		hwAddrs  []net.HardwareAddr
-	)
-
-	for i, iface := range info.Interfaces {
-		if iface.Sandbox == "" {
-			continue
-		}
-		hwAddr, err := net.ParseMAC(iface.Mac)
-		if err != nil {
-			return nil, fmt.Errorf("invalid mac address %q: %v", iface.Mac, err)
-		}
-
-		tapInterfaceName := fmt.Sprintf(tapInterfaceNameTemplate, i)
-		tapFile, err := OpenTAP(tapInterfaceName)
-		if err != nil {
-			return nil, fmt.Errorf("failed to open tap: %v", err)
-		}
-
-		hwAddrs = append(hwAddrs, hwAddr)
-		tapFiles = append(tapFiles, tapFile)
+	// FIXME: this will not work with sr-iov device passed to VM
+	contLinks, err := GetContainerLinks(info.Interfaces)
+	if err != nil {
+		return nil, err
 	}
 
-	return &ContainerSideNetwork{info, nsPath, tapFiles, hwAddrs}, nil
+	var (
+		fds          []*os.File
+		hwAddrs      []net.HardwareAddr
+		ifaceTypes   []InterfaceType
+		pciAddresses []string
+		ifaceNames   []string
+	)
+
+	for i, link := range contLinks {
+		hwAddrs = append(hwAddrs, link.Attrs().HardwareAddr)
+		pciAddress := ""
+		ifaceName := ""
+
+		if isSriovVf(link) {
+			devName := link.Attrs().Name
+			pciAddress, err = getPCIAddressOfVF(devName)
+			if err != nil {
+				return nil, err
+			}
+
+			fd, err := openVfConfigFile(pciAddress)
+			if err != nil {
+				return nil, err
+			}
+			fds = append(fds, fd)
+
+			// device should be already unbound, but after machine reboot that can be necessary
+			_ = unbindDriverFromDevice(pciAddress)
+
+			ifaceTypes = append(ifaceTypes, InterfaceTypeVF)
+		} else {
+			tapInterfaceName := fmt.Sprintf(tapInterfaceNameTemplate, i)
+			tapFile, err := OpenTAP(tapInterfaceName)
+			if err != nil {
+				return nil, fmt.Errorf("failed to open tap: %v", err)
+			}
+			fds = append(fds, tapFile)
+			ifaceTypes = append(ifaceTypes, InterfaceTypeTap)
+		}
+		pciAddresses = append(pciAddresses, pciAddress)
+		ifaceNames = append(ifaceNames, ifaceName)
+	}
+
+	return &ContainerSideNetwork{info, nsPath, fds, hwAddrs, ifaceTypes, pciAddresses, ifaceNames}, nil
 }
 
 // TeardownBridge removes links from bridge and sets it down
@@ -789,13 +921,30 @@ func ConfigureLink(link netlink.Link, info *cnicurrent.Result) error {
 	return nil
 }
 
+func renameLink(mac, name string) error {
+	links, err := netlink.LinkList()
+	if err != nil {
+		return err
+	}
+
+	for _, link := range links {
+		if link.Attrs().HardwareAddr.String() == mac {
+			if err := netlink.LinkSetName(link, name); err != nil {
+				return err
+			}
+		}
+	}
+
+	return fmt.Errorf("link with mac address %q not found, can't rename it to %q", mac, name)
+}
+
 // Teardown cleans up container network configuration.
 // It does so by invoking teardown sequence which removes ebtables rules, links
 // and addresses in an order opposite to that of their creation in SetupContainerSideNetwork.
 // The end result is the same network configuration in the container network namespace
 // as it was before SetupContainerSideNetwork() call.
 func (csn *ContainerSideNetwork) Teardown() error {
-	for _, f := range csn.TapFiles {
+	for _, f := range csn.Fds {
 		f.Close()
 	}
 	contLinks, err := GetContainerLinks(csn.Result.Interfaces)
@@ -809,40 +958,49 @@ func (csn *ContainerSideNetwork) Teardown() error {
 			return nil
 		}
 
-		tapInterfaceName := fmt.Sprintf(tapInterfaceNameTemplate, i)
-		tap, err := netlink.LinkByName(tapInterfaceName)
-		if err != nil {
-			return err
-		}
+		if !isSriovVf(contLink) {
+			tapInterfaceName := fmt.Sprintf(tapInterfaceNameTemplate, i)
+			tap, err := netlink.LinkByName(tapInterfaceName)
+			if err != nil {
+				return err
+			}
 
-		containerBridgeName := fmt.Sprintf(containerBridgeNameTemplate, i)
-		br, err := netlink.LinkByName(containerBridgeName)
-		if err != nil {
-			return err
-		}
+			containerBridgeName := fmt.Sprintf(containerBridgeNameTemplate, i)
+			br, err := netlink.LinkByName(containerBridgeName)
+			if err != nil {
+				return err
+			}
 
-		if err := netlink.AddrDel(br, mustParseAddr(internalDhcpAddr)); err != nil {
-			return err
-		}
+			if err := netlink.AddrDel(br, mustParseAddr(internalDhcpAddr)); err != nil {
+				return err
+			}
 
-		if err := TeardownBridge(br, []netlink.Link{contLink, tap}); err != nil {
-			return err
-		}
+			if err := TeardownBridge(br, []netlink.Link{contLink, tap}); err != nil {
+				return err
+			}
 
-		if err := netlink.LinkDel(br); err != nil {
-			return err
-		}
+			if err := netlink.LinkDel(br); err != nil {
+				return err
+			}
 
-		if err := netlink.LinkSetDown(tap); err != nil {
-			return err
-		}
+			if err := netlink.LinkSetDown(tap); err != nil {
+				return err
+			}
 
-		if err := netlink.LinkDel(tap); err != nil {
-			return err
-		}
+			if err := netlink.LinkDel(tap); err != nil {
+				return err
+			}
 
-		if err := SetHardwareAddr(contLink, csn.HardwareAddrs[i]); err != nil {
-			return err
+			if err := SetHardwareAddr(contLink, csn.HardwareAddrs[i]); err != nil {
+				return err
+			}
+		} else {
+			if err := rebindDriverToDevice(csn.PCIAddresses[i]); err != nil {
+				return err
+			}
+			if err := renameLink(csn.HardwareAddrs[i].String(), csn.InterfaceNames[i]); err != nil {
+				return err
+			}
 		}
 
 		rereadedLink, err := netlink.LinkByName(contLink.Attrs().Name)


### PR DESCRIPTION
Do not merge before #508 on which this one depends.

Thinks which need additional work:
* [ ] replace suid bit hack with proper propagation of rights for accessing pci devices by qemu (code for `configfd` already in sources, but even after passing it through tapmanager/vmwrapper - there is an access error)
* [ ] `RecreateContainerSideNetwork` depends on possibility to look on interfaces in container namespace, but when one is passed to VM it's disconnected from host. Better way of that would be to serialize full csn to metadatastore and deserialize in during this recreate, so there would be no need to try to guess pci address from the sysfs
* [ ] `csn.Teardown` rebinds interface kernel driver, but device is probably visible only on host and this func is called in container namespace. Also even on host it probably will have other mac address than our autogenerated (which is now used to find device), so instead of finding it using mac address it probably needs to be located on `TapFDSource.Release` level by pci address, moved to container namespace and at the end renamed using name expected by cni plugin.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/503)
<!-- Reviewable:end -->
