### PR TITLE
Fix cni conflist handling

### DIFF
--- a/pkg/cni/configuration.go
+++ b/pkg/cni/configuration.go
@@ -12,6 +12,22 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+Based on code from Kubernetes project, pkg/kubelet/network/cni/cni.go
+
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package cni
@@ -19,23 +35,55 @@ package cni
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/containernetworking/cni/libcni"
+	"github.com/golang/glog"
 )
 
-func ReadConfiguration(configsDir string) (*libcni.NetworkConfig, error) {
-	confFileNames, err := libcni.ConfFiles(configsDir, []string{".conf", ".conflist", ".json"})
-	if err != nil {
+func ReadConfiguration(configDir string) (*libcni.NetworkConfigList, error) {
+	files, err := libcni.ConfFiles(configDir, []string{".conf", ".conflist", ".json"})
+	switch {
+	case err != nil:
 		return nil, err
+	case len(files) == 0:
+		return nil, fmt.Errorf("No networks found in %s", configDir)
 	}
 
-	if confFileNames == nil {
-		return nil, fmt.Errorf("can not find any CNI configuration in directory: %s", configsDir)
+	sort.Strings(files)
+	for _, confFile := range files {
+		var confList *libcni.NetworkConfigList
+		if strings.HasSuffix(confFile, ".conflist") {
+			confList, err = libcni.ConfListFromFile(confFile)
+			if err != nil {
+				glog.Warningf("Error loading CNI config list file %s: %v", confFile, err)
+				continue
+			}
+		} else {
+			conf, err := libcni.ConfFromFile(confFile)
+			if err != nil {
+				glog.Warningf("Error loading CNI config file %s: %v", confFile, err)
+				continue
+			}
+			// Ensure the config has a "type" so we know what plugin to run.
+			// Also catches the case where somebody put a conflist into a conf file.
+			if conf.Network.Type == "" {
+				glog.Warningf("Error loading CNI config file %s: no 'type'; perhaps this is a .conflist?", confFile)
+				continue
+			}
+
+			confList, err = libcni.ConfListFromConf(conf)
+			if err != nil {
+				glog.Warningf("Error converting CNI config file %s to list: %v", confFile, err)
+				continue
+			}
+		}
+		if len(confList.Plugins) == 0 {
+			glog.Warningf("CNI config list %s has no networks, skipping", confFile)
+			continue
+		}
+		// TODO: vendor dir handling (see pkg/kubelet/network/cni/cni.go)
+		return confList, err
 	}
-
-	sort.Strings(confFileNames)
-
-	// TODO: read all the conf files
-	// see pkg/kubelet/network/cni/cni.go in k8s
-	return libcni.ConfFromFile(confFileNames[0])
+	return nil, fmt.Errorf("No valid networks found in %s", configDir)
 }


### PR DESCRIPTION
This is done by following current kubelet behavior more closely.
The problem became apparent with Flannel 0.9.1 update which
made use of 'portmap' plugin which is configured in a single
conflist file with the main 'flannel' plugin.
As portmap is needed for hostPort feature, there's high possibility that
other CNIs could become broken soon.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/516)
<!-- Reviewable:end -->
