### PR TITLE
Fix multiple volume mounting in Virtlet

### DIFF
--- a/cmd/flexvolume_driver/flexvolume_driver.go
+++ b/cmd/flexvolume_driver/flexvolume_driver.go
@@ -17,13 +17,16 @@ limitations under the License.
 package main
 
 import (
+	"math/rand"
 	"os"
+	"time"
 
 	"github.com/Mirantis/virtlet/pkg/flexvolume"
 	"github.com/Mirantis/virtlet/pkg/utils"
 )
 
 func main() {
+	rand.Seed(time.Now().UnixNano())
 	driver := flexvolume.NewFlexVolumeDriver(utils.NewUuid, flexvolume.NewLinuxMounter())
 	os.Stdout.WriteString(driver.Run(os.Args[1:]))
 }

--- a/docs/cloud-init-data-generation.md
+++ b/docs/cloud-init-data-generation.md
@@ -204,11 +204,12 @@ The `user-data` content is generated as follows:
   container and pod's volumes that are `flexVolume`s and use
   `virtlet/flexvolume_driver`. These are seen as block devices by the
   VM and Virtlet mounts them into appropriate directories
-* `write_files` are generated based on configmaps and secrets
-  mounted into the container. It also includes `/etc/cloud/environment` file
-  (see [Environment variable support](environment-variables.md) for more info)
-  and optionally `/etc/cloud/mount-volumes.sh` that can be used to
-  mount volumes on systems without udev (see Workarounds for volume mounting below)
+* `write_files` are generated based on configmaps and secrets mounted
+  into the container. It also includes `/etc/cloud/environment` file
+  (see [Environment variable support](environment-variables.md) for
+  more info) and optionally `/etc/cloud/mount-volumes.sh` that can be
+  used to mount volumes on systems without udev (see
+  [Workarounds for volume mounting](#workarounds) below)
 * the yaml content specified using optional `VirtletCloudInitUserData`
   annotation as well as the content from Secret or ConfigMap specified
   using another optional `VirtletCloudInitUserDataSource` annotation
@@ -226,8 +227,8 @@ The `user-data` content is generated as follows:
   useful if you want to pass a script there which may be necessary for
   older/simpler cloud-init implementations such as one used by CirrOS.
   Within the content of this script, `@virtlet-mount-script@` can be
-  replaced with volume mounting shell commands (see Workarounds for
-  volume mounting below)
+  replaced with volume mounting shell commands (see
+  [Workarounds for volume mounting](#workarounds) below)
 
 ## Propagating user-data from kubernetes objects
 
@@ -247,7 +248,7 @@ containing SSH keys in the same format in `VirtletSSHKeys`. The `key` part is op
 `virtlet` will look for the `authorized_keys` key. As with the `user-data` `VirtletSSHKeys` keys are going to be appended to those from
 `VirtletSSHKeySource` unless it is set to overwrite them by `VirtletCloudInitUserData: "true"`.
 
-## Workarounds for volume mounting
+## <a name="workarounds"></a>Workarounds for volume mounting
 
 Currenly Virtlet uses `/dev/disk/by-path` to mount volumes specified
 using Virtlet flexvolume driver. There's a problem with this approach

--- a/docs/cloud-init-data-generation.md
+++ b/docs/cloud-init-data-generation.md
@@ -205,7 +205,10 @@ The `user-data` content is generated as follows:
   `virtlet/flexvolume_driver`. These are seen as block devices by the
   VM and Virtlet mounts them into appropriate directories
 * `write_files` are generated based on configmaps and secrets
-  mounted into the container
+  mounted into the container. It also includes `/etc/cloud/environment` file
+  (see [Environment variable support](environment-variables.md) for more info)
+  and optionally `/etc/cloud/mount-volumes.sh` that can be used to
+  mount volumes on systems without udev (see Workarounds for volume mounting below)
 * the yaml content specified using optional `VirtletCloudInitUserData`
   annotation as well as the content from Secret or ConfigMap specified
   using another optional `VirtletCloudInitUserDataSource` annotation
@@ -222,6 +225,9 @@ The `user-data` content is generated as follows:
   by adding `VirtletCloudInitUserDataScript` option. This may be
   useful if you want to pass a script there which may be necessary for
   older/simpler cloud-init implementations such as one used by CirrOS.
+  Within the content of this script, `@virtlet-mount-script@` can be
+  replaced with volume mounting shell commands (see Workarounds for
+  volume mounting below)
 
 ## Propagating user-data from kubernetes objects
 
@@ -241,6 +247,31 @@ containing SSH keys in the same format in `VirtletSSHKeys`. The `key` part is op
 `virtlet` will look for the `authorized_keys` key. As with the `user-data` `VirtletSSHKeys` keys are going to be appended to those from
 `VirtletSSHKeySource` unless it is set to overwrite them by `VirtletCloudInitUserData: "true"`.
 
+## Workarounds for volume mounting
+
+Currenly Virtlet uses `/dev/disk/by-path` to mount volumes specified
+using Virtlet flexvolume driver. There's a problem with this approach
+however, namely that this depends on `udev` being used by the guest
+system. Moreover, some images (e.g. CirrOS example image) may have
+limited cloud-init support and may not provide proper `user-data`
+handling necessary to mount the block devices. To handle the first of
+this problem, Virtlet uses `write_files` section of `user-data` to
+write a shell script named `/etc/cloud/mount-volumes.sh` (the script
+uses `/bin/sh`) that performs the necessary volume mounts using sysfs
+to look up the proper device names under `/dev`. The script also
+checks whether the volumes are already mounted so as not to mount them
+several times (so it's idempotent). To deal with the systems without
+proper `user-data` support such as CirrOS, Virtlet makes it possible
+to specify `@virtlet-mount-script@` inside
+`VirtletCloudInitUserDataScript` annotation. This string will be
+replaced with the content that's normally written to
+`/etc/cloud/mount-volumes.sh`. Given that the script starts with
+`#!/bin/sh`, you can use the following construct in the pod
+annotations:
+
+```yaml
+VirtletCloudInitUserDataScript: "@virtlet-mount-script@"
+```
 
 ## Additional links
 

--- a/docs/volumes.md
+++ b/docs/volumes.md
@@ -402,6 +402,10 @@ so it's treated as a string when parsing yaml. Below is an example:
         part: "2"
 ```
 
+For guest OSes with limited cloud-init support, there's workaround for
+mounting the volumes by means of user data script. See
+[Workarounds for volume mounting](cloud-init-data-generation.md#workarounds).
+
 ## Injecting Secret and ConfigMap content into the VMs as files
 
 Virtlet supports the standard `volumeMounts` notation for placing ConfigMap

--- a/docs/volumes.md
+++ b/docs/volumes.md
@@ -66,24 +66,16 @@ CD-ROM and all the flexvolume types that Virtlet supports.
 </domain>
 ```
 
-Virtlet tries to do its best so as to make the disk names specified in
-the domain definition to match the devices inside VM in case of Linux
-system.  This will be the case with most Linux images when using
-`virtio-scsi` driver, but in case of `virtio-blk` it depends on
-whether the device naming/numbering in the VM follows the numbering of
-PCI slots used for `virtio-blk` devices. We didn't study this part
-well enough yet.
-
 3. The attached disks are visible by the OS inside VM as hard disk
    devices `/dev/sdb`, `/dev/sdc` and so on (`/dev/vdb`, `/dev/vdc`
-   and so on in case of `virtio-blk`). As said above there is no fixed
-   behavior for device names and their order on the PCI bus.
-4. As with the majority of other guest OS functionality, Virtlet
-   doesn't give any guarantee about the possibility of mounting
-   flexvolumes into the VM. This depends on the cloud-init
-   functionality supported by the image used. Also note that Virtlet
-   doesn't perform any checks on the guest OS side to ensure that
-   volume mounting succeeded.
+   and so on in case of `virtio-blk`). Note that the naming of the
+   devices inside guest OS is usually unpredictable.  The use of
+   Virtlet-generated
+   [cloud-init data](cloud-init-data-generation.md#workarounds) is
+   recommended for mounting of the volumes. Virtlet uses udev-provided
+   `/dev/disk/by-path/...` or, failing that, sysfs information for
+   finding the device inside the virtual machine. Note that both
+   mechanisms are Linux-specific.
 
 ## Flexvolume driver
 

--- a/examples/cirros-vm-volume-mount.yaml
+++ b/examples/cirros-vm-volume-mount.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cirros-vm-volume-mount
+  annotations:
+    kubernetes.io/target-runtime: virtlet.cloud
+    VirtletVCPUCount: "1"
+    VirtletDiskDriver: virtio
+    VirtletSSHKeys: |
+      ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaJEcFDXEK2ZbX0ZLS1EIYFZRbDAcRfuVjpstSc0De8+sV1aiu+dePxdkuDRwqFtCyk6dEZkssjOkBXtri00MECLkir6FcH3kKOJtbJ6vy3uaJc9w1ERo+wyl6SkAh/+JTJkp7QRXj8oylW5E20LsbnA/dIwWzAF51PPwF7A7FtNg9DnwPqMkxFo1Th/buOMKbP5ZA1mmNNtmzbMpMfJATvVyiv3ccsSJKOiyQr6UG+j7sc/7jMVz5Xk34Vd0l8GwcB0334MchHckmqDB142h/NCWTr8oLakDNvkfC1YneAfAO41hDkUbxPtVBG5M/o7P4fxoqiHEX+ZLfRxDtHB53 me@localhost
+    # cloud-init user data
+    # @virtlet-mount-script@ is replaced with commands that mount
+    # volumes into this VM
+    VirtletCloudInitUserDataScript: "@virtlet-mount-script@"
+spec:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: extraRuntime
+            operator: In
+            values:
+            - virtlet
+  containers:
+  - name: cirros-vm
+    image: virtlet.cloud/cirros
+    imagePullPolicy: IfNotPresent
+    tty: true
+    stdin: true
+    resources:
+      limits:
+        memory: 160Mi
+    # volumeMounts are handled by means of @virtlet-mount-script@ here.
+    # They can also be handled by means of cloud-init if the image supports it,
+    # but this is not the case with CirrOS.
+    volumeMounts:
+    - name: somevol
+      mountPath: /somevol
+  volumes:
+  # Define an ephemeral volume to be mounted under /somevol
+  # This can only be used to add some extra disk space
+  # as it'll be removed with this VM.
+  - name: somevol
+    flexVolume:
+      driver: "virtlet/flexvolume_driver"
+      options:
+        type: qcow2
+        capacity: 40MB

--- a/examples/cirros-vm.yaml
+++ b/examples/cirros-vm.yaml
@@ -16,9 +16,12 @@ metadata:
     VirtletSSHKeys: |
       ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaJEcFDXEK2ZbX0ZLS1EIYFZRbDAcRfuVjpstSc0De8+sV1aiu+dePxdkuDRwqFtCyk6dEZkssjOkBXtri00MECLkir6FcH3kKOJtbJ6vy3uaJc9w1ERo+wyl6SkAh/+JTJkp7QRXj8oylW5E20LsbnA/dIwWzAF51PPwF7A7FtNg9DnwPqMkxFo1Th/buOMKbP5ZA1mmNNtmzbMpMfJATvVyiv3ccsSJKOiyQr6UG+j7sc/7jMVz5Xk34Vd0l8GwcB0334MchHckmqDB142h/NCWTr8oLakDNvkfC1YneAfAO41hDkUbxPtVBG5M/o7P4fxoqiHEX+ZLfRxDtHB53 me@localhost
     # cloud-init user data
+    # @virtlet-mount-script@ is replaced with commands that mount
+    # volumes into this VM
     VirtletCloudInitUserDataScript: |
       #!/bin/sh
       echo "Hi there"
+      @virtlet-mount-script@
 spec:
   # This nodeAffinity specification tells Kubernetes to run this
   # pod only on the nodes that have extraRuntime=virtlet label.
@@ -55,3 +58,19 @@ spec:
       limits:
         # This memory limit is applied to the libvirt domain definition
         memory: 160Mi
+    # volumeMounts are handled by means of @virtlet-mount-script@ here.
+    # They can also be handled by means of cloud-init if the image supports it,
+    # but this is not the case with CirrOS.
+    volumeMounts:
+    - name: somevol
+      mountPath: /somevol
+  volumes:
+  # Define an ephemeral volume to be mounted under /somevol
+  # This can only be used to add some extra disk space
+  # as it'll be removed with this VM.
+  - name: somevol
+    flexVolume:
+      driver: "virtlet/flexvolume_driver"
+      options:
+        type: qcow2
+        capacity: 40MB

--- a/examples/cirros-vm.yaml
+++ b/examples/cirros-vm.yaml
@@ -16,12 +16,9 @@ metadata:
     VirtletSSHKeys: |
       ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaJEcFDXEK2ZbX0ZLS1EIYFZRbDAcRfuVjpstSc0De8+sV1aiu+dePxdkuDRwqFtCyk6dEZkssjOkBXtri00MECLkir6FcH3kKOJtbJ6vy3uaJc9w1ERo+wyl6SkAh/+JTJkp7QRXj8oylW5E20LsbnA/dIwWzAF51PPwF7A7FtNg9DnwPqMkxFo1Th/buOMKbP5ZA1mmNNtmzbMpMfJATvVyiv3ccsSJKOiyQr6UG+j7sc/7jMVz5Xk34Vd0l8GwcB0334MchHckmqDB142h/NCWTr8oLakDNvkfC1YneAfAO41hDkUbxPtVBG5M/o7P4fxoqiHEX+ZLfRxDtHB53 me@localhost
     # cloud-init user data
-    # @virtlet-mount-script@ is replaced with commands that mount
-    # volumes into this VM
     VirtletCloudInitUserDataScript: |
       #!/bin/sh
       echo "Hi there"
-      @virtlet-mount-script@
 spec:
   # This nodeAffinity specification tells Kubernetes to run this
   # pod only on the nodes that have extraRuntime=virtlet label.
@@ -58,19 +55,3 @@ spec:
       limits:
         # This memory limit is applied to the libvirt domain definition
         memory: 160Mi
-    # volumeMounts are handled by means of @virtlet-mount-script@ here.
-    # They can also be handled by means of cloud-init if the image supports it,
-    # but this is not the case with CirrOS.
-    volumeMounts:
-    - name: somevol
-      mountPath: /somevol
-  volumes:
-  # Define an ephemeral volume to be mounted under /somevol
-  # This can only be used to add some extra disk space
-  # as it'll be removed with this VM.
-  - name: somevol
-    flexVolume:
-      driver: "virtlet/flexvolume_driver"
-      options:
-        type: qcow2
-        capacity: 40MB

--- a/pkg/libvirttools/TestContainerLifecycle.json
+++ b/pkg/libvirttools/TestContainerLifecycle.json
@@ -111,19 +111,11 @@
     }
   },
   {
-    "name": "domain conn: iso image",
-    "data": {
-      "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\"}",
-      "network-config": "version: 1\n",
-      "user-data": "#cloud-config\n"
-    }
-  },
-  {
     "name": "domain conn: DefineDomain",
     "data": {
       "XMLName": {
         "Space": "",
-        "Local": ""
+        "Local": "domain"
       },
       "Type": "kvm",
       "Name": "virtlet-231700d5-c9a6-container1",
@@ -203,7 +195,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "controller"
             },
             "Type": "scsi",
             "Index": 0,
@@ -215,7 +207,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "disk"
             },
             "Type": "file",
             "Device": "disk",
@@ -264,7 +256,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "disk"
             },
             "Type": "file",
             "Device": "cdrom",
@@ -317,7 +309,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "serial"
             },
             "Type": "unix",
             "Source": {
@@ -338,7 +330,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "input"
             },
             "Type": "tablet",
             "Bus": "usb",
@@ -349,7 +341,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "graphics"
             },
             "Type": "vnc",
             "AutoPort": "",
@@ -376,7 +368,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "video"
             },
             "Model": {
               "Type": "cirrus",
@@ -397,8 +389,8 @@
       },
       "QEMUCommandline": {
         "XMLName": {
-          "Space": "",
-          "Local": ""
+          "Space": "http://libvirt.org/schemas/domain/qemu/1.0",
+          "Local": "commandline"
         },
         "Args": null,
         "Envs": [
@@ -473,6 +465,14 @@
   },
   {
     "name": "domain conn: virtlet-231700d5-c9a6-container1: Create"
+  },
+  {
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: iso image",
+    "data": {
+      "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\"}",
+      "network-config": "version: 1\n",
+      "user-data": "#cloud-config\n"
+    }
   },
   {
     "name": "container status after the container is started",

--- a/pkg/libvirttools/TestContainerLifecycle.json
+++ b/pkg/libvirttools/TestContainerLifecycle.json
@@ -200,6 +200,26 @@
             "Type": "scsi",
             "Index": 0,
             "Model": "virtio-scsi",
+            "Address": {
+              "USB": null,
+              "PCI": {
+                "Domain": 0,
+                "Bus": 0,
+                "Slot": 1,
+                "Function": 0
+              },
+              "Drive": null,
+              "DIMM": null
+            }
+          },
+          {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
+            "Type": "pci",
+            "Index": null,
+            "Model": "pci-root",
             "Address": null
           }
         ],

--- a/pkg/libvirttools/TestDomainCleanup.json
+++ b/pkg/libvirttools/TestDomainCleanup.json
@@ -80,7 +80,7 @@
     "data": {
       "XMLName": {
         "Space": "",
-        "Local": ""
+        "Local": "domain"
       },
       "Type": "",
       "Name": "virtlet-5edfe2ad-9852-container1",
@@ -110,7 +110,7 @@
     "data": {
       "XMLName": {
         "Space": "",
-        "Local": ""
+        "Local": "domain"
       },
       "Type": "",
       "Name": "virtlet-8a6163c3-e4ee-container1",
@@ -140,7 +140,7 @@
     "data": {
       "XMLName": {
         "Space": "",
-        "Local": ""
+        "Local": "domain"
       },
       "Type": "",
       "Name": "virtlet-13f51f8d-0f4e-container1",
@@ -170,7 +170,7 @@
     "data": {
       "XMLName": {
         "Space": "",
-        "Local": ""
+        "Local": "domain"
       },
       "Type": "",
       "Name": "other-than-virtlet-domain",

--- a/pkg/libvirttools/TestDomainCleanup.json
+++ b/pkg/libvirttools/TestDomainCleanup.json
@@ -101,7 +101,35 @@
       "OnPoweroff": "",
       "OnReboot": "",
       "OnCrash": "",
-      "Devices": null,
+      "Devices": {
+        "Emulator": "",
+        "Controllers": [
+          {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
+            "Type": "pci",
+            "Index": null,
+            "Model": "pci-root",
+            "Address": null
+          }
+        ],
+        "Disks": null,
+        "Filesystems": null,
+        "Interfaces": null,
+        "Serials": null,
+        "Consoles": null,
+        "Inputs": null,
+        "Graphics": null,
+        "Videos": null,
+        "Channels": null,
+        "MemBalloon": null,
+        "Sounds": null,
+        "RNGs": null,
+        "Hostdevs": null,
+        "Memorydevs": null
+      },
       "QEMUCommandline": null
     }
   },
@@ -131,7 +159,35 @@
       "OnPoweroff": "",
       "OnReboot": "",
       "OnCrash": "",
-      "Devices": null,
+      "Devices": {
+        "Emulator": "",
+        "Controllers": [
+          {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
+            "Type": "pci",
+            "Index": null,
+            "Model": "pci-root",
+            "Address": null
+          }
+        ],
+        "Disks": null,
+        "Filesystems": null,
+        "Interfaces": null,
+        "Serials": null,
+        "Consoles": null,
+        "Inputs": null,
+        "Graphics": null,
+        "Videos": null,
+        "Channels": null,
+        "MemBalloon": null,
+        "Sounds": null,
+        "RNGs": null,
+        "Hostdevs": null,
+        "Memorydevs": null
+      },
       "QEMUCommandline": null
     }
   },
@@ -161,7 +217,35 @@
       "OnPoweroff": "",
       "OnReboot": "",
       "OnCrash": "",
-      "Devices": null,
+      "Devices": {
+        "Emulator": "",
+        "Controllers": [
+          {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
+            "Type": "pci",
+            "Index": null,
+            "Model": "pci-root",
+            "Address": null
+          }
+        ],
+        "Disks": null,
+        "Filesystems": null,
+        "Interfaces": null,
+        "Serials": null,
+        "Consoles": null,
+        "Inputs": null,
+        "Graphics": null,
+        "Videos": null,
+        "Channels": null,
+        "MemBalloon": null,
+        "Sounds": null,
+        "RNGs": null,
+        "Hostdevs": null,
+        "Memorydevs": null
+      },
       "QEMUCommandline": null
     }
   },
@@ -191,7 +275,35 @@
       "OnPoweroff": "",
       "OnReboot": "",
       "OnCrash": "",
-      "Devices": null,
+      "Devices": {
+        "Emulator": "",
+        "Controllers": [
+          {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
+            "Type": "pci",
+            "Index": null,
+            "Model": "pci-root",
+            "Address": null
+          }
+        ],
+        "Disks": null,
+        "Filesystems": null,
+        "Interfaces": null,
+        "Serials": null,
+        "Consoles": null,
+        "Inputs": null,
+        "Graphics": null,
+        "Videos": null,
+        "Channels": null,
+        "MemBalloon": null,
+        "Sounds": null,
+        "RNGs": null,
+        "Hostdevs": null,
+        "Memorydevs": null
+      },
       "QEMUCommandline": null
     }
   },

--- a/pkg/libvirttools/TestDomainDefinitions__ceph_flexvolume.json
+++ b/pkg/libvirttools/TestDomainDefinitions__ceph_flexvolume.json
@@ -130,19 +130,11 @@
     "data": "66 6f 6f 62 61 72 0a"
   },
   {
-    "name": "domain conn: iso image",
-    "data": {
-      "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\"}",
-      "network-config": "version: 1\n",
-      "user-data": "#cloud-config\nmounts:\n- - /dev/sdb1\n  - /var/lib/whatever\n"
-    }
-  },
-  {
     "name": "domain conn: DefineDomain",
     "data": {
       "XMLName": {
         "Space": "",
-        "Local": ""
+        "Local": "domain"
       },
       "Type": "kvm",
       "Name": "virtlet-231700d5-c9a6-container1",
@@ -222,7 +214,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "controller"
             },
             "Type": "scsi",
             "Index": 0,
@@ -234,7 +226,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "disk"
             },
             "Type": "file",
             "Device": "disk",
@@ -283,7 +275,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "disk"
             },
             "Type": "network",
             "Device": "disk",
@@ -346,7 +338,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "disk"
             },
             "Type": "file",
             "Device": "cdrom",
@@ -399,7 +391,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "serial"
             },
             "Type": "unix",
             "Source": {
@@ -420,7 +412,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "input"
             },
             "Type": "tablet",
             "Bus": "usb",
@@ -431,7 +423,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "graphics"
             },
             "Type": "vnc",
             "AutoPort": "",
@@ -458,7 +450,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "video"
             },
             "Model": {
               "Type": "cirrus",
@@ -479,8 +471,8 @@
       },
       "QEMUCommandline": {
         "XMLName": {
-          "Space": "",
-          "Local": ""
+          "Space": "http://libvirt.org/schemas/domain/qemu/1.0",
+          "Local": "commandline"
         },
         "Args": null,
         "Envs": [
@@ -519,6 +511,20 @@
         ]
       }
     }
+  },
+  {
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Create"
+  },
+  {
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: iso image",
+    "data": {
+      "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\"}",
+      "network-config": "version: 1\n",
+      "user-data": "#cloud-config\nmounts:\n- - /dev/sdb1\n  - /var/lib/whatever\n"
+    }
+  },
+  {
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Destroy"
   },
   {
     "name": "domain conn: virtlet-231700d5-c9a6-container1: Undefine"

--- a/pkg/libvirttools/TestDomainDefinitions__ceph_flexvolume.json
+++ b/pkg/libvirttools/TestDomainDefinitions__ceph_flexvolume.json
@@ -219,6 +219,26 @@
             "Type": "scsi",
             "Index": 0,
             "Model": "virtio-scsi",
+            "Address": {
+              "USB": null,
+              "PCI": {
+                "Domain": 0,
+                "Bus": 0,
+                "Slot": 1,
+                "Function": 0
+              },
+              "Drive": null,
+              "DIMM": null
+            }
+          },
+          {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
+            "Type": "pci",
+            "Index": null,
+            "Model": "pci-root",
             "Address": null
           }
         ],
@@ -520,7 +540,7 @@
     "data": {
       "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\"}",
       "network-config": "version: 1\n",
-      "user-data": "#cloud-config\nmounts:\n- - /dev/sdb1\n  - /var/lib/whatever\n"
+      "user-data": "#cloud-config\nmounts:\n- - /dev/disk/by-path/virtio-pci-0000:00:01.0-scsi-0:0:0:1-part1\n  - /var/lib/whatever\n"
     }
   },
   {

--- a/pkg/libvirttools/TestDomainDefinitions__ceph_flexvolume.json
+++ b/pkg/libvirttools/TestDomainDefinitions__ceph_flexvolume.json
@@ -540,7 +540,7 @@
     "data": {
       "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\"}",
       "network-config": "version: 1\n",
-      "user-data": "#cloud-config\nmounts:\n- - /dev/disk/by-path/virtio-pci-0000:00:01.0-scsi-0:0:0:1-part1\n  - /var/lib/whatever\n"
+      "user-data": "#cloud-config\nmounts:\n- - /dev/disk/by-path/virtio-pci-0000:00:01.0-scsi-0:0:0:1-part1\n  - /var/lib/whatever\nwrite_files:\n- content: |\n    #!/bin/sh\n    if ! mountpoint '/var/lib/whatever'; then mkdir -p '/var/lib/whatever' \u0026\u0026 mount /dev/`ls /sys/devices/pci0000:00/0000:00:01.0/virtio*/host*/target*:0:0/*:0:0:1/block/`1 '/var/lib/whatever'; fi\n  path: /etc/cloud/mount-volumes.sh\n  permissions: \"0755\"\n"
     }
   },
   {

--- a/pkg/libvirttools/TestDomainDefinitions__cloud-init.json
+++ b/pkg/libvirttools/TestDomainDefinitions__cloud-init.json
@@ -196,6 +196,26 @@
             "Type": "scsi",
             "Index": 0,
             "Model": "virtio-scsi",
+            "Address": {
+              "USB": null,
+              "PCI": {
+                "Domain": 0,
+                "Bus": 0,
+                "Slot": 1,
+                "Function": 0
+              },
+              "Drive": null,
+              "DIMM": null
+            }
+          },
+          {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
+            "Type": "pci",
+            "Index": null,
+            "Model": "pci-root",
             "Address": null
           }
         ],

--- a/pkg/libvirttools/TestDomainDefinitions__cloud-init.json
+++ b/pkg/libvirttools/TestDomainDefinitions__cloud-init.json
@@ -107,19 +107,11 @@
     }
   },
   {
-    "name": "domain conn: iso image",
-    "data": {
-      "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\",\"public-keys\":[\"key1\",\"key2\"]}",
-      "network-config": "version: 1\n",
-      "user-data": "#cloud-config\n"
-    }
-  },
-  {
     "name": "domain conn: DefineDomain",
     "data": {
       "XMLName": {
         "Space": "",
-        "Local": ""
+        "Local": "domain"
       },
       "Type": "kvm",
       "Name": "virtlet-231700d5-c9a6-container1",
@@ -199,7 +191,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "controller"
             },
             "Type": "scsi",
             "Index": 0,
@@ -211,7 +203,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "disk"
             },
             "Type": "file",
             "Device": "disk",
@@ -260,7 +252,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "disk"
             },
             "Type": "file",
             "Device": "cdrom",
@@ -313,7 +305,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "serial"
             },
             "Type": "unix",
             "Source": {
@@ -334,7 +326,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "input"
             },
             "Type": "tablet",
             "Bus": "usb",
@@ -345,7 +337,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "graphics"
             },
             "Type": "vnc",
             "AutoPort": "",
@@ -372,7 +364,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "video"
             },
             "Model": {
               "Type": "cirrus",
@@ -393,8 +385,8 @@
       },
       "QEMUCommandline": {
         "XMLName": {
-          "Space": "",
-          "Local": ""
+          "Space": "http://libvirt.org/schemas/domain/qemu/1.0",
+          "Local": "commandline"
         },
         "Args": null,
         "Envs": [
@@ -433,6 +425,20 @@
         ]
       }
     }
+  },
+  {
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Create"
+  },
+  {
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: iso image",
+    "data": {
+      "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\",\"public-keys\":[\"key1\",\"key2\"]}",
+      "network-config": "version: 1\n",
+      "user-data": "#cloud-config\n"
+    }
+  },
+  {
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Destroy"
   },
   {
     "name": "domain conn: virtlet-231700d5-c9a6-container1: Undefine"

--- a/pkg/libvirttools/TestDomainDefinitions__cloud-init_with_user_data.json
+++ b/pkg/libvirttools/TestDomainDefinitions__cloud-init_with_user_data.json
@@ -196,6 +196,26 @@
             "Type": "scsi",
             "Index": 0,
             "Model": "virtio-scsi",
+            "Address": {
+              "USB": null,
+              "PCI": {
+                "Domain": 0,
+                "Bus": 0,
+                "Slot": 1,
+                "Function": 0
+              },
+              "Drive": null,
+              "DIMM": null
+            }
+          },
+          {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
+            "Type": "pci",
+            "Index": null,
+            "Model": "pci-root",
             "Address": null
           }
         ],

--- a/pkg/libvirttools/TestDomainDefinitions__cloud-init_with_user_data.json
+++ b/pkg/libvirttools/TestDomainDefinitions__cloud-init_with_user_data.json
@@ -107,19 +107,11 @@
     }
   },
   {
-    "name": "domain conn: iso image",
-    "data": {
-      "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\",\"public-keys\":[\"key1\",\"key2\"]}",
-      "network-config": "version: 1\n",
-      "user-data": "#cloud-config\nusers:\n- name: cloudy\n"
-    }
-  },
-  {
     "name": "domain conn: DefineDomain",
     "data": {
       "XMLName": {
         "Space": "",
-        "Local": ""
+        "Local": "domain"
       },
       "Type": "kvm",
       "Name": "virtlet-231700d5-c9a6-container1",
@@ -199,7 +191,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "controller"
             },
             "Type": "scsi",
             "Index": 0,
@@ -211,7 +203,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "disk"
             },
             "Type": "file",
             "Device": "disk",
@@ -260,7 +252,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "disk"
             },
             "Type": "file",
             "Device": "cdrom",
@@ -313,7 +305,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "serial"
             },
             "Type": "unix",
             "Source": {
@@ -334,7 +326,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "input"
             },
             "Type": "tablet",
             "Bus": "usb",
@@ -345,7 +337,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "graphics"
             },
             "Type": "vnc",
             "AutoPort": "",
@@ -372,7 +364,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "video"
             },
             "Model": {
               "Type": "cirrus",
@@ -393,8 +385,8 @@
       },
       "QEMUCommandline": {
         "XMLName": {
-          "Space": "",
-          "Local": ""
+          "Space": "http://libvirt.org/schemas/domain/qemu/1.0",
+          "Local": "commandline"
         },
         "Args": null,
         "Envs": [
@@ -433,6 +425,20 @@
         ]
       }
     }
+  },
+  {
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Create"
+  },
+  {
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: iso image",
+    "data": {
+      "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\",\"public-keys\":[\"key1\",\"key2\"]}",
+      "network-config": "version: 1\n",
+      "user-data": "#cloud-config\nusers:\n- name: cloudy\n"
+    }
+  },
+  {
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Destroy"
   },
   {
     "name": "domain conn: virtlet-231700d5-c9a6-container1: Undefine"

--- a/pkg/libvirttools/TestDomainDefinitions__plain_domain.json
+++ b/pkg/libvirttools/TestDomainDefinitions__plain_domain.json
@@ -196,6 +196,26 @@
             "Type": "scsi",
             "Index": 0,
             "Model": "virtio-scsi",
+            "Address": {
+              "USB": null,
+              "PCI": {
+                "Domain": 0,
+                "Bus": 0,
+                "Slot": 1,
+                "Function": 0
+              },
+              "Drive": null,
+              "DIMM": null
+            }
+          },
+          {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
+            "Type": "pci",
+            "Index": null,
+            "Model": "pci-root",
             "Address": null
           }
         ],

--- a/pkg/libvirttools/TestDomainDefinitions__plain_domain.json
+++ b/pkg/libvirttools/TestDomainDefinitions__plain_domain.json
@@ -107,19 +107,11 @@
     }
   },
   {
-    "name": "domain conn: iso image",
-    "data": {
-      "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\"}",
-      "network-config": "version: 1\n",
-      "user-data": "#cloud-config\n"
-    }
-  },
-  {
     "name": "domain conn: DefineDomain",
     "data": {
       "XMLName": {
         "Space": "",
-        "Local": ""
+        "Local": "domain"
       },
       "Type": "kvm",
       "Name": "virtlet-231700d5-c9a6-container1",
@@ -199,7 +191,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "controller"
             },
             "Type": "scsi",
             "Index": 0,
@@ -211,7 +203,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "disk"
             },
             "Type": "file",
             "Device": "disk",
@@ -260,7 +252,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "disk"
             },
             "Type": "file",
             "Device": "cdrom",
@@ -313,7 +305,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "serial"
             },
             "Type": "unix",
             "Source": {
@@ -334,7 +326,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "input"
             },
             "Type": "tablet",
             "Bus": "usb",
@@ -345,7 +337,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "graphics"
             },
             "Type": "vnc",
             "AutoPort": "",
@@ -372,7 +364,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "video"
             },
             "Model": {
               "Type": "cirrus",
@@ -393,8 +385,8 @@
       },
       "QEMUCommandline": {
         "XMLName": {
-          "Space": "",
-          "Local": ""
+          "Space": "http://libvirt.org/schemas/domain/qemu/1.0",
+          "Local": "commandline"
         },
         "Args": null,
         "Envs": [
@@ -433,6 +425,20 @@
         ]
       }
     }
+  },
+  {
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Create"
+  },
+  {
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: iso image",
+    "data": {
+      "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\"}",
+      "network-config": "version: 1\n",
+      "user-data": "#cloud-config\n"
+    }
+  },
+  {
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Destroy"
   },
   {
     "name": "domain conn: virtlet-231700d5-c9a6-container1: Undefine"

--- a/pkg/libvirttools/TestDomainDefinitions__raw_devices.json
+++ b/pkg/libvirttools/TestDomainDefinitions__raw_devices.json
@@ -196,6 +196,26 @@
             "Type": "scsi",
             "Index": 0,
             "Model": "virtio-scsi",
+            "Address": {
+              "USB": null,
+              "PCI": {
+                "Domain": 0,
+                "Bus": 0,
+                "Slot": 1,
+                "Function": 0
+              },
+              "Drive": null,
+              "DIMM": null
+            }
+          },
+          {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
+            "Type": "pci",
+            "Index": null,
+            "Model": "pci-root",
             "Address": null
           }
         ],

--- a/pkg/libvirttools/TestDomainDefinitions__raw_devices.json
+++ b/pkg/libvirttools/TestDomainDefinitions__raw_devices.json
@@ -107,19 +107,11 @@
     }
   },
   {
-    "name": "domain conn: iso image",
-    "data": {
-      "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\"}",
-      "network-config": "version: 1\n",
-      "user-data": "#cloud-config\n"
-    }
-  },
-  {
     "name": "domain conn: DefineDomain",
     "data": {
       "XMLName": {
         "Space": "",
-        "Local": ""
+        "Local": "domain"
       },
       "Type": "kvm",
       "Name": "virtlet-231700d5-c9a6-container1",
@@ -199,7 +191,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "controller"
             },
             "Type": "scsi",
             "Index": 0,
@@ -211,7 +203,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "disk"
             },
             "Type": "file",
             "Device": "disk",
@@ -260,7 +252,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "disk"
             },
             "Type": "block",
             "Device": "disk",
@@ -309,7 +301,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "disk"
             },
             "Type": "file",
             "Device": "cdrom",
@@ -362,7 +354,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "serial"
             },
             "Type": "unix",
             "Source": {
@@ -383,7 +375,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "input"
             },
             "Type": "tablet",
             "Bus": "usb",
@@ -394,7 +386,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "graphics"
             },
             "Type": "vnc",
             "AutoPort": "",
@@ -421,7 +413,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "video"
             },
             "Model": {
               "Type": "cirrus",
@@ -442,8 +434,8 @@
       },
       "QEMUCommandline": {
         "XMLName": {
-          "Space": "",
-          "Local": ""
+          "Space": "http://libvirt.org/schemas/domain/qemu/1.0",
+          "Local": "commandline"
         },
         "Args": null,
         "Envs": [
@@ -482,6 +474,20 @@
         ]
       }
     }
+  },
+  {
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Create"
+  },
+  {
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: iso image",
+    "data": {
+      "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\"}",
+      "network-config": "version: 1\n",
+      "user-data": "#cloud-config\n"
+    }
+  },
+  {
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Destroy"
   },
   {
     "name": "domain conn: virtlet-231700d5-c9a6-container1: Undefine"

--- a/pkg/libvirttools/TestDomainDefinitions__vcpu_count.json
+++ b/pkg/libvirttools/TestDomainDefinitions__vcpu_count.json
@@ -196,6 +196,26 @@
             "Type": "scsi",
             "Index": 0,
             "Model": "virtio-scsi",
+            "Address": {
+              "USB": null,
+              "PCI": {
+                "Domain": 0,
+                "Bus": 0,
+                "Slot": 1,
+                "Function": 0
+              },
+              "Drive": null,
+              "DIMM": null
+            }
+          },
+          {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
+            "Type": "pci",
+            "Index": null,
+            "Model": "pci-root",
             "Address": null
           }
         ],

--- a/pkg/libvirttools/TestDomainDefinitions__vcpu_count.json
+++ b/pkg/libvirttools/TestDomainDefinitions__vcpu_count.json
@@ -107,19 +107,11 @@
     }
   },
   {
-    "name": "domain conn: iso image",
-    "data": {
-      "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\"}",
-      "network-config": "version: 1\n",
-      "user-data": "#cloud-config\n"
-    }
-  },
-  {
     "name": "domain conn: DefineDomain",
     "data": {
       "XMLName": {
         "Space": "",
-        "Local": ""
+        "Local": "domain"
       },
       "Type": "kvm",
       "Name": "virtlet-231700d5-c9a6-container1",
@@ -199,7 +191,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "controller"
             },
             "Type": "scsi",
             "Index": 0,
@@ -211,7 +203,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "disk"
             },
             "Type": "file",
             "Device": "disk",
@@ -260,7 +252,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "disk"
             },
             "Type": "file",
             "Device": "cdrom",
@@ -313,7 +305,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "serial"
             },
             "Type": "unix",
             "Source": {
@@ -334,7 +326,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "input"
             },
             "Type": "tablet",
             "Bus": "usb",
@@ -345,7 +337,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "graphics"
             },
             "Type": "vnc",
             "AutoPort": "",
@@ -372,7 +364,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "video"
             },
             "Model": {
               "Type": "cirrus",
@@ -393,8 +385,8 @@
       },
       "QEMUCommandline": {
         "XMLName": {
-          "Space": "",
-          "Local": ""
+          "Space": "http://libvirt.org/schemas/domain/qemu/1.0",
+          "Local": "commandline"
         },
         "Args": null,
         "Envs": [
@@ -433,6 +425,20 @@
         ]
       }
     }
+  },
+  {
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Create"
+  },
+  {
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: iso image",
+    "data": {
+      "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\"}",
+      "network-config": "version: 1\n",
+      "user-data": "#cloud-config\n"
+    }
+  },
+  {
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Destroy"
   },
   {
     "name": "domain conn: virtlet-231700d5-c9a6-container1: Undefine"

--- a/pkg/libvirttools/TestDomainDefinitions__virtio_disk_driver.json
+++ b/pkg/libvirttools/TestDomainDefinitions__virtio_disk_driver.json
@@ -196,6 +196,26 @@
             "Type": "scsi",
             "Index": 0,
             "Model": "virtio-scsi",
+            "Address": {
+              "USB": null,
+              "PCI": {
+                "Domain": 0,
+                "Bus": 0,
+                "Slot": 1,
+                "Function": 0
+              },
+              "Drive": null,
+              "DIMM": null
+            }
+          },
+          {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
+            "Type": "pci",
+            "Index": null,
+            "Model": "pci-root",
             "Address": null
           }
         ],

--- a/pkg/libvirttools/TestDomainDefinitions__virtio_disk_driver.json
+++ b/pkg/libvirttools/TestDomainDefinitions__virtio_disk_driver.json
@@ -107,19 +107,11 @@
     }
   },
   {
-    "name": "domain conn: iso image",
-    "data": {
-      "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\"}",
-      "network-config": "version: 1\n",
-      "user-data": "#cloud-config\n"
-    }
-  },
-  {
     "name": "domain conn: DefineDomain",
     "data": {
       "XMLName": {
         "Space": "",
-        "Local": ""
+        "Local": "domain"
       },
       "Type": "kvm",
       "Name": "virtlet-231700d5-c9a6-container1",
@@ -199,7 +191,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "controller"
             },
             "Type": "scsi",
             "Index": 0,
@@ -211,7 +203,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "disk"
             },
             "Type": "file",
             "Device": "disk",
@@ -260,7 +252,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "disk"
             },
             "Type": "file",
             "Device": "cdrom",
@@ -313,7 +305,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "serial"
             },
             "Type": "unix",
             "Source": {
@@ -334,7 +326,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "input"
             },
             "Type": "tablet",
             "Bus": "usb",
@@ -345,7 +337,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "graphics"
             },
             "Type": "vnc",
             "AutoPort": "",
@@ -372,7 +364,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "video"
             },
             "Model": {
               "Type": "cirrus",
@@ -393,8 +385,8 @@
       },
       "QEMUCommandline": {
         "XMLName": {
-          "Space": "",
-          "Local": ""
+          "Space": "http://libvirt.org/schemas/domain/qemu/1.0",
+          "Local": "commandline"
         },
         "Args": null,
         "Envs": [
@@ -433,6 +425,20 @@
         ]
       }
     }
+  },
+  {
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Create"
+  },
+  {
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: iso image",
+    "data": {
+      "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\"}",
+      "network-config": "version: 1\n",
+      "user-data": "#cloud-config\n"
+    }
+  },
+  {
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Destroy"
   },
   {
     "name": "domain conn: virtlet-231700d5-c9a6-container1: Undefine"

--- a/pkg/libvirttools/TestDomainDefinitions__volumes.json
+++ b/pkg/libvirttools/TestDomainDefinitions__volumes.json
@@ -307,6 +307,26 @@
             "Type": "scsi",
             "Index": 0,
             "Model": "virtio-scsi",
+            "Address": {
+              "USB": null,
+              "PCI": {
+                "Domain": 0,
+                "Bus": 0,
+                "Slot": 1,
+                "Function": 0
+              },
+              "Drive": null,
+              "DIMM": null
+            }
+          },
+          {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
+            "Type": "pci",
+            "Index": null,
+            "Model": "pci-root",
             "Address": null
           }
         ],

--- a/pkg/libvirttools/TestDomainDefinitions__volumes.json
+++ b/pkg/libvirttools/TestDomainDefinitions__volumes.json
@@ -218,19 +218,11 @@
     "name": "storage: volumes: virtlet-231700d5-c9a6-5a49-738d-99a954c51550-vol3: Format"
   },
   {
-    "name": "domain conn: iso image",
-    "data": {
-      "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\"}",
-      "network-config": "version: 1\n",
-      "user-data": "#cloud-config\n"
-    }
-  },
-  {
     "name": "domain conn: DefineDomain",
     "data": {
       "XMLName": {
         "Space": "",
-        "Local": ""
+        "Local": "domain"
       },
       "Type": "kvm",
       "Name": "virtlet-231700d5-c9a6-container1",
@@ -310,7 +302,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "controller"
             },
             "Type": "scsi",
             "Index": 0,
@@ -322,7 +314,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "disk"
             },
             "Type": "file",
             "Device": "disk",
@@ -371,7 +363,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "disk"
             },
             "Type": "file",
             "Device": "disk",
@@ -420,7 +412,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "disk"
             },
             "Type": "file",
             "Device": "disk",
@@ -469,7 +461,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "disk"
             },
             "Type": "file",
             "Device": "disk",
@@ -518,7 +510,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "disk"
             },
             "Type": "file",
             "Device": "cdrom",
@@ -571,7 +563,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "serial"
             },
             "Type": "unix",
             "Source": {
@@ -592,7 +584,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "input"
             },
             "Type": "tablet",
             "Bus": "usb",
@@ -603,7 +595,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "graphics"
             },
             "Type": "vnc",
             "AutoPort": "",
@@ -630,7 +622,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "video"
             },
             "Model": {
               "Type": "cirrus",
@@ -651,8 +643,8 @@
       },
       "QEMUCommandline": {
         "XMLName": {
-          "Space": "",
-          "Local": ""
+          "Space": "http://libvirt.org/schemas/domain/qemu/1.0",
+          "Local": "commandline"
         },
         "Args": null,
         "Envs": [
@@ -691,6 +683,20 @@
         ]
       }
     }
+  },
+  {
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Create"
+  },
+  {
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: iso image",
+    "data": {
+      "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\"}",
+      "network-config": "version: 1\n",
+      "user-data": "#cloud-config\n"
+    }
+  },
+  {
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: Destroy"
   },
   {
     "name": "domain conn: virtlet-231700d5-c9a6-container1: Undefine"

--- a/pkg/libvirttools/TestDomainForcedShutdown.json
+++ b/pkg/libvirttools/TestDomainForcedShutdown.json
@@ -107,19 +107,11 @@
     }
   },
   {
-    "name": "domain conn: iso image",
-    "data": {
-      "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\"}",
-      "network-config": "version: 1\n",
-      "user-data": "#cloud-config\n"
-    }
-  },
-  {
     "name": "domain conn: DefineDomain",
     "data": {
       "XMLName": {
         "Space": "",
-        "Local": ""
+        "Local": "domain"
       },
       "Type": "kvm",
       "Name": "virtlet-231700d5-c9a6-container1",
@@ -199,7 +191,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "controller"
             },
             "Type": "scsi",
             "Index": 0,
@@ -211,7 +203,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "disk"
             },
             "Type": "file",
             "Device": "disk",
@@ -260,7 +252,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "disk"
             },
             "Type": "file",
             "Device": "cdrom",
@@ -313,7 +305,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "serial"
             },
             "Type": "unix",
             "Source": {
@@ -334,7 +326,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "input"
             },
             "Type": "tablet",
             "Bus": "usb",
@@ -345,7 +337,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "graphics"
             },
             "Type": "vnc",
             "AutoPort": "",
@@ -372,7 +364,7 @@
           {
             "XMLName": {
               "Space": "",
-              "Local": ""
+              "Local": "video"
             },
             "Model": {
               "Type": "cirrus",
@@ -393,8 +385,8 @@
       },
       "QEMUCommandline": {
         "XMLName": {
-          "Space": "",
-          "Local": ""
+          "Space": "http://libvirt.org/schemas/domain/qemu/1.0",
+          "Local": "commandline"
         },
         "Args": null,
         "Envs": [
@@ -436,6 +428,14 @@
   },
   {
     "name": "domain conn: virtlet-231700d5-c9a6-container1: Create"
+  },
+  {
+    "name": "domain conn: virtlet-231700d5-c9a6-container1: iso image",
+    "data": {
+      "meta-data": "{\"instance-id\":\"testName_0.default\",\"local-hostname\":\"testName_0\"}",
+      "network-config": "version: 1\n",
+      "user-data": "#cloud-config\n"
+    }
   },
   {
     "name": "invoking StopContainer()"

--- a/pkg/libvirttools/TestDomainForcedShutdown.json
+++ b/pkg/libvirttools/TestDomainForcedShutdown.json
@@ -196,6 +196,26 @@
             "Type": "scsi",
             "Index": 0,
             "Model": "virtio-scsi",
+            "Address": {
+              "USB": null,
+              "PCI": {
+                "Domain": 0,
+                "Bus": 0,
+                "Slot": 1,
+                "Function": 0
+              },
+              "Drive": null,
+              "DIMM": null
+            }
+          },
+          {
+            "XMLName": {
+              "Space": "",
+              "Local": ""
+            },
+            "Type": "pci",
+            "Index": null,
+            "Model": "pci-root",
             "Address": null
           }
         ],

--- a/pkg/libvirttools/ceph_flexvolume.go
+++ b/pkg/libvirttools/ceph_flexvolume.go
@@ -49,6 +49,8 @@ type cephVolume struct {
 	opts       *cephFlexvolumeOptions
 }
 
+var _ VMVolume = &cephVolume{}
+
 func newCephVolume(volumeName, configPath string, config *VMConfig, owner VolumeOwner) (VMVolume, error) {
 	v := &cephVolume{
 		volumeBase: volumeBase{config, owner},
@@ -90,7 +92,7 @@ func (v *cephVolume) Uuid() string {
 	return v.opts.Uuid
 }
 
-func (v *cephVolume) Setup(volumeMap map[string]string) (*libvirtxml.DomainDisk, error) {
+func (v *cephVolume) Setup() (*libvirtxml.DomainDisk, error) {
 	ipPortPair := strings.Split(v.opts.Monitor, ":")
 	if len(ipPortPair) != 2 {
 		return nil, fmt.Errorf("invalid format of ceph monitor setting: %s. Expected ip:port", v.opts.Monitor)

--- a/pkg/libvirttools/cloudinit.go
+++ b/pkg/libvirttools/cloudinit.go
@@ -325,7 +325,7 @@ func (g *CloudInitGenerator) generateMounts(volumeMap map[string]string) []inter
 			part = 1
 		}
 		if part != 0 {
-			devPath = fmt.Sprintf("%s%d", devPath, part)
+			devPath = fmt.Sprintf("%s-part%d", devPath, part)
 		}
 		r = append(r, []interface{}{devPath, m.ContainerPath})
 	}

--- a/pkg/libvirttools/cloudinit_test.go
+++ b/pkg/libvirttools/cloudinit_test.go
@@ -91,7 +91,7 @@ func TestCloudInitGenerator(t *testing.T) {
 	for _, tc := range []struct {
 		name                  string
 		config                *VMConfig
-		volumeMap             map[string]string
+		volumeMap             diskPathMap
 		expectedMetaData      map[string]interface{}
 		expectedUserData      map[string]interface{}
 		expectedNetworkConfig map[string]interface{}
@@ -196,8 +196,9 @@ func TestCloudInitGenerator(t *testing.T) {
 			expectedUserData: map[string]interface{}{
 				"write_files": []interface{}{
 					map[string]interface{}{
-						"path":    "/etc/cloud/environment",
-						"content": "foo=bar\nbaz=abc\n",
+						"path":        "/etc/cloud/environment",
+						"content":     "foo=bar\nbaz=abc\n",
+						"permissions": "0644",
 					},
 				},
 			},
@@ -243,8 +244,9 @@ func TestCloudInitGenerator(t *testing.T) {
 						"content": "whatever",
 					},
 					map[string]interface{}{
-						"path":    "/etc/cloud/environment",
-						"content": "foo=bar\nbaz=abc\n",
+						"path":        "/etc/cloud/environment",
+						"content":     "foo=bar\nbaz=abc\n",
+						"permissions": "0644",
 					},
 				},
 			},
@@ -287,10 +289,19 @@ func TestCloudInitGenerator(t *testing.T) {
 					},
 				},
 			},
-			volumeMap: map[string]string{
-				vols[0].uuid: "/dev/disk/by-path/virtio-pci-0000:00:01.0-scsi-0:0:0:1",
-				vols[1].uuid: "/dev/disk/by-path/virtio-pci-0000:00:01.0-scsi-0:0:0:2",
-				vols[2].uuid: "/dev/disk/by-path/virtio-pci-0000:00:01.0-scsi-0:0:0:3",
+			volumeMap: diskPathMap{
+				vols[0].uuid: {
+					devPath:   "/dev/disk/by-path/virtio-pci-0000:00:01.0-scsi-0:0:0:1",
+					sysfsPath: "/sys/devices/pci0000:00/0000:00:03.0/virtio*/host*/target*:0:0/*:0:0:1/block/",
+				},
+				vols[1].uuid: {
+					devPath:   "/dev/disk/by-path/virtio-pci-0000:00:01.0-scsi-0:0:0:2",
+					sysfsPath: "/sys/devices/pci0000:00/0000:00:03.0/virtio*/host*/target*:0:0/*:0:0:2/block/",
+				},
+				vols[2].uuid: {
+					devPath:   "/dev/disk/by-path/virtio-pci-0000:00:01.0-scsi-0:0:0:3",
+					sysfsPath: "/sys/devices/pci0000:00/0000:00:03.0/virtio*/host*/target*:0:0/*:0:0:3/block/",
+				},
 			},
 			expectedMetaData: map[string]interface{}{
 				"instance-id":    "foo.default",
@@ -302,7 +313,46 @@ func TestCloudInitGenerator(t *testing.T) {
 					[]interface{}{"/dev/disk/by-path/virtio-pci-0000:00:01.0-scsi-0:0:0:2", "/var/lib/whatever"},
 					[]interface{}{"/dev/disk/by-path/virtio-pci-0000:00:01.0-scsi-0:0:0:3-part2", "/var/lib/foobar"},
 				},
+				"write_files": []interface{}{
+					map[string]interface{}{
+						"path":        "/etc/cloud/mount-volumes.sh",
+						"permissions": "0755",
+						"content": "#!/bin/sh\n" +
+							"if ! mountpoint '/opt'; then mkdir -p '/opt' && mount /dev/`ls /sys/devices/pci0000:00/0000:00:03.0/virtio*/host*/target*:0:0/*:0:0:1/block/`1 '/opt'; fi\n" +
+							"if ! mountpoint '/var/lib/whatever'; then mkdir -p '/var/lib/whatever' && mount /dev/`ls /sys/devices/pci0000:00/0000:00:03.0/virtio*/host*/target*:0:0/*:0:0:2/block/` '/var/lib/whatever'; fi\n" +
+							"if ! mountpoint '/var/lib/foobar'; then mkdir -p '/var/lib/foobar' && mount /dev/`ls /sys/devices/pci0000:00/0000:00:03.0/virtio*/host*/target*:0:0/*:0:0:3/block/`2 '/var/lib/foobar'; fi\n",
+					},
+				},
 			},
+		},
+		{
+			name: "injecting mount script into user data script",
+			config: &VMConfig{
+				PodName:      "foo",
+				PodNamespace: "default",
+				ParsedAnnotations: &VirtletAnnotations{
+					UserDataScript: "#!/bin/sh\necho hi\n@virtlet-mount-script@",
+				},
+				Mounts: []*VMMount{
+					{
+						ContainerPath: "/opt",
+						HostPath:      vols[0].path,
+					},
+				},
+			},
+			volumeMap: diskPathMap{
+				vols[0].uuid: {
+					devPath:   "/dev/disk/by-path/virtio-pci-0000:00:01.0-scsi-0:0:0:1",
+					sysfsPath: "/sys/devices/pci0000:00/0000:00:03.0/virtio*/host*/target*:0:0/*:0:0:1/block/",
+				},
+			},
+			expectedMetaData: map[string]interface{}{
+				"instance-id":    "foo.default",
+				"local-hostname": "foo",
+			},
+			expectedUserDataStr: "#!/bin/sh\necho hi\n" +
+				"#!/bin/sh\n" +
+				"if ! mountpoint '/opt'; then mkdir -p '/opt' && mount /dev/`ls /sys/devices/pci0000:00/0000:00:03.0/virtio*/host*/target*:0:0/*:0:0:1/block/`1 '/opt'; fi\n",
 		},
 		{
 			name: "pod with network config",
@@ -584,131 +634,95 @@ func TestEnvDataGeneration(t *testing.T) {
 	}
 }
 
-func TestAddingSecrets(t *testing.T) {
+func verifyWriteFiles(t *testing.T, u *writeFilesUpdater, expectedWriteFiles ...interface{}) {
+	userData := make(map[string]interface{})
+	u.updateUserData(userData)
+	expectedUserData := map[string]interface{}{"write_files": expectedWriteFiles}
+	if !reflect.DeepEqual(userData, expectedUserData) {
+		t.Errorf("Bad user-data:\n%s\nExpected:\n%s", spew.Sdump(userData), spew.Sdump(expectedUserData))
+	}
+}
+
+func withFakeVolumeDir(t *testing.T, subdir string, perms os.FileMode, toRun func(location string)) {
 	tmpDir, err := ioutil.TempDir("", "")
 	if err != nil {
 		t.Fatalf("Can't create temp dir: %v", err)
 	}
 	defer os.RemoveAll(tmpDir)
 
-	location := filepath.Join(tmpDir, "volumes/kubernetes.io~secret/test-volume")
-	if err := os.MkdirAll(location, 0755); err != nil {
-		t.Fatalf("Can't create secrets directory in temp dir: %v", err)
+	var location, filePath string
+	if subdir != "" {
+		location = filepath.Join(tmpDir, subdir)
+		if err := os.MkdirAll(location, 0755); err != nil {
+			t.Fatalf("Can't create secrets directory in temp dir: %v", err)
+		}
+		filePath = filepath.Join(location, "file")
+	} else {
+		filePath = filepath.Join(tmpDir, "file")
+		location = filePath
 	}
 
-	f, err := os.Create(filepath.Join(location, "file"))
+	f, err := os.Create(filePath)
 	if err != nil {
 		t.Fatalf("Can't create sample file in temp directory: %v", err)
 	}
-	f.Chmod(0640)
-	defer f.Close()
 	if _, err := f.WriteString("test content"); err != nil {
-		t.Fatalf("Error during write to test file: %v", err)
+		f.Close()
+		t.Fatalf("Error writing test file: %v", err)
+	}
+	if perms != 0 {
+		if err := f.Chmod(perms); err != nil {
+			t.Fatalf("Chmod(): %v", err)
+		}
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("Error closing test file: %v", err)
 	}
 
-	userData := make(map[string]interface{})
-	g := NewWriteFilesManipulator(userData, []*VMMount{
-		{ContainerPath: "/container", HostPath: location},
+	toRun(location)
+}
+
+func TestAddingSecrets(t *testing.T) {
+	withFakeVolumeDir(t, "volumes/kubernetes.io~secret/test-volume", 0640, func(location string) {
+		u := newWriteFilesUpdater([]*VMMount{
+			{ContainerPath: "/container", HostPath: location},
+		})
+		u.addSecrets()
+		verifyWriteFiles(t, u, map[string]interface{}{
+			"path":        "/container/file",
+			"content":     "dGVzdCBjb250ZW50",
+			"encoding":    "b64",
+			"permissions": "0640",
+		})
 	})
-
-	g.AddSecrets()
-
-	expectedUserData := map[string]interface{}{
-		"write_files": []interface{}{
-			map[string]interface{}{
-				"path":        "/container/file",
-				"content":     "dGVzdCBjb250ZW50",
-				"encoding":    "b64",
-				"permissions": "0640",
-			},
-		},
-	}
-
-	if !reflect.DeepEqual(userData, expectedUserData) {
-		t.Errorf("Bad user-data:\n%s\nExpected:\n%s", spew.Sdump(userData), spew.Sdump(expectedUserData))
-	}
 }
 
 func TestAddingConfigMap(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal("Can't create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	location := filepath.Join(tmpDir, "volumes/kubernetes.io~configmap/test-volume")
-	if err := os.MkdirAll(location, 0755); err != nil {
-		t.Fatal("Can't create secrets directory in temp dir: %v", err)
-	}
-
-	f, err := os.Create(filepath.Join(location, "file"))
-	if err != nil {
-		t.Fatal("Can't create sample file in temp directory: %v", err)
-	}
-	defer f.Close()
-	if _, err := f.WriteString("test content"); err != nil {
-		t.Fatal("Error during write to test file: %v", err)
-	}
-
-	userData := make(map[string]interface{})
-	g := NewWriteFilesManipulator(userData, []*VMMount{
-		{ContainerPath: "/container", HostPath: location},
+	withFakeVolumeDir(t, "volumes/kubernetes.io~configmap/test-volume", 0, func(location string) {
+		u := newWriteFilesUpdater([]*VMMount{
+			{ContainerPath: "/container", HostPath: location},
+		})
+		u.addConfigMapEntries()
+		verifyWriteFiles(t, u, map[string]interface{}{
+			"path":        "/container/file",
+			"content":     "dGVzdCBjb250ZW50",
+			"encoding":    "b64",
+			"permissions": "0644",
+		})
 	})
-
-	g.AddConfigMapEntries()
-
-	expectedUserData := map[string]interface{}{
-		"write_files": []interface{}{
-			map[string]interface{}{
-				"path":        "/container/file",
-				"content":     "dGVzdCBjb250ZW50",
-				"encoding":    "b64",
-				"permissions": "0644",
-			},
-		},
-	}
-
-	if !reflect.DeepEqual(userData, expectedUserData) {
-		t.Errorf("Bad user-data:\n%s\nExpected:\n%s", spew.Sdump(userData), spew.Sdump(expectedUserData))
-	}
 }
 
 func TestAddingFileLikeMount(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal("Can't create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	fname := filepath.Join(tmpDir, "file")
-	f, err := os.Create(fname)
-	if err != nil {
-		t.Fatal("Can't create sample file in temp directory: %v", err)
-	}
-	defer f.Close()
-	if _, err := f.WriteString("test content"); err != nil {
-		t.Fatal("Error during write to test file: %v", err)
-	}
-
-	userData := make(map[string]interface{})
-	g := NewWriteFilesManipulator(userData, []*VMMount{
-		{ContainerPath: "/container", HostPath: fname},
+	withFakeVolumeDir(t, "", 0, func(location string) {
+		u := newWriteFilesUpdater([]*VMMount{
+			{ContainerPath: "/container", HostPath: location},
+		})
+		u.addFileLikeMounts()
+		verifyWriteFiles(t, u, map[string]interface{}{
+			"path":        "/container",
+			"content":     "dGVzdCBjb250ZW50",
+			"encoding":    "b64",
+			"permissions": "0644",
+		})
 	})
-
-	g.AddFileLikeMounts()
-
-	expectedUserData := map[string]interface{}{
-		"write_files": []interface{}{
-			map[string]interface{}{
-				"path":        "/container",
-				"content":     "dGVzdCBjb250ZW50",
-				"encoding":    "b64",
-				"permissions": "0644",
-			},
-		},
-	}
-
-	if !reflect.DeepEqual(userData, expectedUserData) {
-		t.Errorf("Bad user-data:\n%s\nExpected:\n%s", spew.Sdump(userData), spew.Sdump(expectedUserData))
-	}
 }

--- a/pkg/libvirttools/cloudinit_test.go
+++ b/pkg/libvirttools/cloudinit_test.go
@@ -288,9 +288,9 @@ func TestCloudInitGenerator(t *testing.T) {
 				},
 			},
 			volumeMap: map[string]string{
-				vols[0].uuid: "/dev/sdb",
-				vols[1].uuid: "/dev/sdc",
-				vols[2].uuid: "/dev/sdd",
+				vols[0].uuid: "/dev/disk/by-path/virtio-pci-0000:00:01.0-scsi-0:0:0:1",
+				vols[1].uuid: "/dev/disk/by-path/virtio-pci-0000:00:01.0-scsi-0:0:0:2",
+				vols[2].uuid: "/dev/disk/by-path/virtio-pci-0000:00:01.0-scsi-0:0:0:3",
 			},
 			expectedMetaData: map[string]interface{}{
 				"instance-id":    "foo.default",
@@ -298,9 +298,9 @@ func TestCloudInitGenerator(t *testing.T) {
 			},
 			expectedUserData: map[string]interface{}{
 				"mounts": []interface{}{
-					[]interface{}{"/dev/sdb1", "/opt"},
-					[]interface{}{"/dev/sdc", "/var/lib/whatever"},
-					[]interface{}{"/dev/sdd2", "/var/lib/foobar"},
+					[]interface{}{"/dev/disk/by-path/virtio-pci-0000:00:01.0-scsi-0:0:0:1-part1", "/opt"},
+					[]interface{}{"/dev/disk/by-path/virtio-pci-0000:00:01.0-scsi-0:0:0:2", "/var/lib/whatever"},
+					[]interface{}{"/dev/disk/by-path/virtio-pci-0000:00:01.0-scsi-0:0:0:3-part2", "/var/lib/foobar"},
 				},
 			},
 		},

--- a/pkg/libvirttools/diskdriver.go
+++ b/pkg/libvirttools/diskdriver.go
@@ -34,23 +34,6 @@ const (
 	maxScsiBlockDevChar   = 'z'
 )
 
-type diskPath struct {
-	// devPath denotes path to the device under /dev, e.g.
-	// /dev/disk/by-path/virtio-pci-0000:00:03.0-scsi-0:0:0:0 or
-	// /dev/disk/by-path/pci-0000:00:03.0-virtio-pci-0000:01:01.0
-	devPath string
-	// sysfsPath denotes a path to a directory in sysfs that
-	// contains a file with the same name as the device in /dev, e.g.
-	// /sys/devices/pci0000:00/0000:00:03.0/0000:01:01.0/virtio*/block/ or
-	// /sys/devices/pci0000:00/0000:00:03.0/virtio*/host*/target*:0:0/*:0:0:0/block/sda
-	// (note that in the latter case * is used instead of host because host number appear
-	// to be wrong in sysfs for some reason)
-	// The path needs to be globbed and the single file name from there
-	// should be used as device name, e.g.
-	// ls -l /dev/`ls /sys/devices/pci0000:00/0000:00:03.0/0000:01:01.0/virtio*/block/`
-	sysfsPath string
-}
-
 type diskDriver interface {
 	diskPath(domainDef *libvirtxml.Domain) (*diskPath, error)
 	target() *libvirtxml.DomainDiskTarget

--- a/pkg/libvirttools/diskdriver.go
+++ b/pkg/libvirttools/diskdriver.go
@@ -33,7 +33,7 @@ const (
 )
 
 type diskDriver interface {
-	devPath() string
+	devPath(domainDef *libvirtxml.Domain) string
 	target() *libvirtxml.DomainDiskTarget
 	address() *libvirtxml.DomainAddress
 }
@@ -58,7 +58,8 @@ func virtioBlkDriverFactory(n int) (diskDriver, error) {
 	return &virtioBlkDriver{n, diskChar}, nil
 }
 
-func (d *virtioBlkDriver) devPath() string {
+func (d *virtioBlkDriver) devPath(domainDef *libvirtxml.Domain) string {
+	// XXX: use /dev/disk/by-path
 	return fmt.Sprintf("/dev/vd%c", d.diskChar)
 }
 
@@ -98,7 +99,7 @@ func scsiDriverFactory(n int) (diskDriver, error) {
 	return &scsiDriver{n, diskChar}, nil
 }
 
-func (d *scsiDriver) devPath() string {
+func (d *scsiDriver) devPath(domainDef *libvirtxml.Domain) string {
 	// FIXME: in case of cdrom, that's actually sr0, but we're
 	// only using cdrom for nocloud drive currently
 	return fmt.Sprintf("/dev/sd%c", d.diskChar)

--- a/pkg/libvirttools/diskdriver_test.go
+++ b/pkg/libvirttools/diskdriver_test.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2017 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package libvirttools
+
+import (
+	"testing"
+
+	libvirtxml "github.com/libvirt/libvirt-go-xml"
+)
+
+func TestDiskPath(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		driverName DiskDriver
+		diskCount  int
+		devList    libvirtxml.DomainDeviceList
+		diskPaths  []diskPath
+	}{
+		{
+			name:       "scsi driver",
+			driverName: DiskDriverScsi,
+			diskCount:  3,
+			devList: libvirtxml.DomainDeviceList{
+				Disks: []libvirtxml.DomainDisk{
+					{
+						Type:   "file",
+						Device: "disk",
+						// NOTE: Source & Driver aren't used here, so omitting them for the sake of simplicity
+						Target: &libvirtxml.DomainDiskTarget{
+							Dev: "sda",
+							Bus: "scsi",
+						},
+						Address: scsiAddress(0, 0, 0, 0),
+					},
+					{
+						Type:   "file",
+						Device: "disk",
+						Target: &libvirtxml.DomainDiskTarget{
+							Dev: "sdb",
+							Bus: "scsi",
+						},
+						Address: scsiAddress(0, 0, 0, 1),
+					},
+					{
+						Type:   "file",
+						Device: "cdrom",
+						Target: &libvirtxml.DomainDiskTarget{
+							// this one is usually sr0 in the VM,
+							// but it doesn't matter here
+							Dev: "sdc",
+							Bus: "scsi",
+						},
+						Address:  scsiAddress(0, 0, 0, 2),
+						ReadOnly: &libvirtxml.DomainDiskReadOnly{},
+					},
+				},
+				Controllers: []libvirtxml.DomainController{
+					{
+						Type:  "pci",
+						Model: "pci-root",
+					},
+					{
+						Type:    "scsi",
+						Index:   puint(0),
+						Model:   "virtio-scsi",
+						Address: pciAddress(0, 0, 3, 0),
+					},
+				},
+			},
+			diskPaths: []diskPath{
+				{
+					"/dev/disk/by-path/virtio-pci-0000:00:03.0-scsi-0:0:0:0",
+					"/sys/devices/pci0000:00/0000:00:03.0/virtio*/host*/target*:0:0/*:0:0:0/block/",
+				},
+				{
+					"/dev/disk/by-path/virtio-pci-0000:00:03.0-scsi-0:0:0:1",
+					"/sys/devices/pci0000:00/0000:00:03.0/virtio*/host*/target*:0:0/*:0:0:1/block/",
+				},
+				{
+					"/dev/disk/by-path/virtio-pci-0000:00:03.0-scsi-0:0:0:2",
+					"/sys/devices/pci0000:00/0000:00:03.0/virtio*/host*/target*:0:0/*:0:0:2/block/",
+				},
+			},
+		},
+		{
+			name:       "virtio driver",
+			driverName: DiskDriverVirtio,
+			diskCount:  3,
+			devList: libvirtxml.DomainDeviceList{
+				Disks: []libvirtxml.DomainDisk{
+					{
+						Type:   "file",
+						Device: "disk",
+						Target: &libvirtxml.DomainDiskTarget{
+							Dev: "vda",
+							Bus: "virtio",
+						},
+						Address: pciAddress(0, 1, 1, 0),
+					},
+					{
+						Type:   "file",
+						Device: "disk",
+						Target: &libvirtxml.DomainDiskTarget{
+							Dev: "vdb",
+							Bus: "virtio",
+						},
+						Address: pciAddress(0, 1, 2, 0),
+					},
+					{
+						Type:   "file",
+						Device: "cdrom",
+						Target: &libvirtxml.DomainDiskTarget{
+							Dev: "vdc",
+							Bus: "virtio",
+						},
+						Address:  pciAddress(0, 1, 3, 0),
+						ReadOnly: &libvirtxml.DomainDiskReadOnly{},
+					},
+				},
+				Controllers: []libvirtxml.DomainController{
+					{
+						Type:  "pci",
+						Model: "pci-root",
+					},
+					{
+						Type:    "pci",
+						Index:   puint(1),
+						Model:   "pci-bridge",
+						Address: pciAddress(0, 0, 3, 0),
+					},
+				},
+			},
+			diskPaths: []diskPath{
+				{
+					"/dev/disk/by-path/pci-0000:00:03.0-virtio-pci-0000:01:01.0",
+					"/sys/devices/pci0000:00/0000:00:03.0/0000:01:01.0/virtio*/block/",
+				},
+				{
+					"/dev/disk/by-path/pci-0000:00:03.0-virtio-pci-0000:01:02.0",
+					"/sys/devices/pci0000:00/0000:00:03.0/0000:01:02.0/virtio*/block/",
+				},
+				{
+					"/dev/disk/by-path/pci-0000:00:03.0-virtio-pci-0000:01:03.0",
+					"/sys/devices/pci0000:00/0000:00:03.0/0000:01:03.0/virtio*/block/",
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			factory, err := getDiskDriverFactory(tc.driverName)
+			if err != nil {
+				t.Fatalf("creating factory %q: %v", tc.driverName, err)
+			}
+			domain := &libvirtxml.Domain{Devices: &tc.devList}
+			for n := 0; n < tc.diskCount; n++ {
+				driver, err := factory(n)
+				if err != nil {
+					t.Errorf("error making driver #%d: %v", n, err)
+					continue
+				}
+				diskPath, err := driver.diskPath(domain)
+				if err != nil {
+					t.Errorf("diskPath() #%d: %v", n, err)
+					continue
+				}
+				if diskPath.devPath != tc.diskPaths[n].devPath {
+					t.Errorf("bad devPath #%d: expected %q, got %q", n, tc.diskPaths[n].devPath, diskPath.devPath)
+				}
+				if diskPath.sysfsPath != tc.diskPaths[n].sysfsPath {
+					t.Errorf("bad sysfsPath #%d: expected %q, got %q", n, tc.diskPaths[n].sysfsPath, diskPath.sysfsPath)
+				}
+			}
+		})
+	}
+}
+
+func puint(n uint) *uint { return &n }
+
+func scsiAddress(controller, bus, target, unit uint) *libvirtxml.DomainAddress {
+	return &libvirtxml.DomainAddress{
+		Drive: &libvirtxml.DomainAddressDrive{
+			Controller: &controller,
+			Bus:        &bus,
+			Target:     &target,
+			Unit:       &unit,
+		},
+	}
+}
+
+func pciAddress(domain, bus, slot, function uint) *libvirtxml.DomainAddress {
+	return &libvirtxml.DomainAddress{
+		PCI: &libvirtxml.DomainAddressPCI{
+			Domain:   &domain,
+			Bus:      &bus,
+			Slot:     &slot,
+			Function: &function,
+		},
+	}
+}
+
+// TODO: sort pci-bridge controllers by index !!!

--- a/pkg/libvirttools/disklist.go
+++ b/pkg/libvirttools/disklist.go
@@ -46,7 +46,7 @@ type diskList struct {
 	items  []*diskItem
 }
 
-// newDiskSet creates a diskList for the specified VMConfig, volume
+// newDiskList creates a diskList for the specified VMConfig, volume
 // source and volume owner
 func newDiskList(config *VMConfig, source VMVolumeSource, owner VolumeOwner) (*diskList, error) {
 	vmVols, err := source(config, owner)
@@ -70,8 +70,8 @@ func newDiskList(config *VMConfig, source VMVolumeSource, owner VolumeOwner) (*d
 	return &diskList{config, items}, nil
 }
 
-// setupVolumes performs the setup procedure on each volume in the
-// diskList and returns a list of libvirtxml DomainDisk structs
+// setup performs the setup procedure on each volume in the diskList
+// and returns a list of libvirtxml DomainDisk structs
 func (dl *diskList) setup() ([]libvirtxml.DomainDisk, error) {
 	var domainDisks []libvirtxml.DomainDisk
 	for n, item := range dl.items {
@@ -90,9 +90,9 @@ func (dl *diskList) setup() ([]libvirtxml.DomainDisk, error) {
 	return domainDisks, nil
 }
 
-// writeVolumeImages writes images for volumes that are based on
-// generated images (such as cloud-init nocloud datasource).  It must
-// be passed a VirtDomain for which images are being generated.
+// writeImages writes images for volumes that are based on generated
+// images (such as cloud-init nocloud datasource).  It must be passed
+// a VirtDomain for which images are being generated.
 func (dl *diskList) writeImages(domain virt.VirtDomain) error {
 	domainDesc, err := domain.Xml()
 	if err != nil {

--- a/pkg/libvirttools/disklist.go
+++ b/pkg/libvirttools/disklist.go
@@ -103,7 +103,11 @@ func (dl *diskList) writeImages(domain virt.VirtDomain) error {
 	for _, item := range dl.items {
 		uuid := item.volume.Uuid()
 		if uuid != "" {
-			volumeMap[uuid] = item.driver.devPath(domainDesc)
+			diskPath, err := item.driver.diskPath(domainDesc)
+			if err != nil {
+				return err
+			}
+			volumeMap[uuid] = diskPath.devPath
 		}
 	}
 

--- a/pkg/libvirttools/disklist.go
+++ b/pkg/libvirttools/disklist.go
@@ -99,7 +99,7 @@ func (dl *diskList) writeImages(domain virt.VirtDomain) error {
 		return fmt.Errorf("couldn't get domain xml: %v", err)
 	}
 
-	volumeMap := make(map[string]string)
+	volumeMap := make(diskPathMap)
 	for _, item := range dl.items {
 		uuid := item.volume.Uuid()
 		if uuid != "" {
@@ -107,7 +107,7 @@ func (dl *diskList) writeImages(domain virt.VirtDomain) error {
 			if err != nil {
 				return err
 			}
-			volumeMap[uuid] = diskPath.devPath
+			volumeMap[uuid] = *diskPath
 		}
 	}
 

--- a/pkg/libvirttools/disklist.go
+++ b/pkg/libvirttools/disklist.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2016-2017 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package libvirttools
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/golang/glog"
+	libvirtxml "github.com/libvirt/libvirt-go-xml"
+
+	"github.com/Mirantis/virtlet/pkg/virt"
+)
+
+type diskItem struct {
+	driver diskDriver
+	volume VMVolume
+}
+
+func (di *diskItem) setup(config *VMConfig) (*libvirtxml.DomainDisk, error) {
+	diskDef, err := di.volume.Setup()
+	if err != nil {
+		return nil, err
+	}
+	diskDef.Target = di.driver.target()
+	diskDef.Address = di.driver.address()
+	return diskDef, nil
+}
+
+type diskList struct {
+	config *VMConfig
+	items  []*diskItem
+}
+
+// newDiskSet creates a diskList for the specified VMConfig, volume
+// source and volume owner
+func newDiskList(config *VMConfig, source VMVolumeSource, owner VolumeOwner) (*diskList, error) {
+	vmVols, err := source(config, owner)
+	if err != nil {
+		return nil, err
+	}
+
+	diskDriverFactory, err := getDiskDriverFactory(config.ParsedAnnotations.DiskDriver)
+	if err != nil {
+		return nil, err
+	}
+	var items []*diskItem
+	for n, volume := range vmVols {
+		driver, err := diskDriverFactory(n)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, &diskItem{driver, volume})
+	}
+
+	return &diskList{config, items}, nil
+}
+
+// setupVolumes performs the setup procedure on each volume in the
+// diskList and returns a list of libvirtxml DomainDisk structs
+func (dl *diskList) setup() ([]libvirtxml.DomainDisk, error) {
+	var domainDisks []libvirtxml.DomainDisk
+	for n, item := range dl.items {
+		diskDef, err := item.setup(dl.config)
+		if err != nil {
+			// try to tear down volumes that were already set up
+			for _, item := range dl.items[:n] {
+				if err := item.volume.Teardown(); err != nil {
+					glog.Warningf("Failed to tear down a volume on error: %v", err)
+				}
+			}
+			return nil, err
+		}
+		domainDisks = append(domainDisks, *diskDef)
+	}
+	return domainDisks, nil
+}
+
+// writeVolumeImages writes images for volumes that are based on
+// generated images (such as cloud-init nocloud datasource).  It must
+// be passed a VirtDomain for which images are being generated.
+func (dl *diskList) writeImages(domain virt.VirtDomain) error {
+	domainDesc, err := domain.Xml()
+	if err != nil {
+		return fmt.Errorf("couldn't get domain xml: %v", err)
+	}
+
+	volumeMap := make(map[string]string)
+	for _, item := range dl.items {
+		uuid := item.volume.Uuid()
+		if uuid != "" {
+			volumeMap[uuid] = item.driver.devPath(domainDesc)
+		}
+	}
+
+	for _, item := range dl.items {
+		if err := item.volume.WriteImage(volumeMap); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (dl *diskList) teardown() error {
+	var errs []string
+	for _, item := range dl.items {
+		if err := item.volume.Teardown(); err != nil {
+			errs = append(errs, err.Error())
+		}
+	}
+	if errs != nil {
+		return fmt.Errorf("failed to tear down some of the volumes:\n%s", strings.Join(errs, "\n"))
+	}
+	return nil
+}

--- a/pkg/libvirttools/libvirt_domain.go
+++ b/pkg/libvirttools/libvirt_domain.go
@@ -185,6 +185,18 @@ func (domain *LibvirtDomain) Name() (string, error) {
 	return domain.d.GetName()
 }
 
+func (domain *LibvirtDomain) Xml() (*libvirtxml.Domain, error) {
+	desc, err := domain.d.GetXMLDesc(libvirt.DOMAIN_XML_INACTIVE)
+	if err != nil {
+		return nil, err
+	}
+	var d libvirtxml.Domain
+	if err := d.Unmarshal(desc); err != nil {
+		return nil, fmt.Errorf("error unmarshalling domain definition: %v", err)
+	}
+	return &d, nil
+}
+
 type LibvirtSecret struct {
 	s *libvirt.Secret
 }

--- a/pkg/libvirttools/nocloud_volumesource.go
+++ b/pkg/libvirttools/nocloud_volumesource.go
@@ -54,7 +54,7 @@ func (v *nocloudVolume) Setup() (*libvirtxml.DomainDisk, error) {
 	return v.cloudInitGenerator().DiskDef(), nil
 }
 
-func (v *nocloudVolume) WriteImage(volumeMap map[string]string) error {
+func (v *nocloudVolume) WriteImage(volumeMap diskPathMap) error {
 	return v.cloudInitGenerator().GenerateImage(volumeMap)
 }
 

--- a/pkg/libvirttools/nocloud_volumesource.go
+++ b/pkg/libvirttools/nocloud_volumesource.go
@@ -34,6 +34,8 @@ type nocloudVolume struct {
 	volumeBase
 }
 
+var _ VMVolume = &nocloudVolume{}
+
 func GetNocloudVolume(config *VMConfig, owner VolumeOwner) ([]VMVolume, error) {
 	return []VMVolume{
 		&nocloudVolume{
@@ -44,17 +46,20 @@ func GetNocloudVolume(config *VMConfig, owner VolumeOwner) ([]VMVolume, error) {
 
 func (v *nocloudVolume) Uuid() string { return "" }
 
-func (v *nocloudVolume) Setup(volumeMap map[string]string) (*libvirtxml.DomainDisk, error) {
-	g := NewCloudInitGenerator(v.config, volumeMap, nocloudIsoDir)
-	nocloudDiskDef, err := g.GenerateDisk()
-	if err != nil {
-		return nil, err
-	}
-	return nocloudDiskDef, nil
+func (v *nocloudVolume) cloudInitGenerator() *CloudInitGenerator {
+	return NewCloudInitGenerator(v.config, nocloudIsoDir)
+}
+
+func (v *nocloudVolume) Setup() (*libvirtxml.DomainDisk, error) {
+	return v.cloudInitGenerator().DiskDef(), nil
+}
+
+func (v *nocloudVolume) WriteImage(volumeMap map[string]string) error {
+	return v.cloudInitGenerator().GenerateImage(volumeMap)
 }
 
 func (v *nocloudVolume) Teardown() error {
-	isoPath := NewCloudInitGenerator(v.config, nil, nocloudIsoDir).IsoPath()
+	isoPath := v.cloudInitGenerator().IsoPath()
 	if err := os.Remove(isoPath); err != nil && !os.IsNotExist(err) {
 		glog.Warningf("Cannot remove temporary nocloud file %q: %v", isoPath, err)
 	}

--- a/pkg/libvirttools/qcow2_flexvolume.go
+++ b/pkg/libvirttools/qcow2_flexvolume.go
@@ -54,6 +54,8 @@ type qcow2Volume struct {
 	uuid         string
 }
 
+var _ VMVolume = &qcow2Volume{}
+
 func newQCOW2Volume(volumeName, configPath string, config *VMConfig, owner VolumeOwner) (VMVolume, error) {
 	var err error
 	var opts qcow2VolumeOptions
@@ -90,7 +92,7 @@ func (v *qcow2Volume) Uuid() string {
 	return v.uuid
 }
 
-func (v *qcow2Volume) Setup(volumeMap map[string]string) (*libvirtxml.DomainDisk, error) {
+func (v *qcow2Volume) Setup() (*libvirtxml.DomainDisk, error) {
 	vol, err := v.createQCOW2Volume(uint64(v.capacity), v.capacityUnit)
 	if err != nil {
 		return nil, fmt.Errorf("error during creation of volume '%s' with virtlet description %s: %v", v.volumeName(), v.name, err)

--- a/pkg/libvirttools/raw_flexvolume.go
+++ b/pkg/libvirttools/raw_flexvolume.go
@@ -44,6 +44,8 @@ type rawDeviceVolume struct {
 	opts *rawVolumeOptions
 }
 
+var _ VMVolume = &rawDeviceVolume{}
+
 func newRawDeviceVolume(volumeName, configPath string, config *VMConfig, owner VolumeOwner) (VMVolume, error) {
 	var opts rawVolumeOptions
 	if err := utils.ReadJson(configPath, &opts); err != nil {
@@ -77,7 +79,7 @@ func (v *rawDeviceVolume) Uuid() string {
 	return v.opts.Uuid
 }
 
-func (v *rawDeviceVolume) Setup(volumeMap map[string]string) (*libvirtxml.DomainDisk, error) {
+func (v *rawDeviceVolume) Setup() (*libvirtxml.DomainDisk, error) {
 	if err := v.verifyRawDeviceWhitelisted(v.opts.Path); err != nil {
 		return nil, err
 	}
@@ -92,8 +94,6 @@ func (v *rawDeviceVolume) Setup(volumeMap map[string]string) (*libvirtxml.Domain
 		Driver: &libvirtxml.DomainDiskDriver{Name: "qemu", Type: "raw"},
 	}, nil
 }
-
-func (v *rawDeviceVolume) Teardown() error { return nil }
 
 func init() {
 	AddFlexvolumeSource("raw", newRawDeviceVolume)

--- a/pkg/libvirttools/root_volumesource.go
+++ b/pkg/libvirttools/root_volumesource.go
@@ -29,6 +29,8 @@ type rootVolume struct {
 	volumeBase
 }
 
+var _ VMVolume = &rootVolume{}
+
 func GetRootVolume(config *VMConfig, owner VolumeOwner) ([]VMVolume, error) {
 	return []VMVolume{
 		&rootVolume{
@@ -53,7 +55,7 @@ func (v *rootVolume) cloneVolume(name string, from virt.VirtStorageVolume) (virt
 
 func (v *rootVolume) Uuid() string { return "" }
 
-func (v *rootVolume) Setup(volumeMap map[string]string) (*libvirtxml.DomainDisk, error) {
+func (v *rootVolume) Setup() (*libvirtxml.DomainDisk, error) {
 	imageVolume, err := v.owner.ImageManager().GetImageVolume(v.config.Image)
 	if err != nil {
 		return nil, err

--- a/pkg/libvirttools/root_volumesource_test.go
+++ b/pkg/libvirttools/root_volumesource_test.go
@@ -68,7 +68,7 @@ func TestRootVolumeLifeCycle(t *testing.T) {
 
 	rootVol := volumes[0]
 
-	vol, err := rootVol.Setup(nil)
+	vol, err := rootVol.Setup()
 	if err != nil {
 		t.Errorf("Setup returned an error: %v", err)
 	}

--- a/pkg/libvirttools/storage_utils.go
+++ b/pkg/libvirttools/storage_utils.go
@@ -25,6 +25,28 @@ import (
 	"github.com/Mirantis/virtlet/pkg/virt"
 )
 
+// diskPath contains paths that can be used to locate a device inside
+// the VM using Linux-specific /dev or /sys paths
+type diskPath struct {
+	// devPath denotes path to the device under /dev, e.g.
+	// /dev/disk/by-path/virtio-pci-0000:00:03.0-scsi-0:0:0:0 or
+	// /dev/disk/by-path/pci-0000:00:03.0-virtio-pci-0000:01:01.0
+	devPath string
+	// sysfsPath denotes a path to a directory in sysfs that
+	// contains a file with the same name as the device in /dev, e.g.
+	// /sys/devices/pci0000:00/0000:00:03.0/0000:01:01.0/virtio*/block/ or
+	// /sys/devices/pci0000:00/0000:00:03.0/virtio*/host*/target*:0:0/*:0:0:0/block/sda
+	// (note that in the latter case * is used instead of host because host number appear
+	// to be wrong in sysfs for some reason)
+	// The path needs to be globbed and the single file name from there
+	// should be used as device name, e.g.
+	// ls -l /dev/`ls /sys/devices/pci0000:00/0000:00:03.0/0000:01:01.0/virtio*/block/`
+	sysfsPath string
+}
+
+// diskPathMap maps volume uuids to diskPath items
+type diskPathMap map[string]diskPath
+
 var supportedStoragePools = map[string]string{
 	"default": "/var/lib/libvirt/images",
 	"volumes": "/var/lib/virtlet/volumes",

--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -216,67 +216,6 @@ func (v *VirtualizationTool) SetKubeletRootDir(kubeletRootDir string) {
 	v.kubeletRootDir = kubeletRootDir
 }
 
-func (v *VirtualizationTool) getVMVolumes(config *VMConfig) ([]VMVolume, error) {
-	return v.volumeSource(config, v)
-}
-
-func (v *VirtualizationTool) setupVolumes(config *VMConfig, domainDef *libvirtxml.Domain) error {
-	vmVols, err := v.getVMVolumes(config)
-	if err != nil {
-		return err
-	}
-	diskDriverFactory, err := getDiskDriverFactory(config.ParsedAnnotations.DiskDriver)
-	if err != nil {
-		return err
-	}
-	volumeMap := make(map[string]string)
-	var diskDrivers []diskDriver
-	for n, vmVol := range vmVols {
-		driver, err := diskDriverFactory(n)
-		if err != nil {
-			return err
-		}
-		diskDrivers = append(diskDrivers, driver)
-		uuid := vmVol.Uuid()
-		if uuid != "" {
-			volumeMap[uuid] = driver.devPath()
-		}
-	}
-	for n, vmVol := range vmVols {
-		diskDef, err := vmVol.Setup(volumeMap)
-		if err != nil {
-			// try to tear down volumes that were already set up
-			for _, vmVol := range vmVols[:n] {
-				if err := vmVol.Teardown(); err != nil {
-					glog.Warningf("Failed to tear down a volume on error: %v", err)
-				}
-			}
-			return err
-		}
-		diskDef.Target = diskDrivers[n].target()
-		diskDef.Address = diskDrivers[n].address()
-		domainDef.Devices.Disks = append(domainDef.Devices.Disks, *diskDef)
-	}
-	return nil
-}
-
-func (v *VirtualizationTool) teardownVolumes(config *VMConfig) error {
-	vmVols, err := v.getVMVolumes(config)
-	if err != nil {
-		return err
-	}
-	var errs []string
-	for _, vmVol := range vmVols {
-		if err := vmVol.Teardown(); err != nil {
-			errs = append(errs, err.Error())
-		}
-	}
-	if errs != nil {
-		return fmt.Errorf("failed to tear down some of the volumes:\n%s", strings.Join(errs, "\n"))
-	}
-	return nil
-}
-
 func loggingDisabled() bool {
 	disabled := os.Getenv("VIRTLET_DISABLE_LOGGING")
 	return utils.GetBoolFromString(disabled)
@@ -340,9 +279,14 @@ func (v *VirtualizationTool) CreateContainer(config *VMConfig, netFdKey string) 
 	}
 
 	settings.useKvm = v.forceKVM || canUseKvm()
-	domainConf := settings.createDomain(config)
+	domainDef := settings.createDomain(config)
 
-	if err := v.setupVolumes(config, domainConf); err != nil {
+	diskList, err := newDiskList(config, v.volumeSource, v)
+	if err != nil {
+		return "", err
+	}
+	domainDef.Devices.Disks, err = diskList.setup()
+	if err != nil {
 		return "", err
 	}
 
@@ -354,10 +298,13 @@ func (v *VirtualizationTool) CreateContainer(config *VMConfig, netFdKey string) 
 		if err := v.removeDomain(settings.domainUUID, config, kubeapi.ContainerState_CONTAINER_UNKNOWN, true); err != nil {
 			glog.Warningf("Failed to remove domain %q: %v", settings.domainUUID, err)
 		}
+		if err := diskList.teardown(); err != nil {
+			glog.Warningf("error tearing down volumes after an error: %v", err)
+		}
 	}()
 
 	containerAttempt := config.Attempt
-	if err := v.addSerialDevicesToDomain(config.PodSandboxId, config.Name, containerAttempt, domainConf, settings); err != nil {
+	if err := v.addSerialDevicesToDomain(config.PodSandboxId, config.Name, containerAttempt, domainDef, settings); err != nil {
 		return "", err
 	}
 
@@ -370,17 +317,10 @@ func (v *VirtualizationTool) CreateContainer(config *VMConfig, netFdKey string) 
 	labels[kubetypes.KubernetesPodUIDLabel] = config.PodSandboxId
 	labels[kubetypes.KubernetesContainerNameLabel] = config.Name
 
-	if _, err := v.domainConn.DefineDomain(domainConf); err != nil {
-		return "", err
-	}
-
-	domain, err := v.domainConn.LookupDomainByUUIDString(settings.domainUUID)
+	domain, err := v.domainConn.DefineDomain(domainDef)
 	if err == nil {
-		// FIXME: do we really need this?
-		// (this causes an GetInfo() call on the domain in case of libvirt)
-		_, err = domain.State()
+		err = diskList.writeImages(domain)
 	}
-
 	if err == nil {
 		// FIXME: store VMConfig + VMStatus (to be added)
 		err = v.metadataStore.Container(settings.domainUUID).Save(
@@ -589,7 +529,6 @@ func (v *VirtualizationTool) getVMConfigFromMetadata(containerId string) (*VMCon
 
 func (v *VirtualizationTool) cleanupVolumes(containerId string) error {
 	config, _, err := v.getVMConfigFromMetadata(containerId)
-
 	if err != nil {
 		return err
 	}
@@ -599,7 +538,12 @@ func (v *VirtualizationTool) cleanupVolumes(containerId string) error {
 		return nil
 	}
 
-	if err := v.teardownVolumes(config); err != nil {
+	diskList, err := newDiskList(config, v.volumeSource, v)
+	if err == nil {
+		err = diskList.teardown()
+	}
+
+	if err != nil {
 		glog.Errorf("Volume teardown failed for domain %q: %v", containerId, err)
 		return err
 
@@ -608,7 +552,7 @@ func (v *VirtualizationTool) cleanupVolumes(containerId string) error {
 	return nil
 }
 
-func (v *VirtualizationTool) removeDomain(containerId string, config *VMConfig, state kubeapi.ContainerState, disallowVolumesTeardownFailure bool) error {
+func (v *VirtualizationTool) removeDomain(containerId string, config *VMConfig, state kubeapi.ContainerState, failUponVolumeTeardownFailure bool) error {
 	// Give a chance to gracefully stop domain
 	// TODO: handle errors - there could be e.g. lost connection error
 	domain, err := v.domainConn.LookupDomainByUUIDString(containerId)
@@ -641,15 +585,20 @@ func (v *VirtualizationTool) removeDomain(containerId string, config *VMConfig, 
 		}
 	}
 
-	if err := v.teardownVolumes(config); err != nil {
-		if disallowVolumesTeardownFailure {
-			return err
-		} else {
-			glog.Warningf("Error during volumes teardown for container %s: %v", containerId, err)
-		}
+	diskList, err := newDiskList(config, v.volumeSource, v)
+	if err == nil {
+		err = diskList.teardown()
 	}
 
-	return nil
+	switch {
+	case err == nil:
+		return nil
+	case failUponVolumeTeardownFailure:
+		return err
+	default:
+		glog.Warningf("Error during volume teardown for container %s: %v", containerId, err)
+		return nil
+	}
 }
 
 // RemoveContainer tries to gracefully stop domain, then forcibly removes it

--- a/pkg/libvirttools/virtualization_test.go
+++ b/pkg/libvirttools/virtualization_test.go
@@ -465,6 +465,9 @@ func TestDomainDefinitions(t *testing.T) {
 				})
 			}
 			containerId := ct.createContainer(sandbox, mounts)
+			// startContainer will cause fake VirtDomain
+			// to dump the cloudinit iso content
+			ct.startContainer(containerId)
 			ct.removeContainer(containerId)
 			gm.Verify(t, ct.rec.Content())
 		})

--- a/pkg/libvirttools/volumes.go
+++ b/pkg/libvirttools/volumes.go
@@ -44,7 +44,7 @@ type VMVolumeSource func(config *VMConfig, owner VolumeOwner) ([]VMVolume, error
 type VMVolume interface {
 	Uuid() string
 	Setup() (*libvirtxml.DomainDisk, error)
-	WriteImage(volumeMap map[string]string) error
+	WriteImage(diskPathMap) error
 	Teardown() error
 }
 
@@ -53,8 +53,8 @@ type volumeBase struct {
 	owner  VolumeOwner
 }
 
-func (v *volumeBase) WriteImage(volumeMap map[string]string) error { return nil }
-func (v *volumeBase) Teardown() error                              { return nil }
+func (v *volumeBase) WriteImage(diskPathMap) error { return nil }
+func (v *volumeBase) Teardown() error              { return nil }
 
 func CombineVMVolumeSources(srcs ...VMVolumeSource) VMVolumeSource {
 	return func(config *VMConfig, owner VolumeOwner) ([]VMVolume, error) {

--- a/pkg/libvirttools/volumes.go
+++ b/pkg/libvirttools/volumes.go
@@ -43,7 +43,8 @@ type VMVolumeSource func(config *VMConfig, owner VolumeOwner) ([]VMVolume, error
 
 type VMVolume interface {
 	Uuid() string
-	Setup(volumeMap map[string]string) (*libvirtxml.DomainDisk, error)
+	Setup() (*libvirtxml.DomainDisk, error)
+	WriteImage(volumeMap map[string]string) error
 	Teardown() error
 }
 
@@ -51,6 +52,9 @@ type volumeBase struct {
 	config *VMConfig
 	owner  VolumeOwner
 }
+
+func (v *volumeBase) WriteImage(volumeMap map[string]string) error { return nil }
+func (v *volumeBase) Teardown() error                              { return nil }
 
 func CombineVMVolumeSources(srcs ...VMVolumeSource) VMVolumeSource {
 	return func(config *VMConfig, owner VolumeOwner) ([]VMVolume, error) {

--- a/pkg/virt/domain_interface.go
+++ b/pkg/virt/domain_interface.go
@@ -99,8 +99,10 @@ type VirtDomain interface {
 	Shutdown() error
 	// State obtains the current state of the domain
 	State() (DomainState, error)
-	// UUIDString() returns UUID string for this domain
+	// UUIDString returns UUID string for this domain
 	UUIDString() (string, error)
-	// Name() returns the name of this domain
+	// Name returns the name of this domain
 	Name() (string, error)
+	// Xml retrieves xml definition of the domain
+	Xml() (*libvirtxml.Domain, error)
 }

--- a/pkg/virt/fake/fake_domain.go
+++ b/pkg/virt/fake/fake_domain.go
@@ -56,14 +56,14 @@ func (dc *FakeDomainConnection) SetIgnoreShutdown(ignoreShutdown bool) {
 }
 
 func (dc *FakeDomainConnection) removeDomain(d *FakeDomain) {
-	if _, found := dc.domains[d.name]; !found {
-		log.Panicf("domain %q not found", d.name)
+	if _, found := dc.domains[d.def.Name]; !found {
+		log.Panicf("domain %q not found", d.def.Name)
 	}
-	delete(dc.domains, d.name)
-	if _, found := dc.domainsByUuid[d.uuid]; !found {
-		log.Panicf("domain uuid %q not found (name %q)", d.uuid, d.name)
+	delete(dc.domains, d.def.Name)
+	if _, found := dc.domainsByUuid[d.def.UUID]; !found {
+		log.Panicf("domain uuid %q not found (name %q)", d.def.UUID, d.def.Name)
 	}
-	delete(dc.domainsByUuid, d.uuid)
+	delete(dc.domainsByUuid, d.def.UUID)
 }
 
 func (dc *FakeDomainConnection) removeSecret(s *FakeSecret) {
@@ -74,22 +74,8 @@ func (dc *FakeDomainConnection) removeSecret(s *FakeSecret) {
 }
 
 func (dc *FakeDomainConnection) DefineDomain(def *libvirtxml.Domain) (virt.VirtDomain, error) {
-	if def.Devices != nil {
-		for _, disk := range def.Devices.Disks {
-			if disk.Type != "file" || disk.Source == nil {
-				continue
-			}
-			origPath := disk.Source.File
-			if filepath.Ext(origPath) == ".iso" || strings.HasPrefix(filepath.Base(origPath), "nocloud-iso") {
-				m, err := testutils.IsoToMap(origPath)
-				if err != nil {
-					return nil, fmt.Errorf("bad iso image: %q", origPath)
-				}
-				dc.rec.Rec("iso image", m)
-			}
-		}
-	}
-	dc.rec.Rec("DefineDomain", def)
+	dc.rec.Rec("DefineDomain", copyDomain(def))
+	assignFakePCIAddressesToControllers(def)
 	// TODO: dump any ISOs mentioned in disks (Type=file) as json
 	// Include file name (base) in rec name
 	if _, found := dc.domains[def.Name]; found {
@@ -101,7 +87,7 @@ func (dc *FakeDomainConnection) DefineDomain(def *libvirtxml.Domain) (virt.VirtD
 	if def.UUID == "" {
 		return nil, fmt.Errorf("domain %q has empty uuid", def.Name)
 	}
-	d := newFakeDomain(dc, def.Name, def.UUID)
+	d := newFakeDomain(dc, def)
 	dc.domains[def.Name] = d
 	dc.domainsByUuid[def.UUID] = d
 	return d, nil
@@ -168,27 +154,40 @@ type FakeDomain struct {
 	removed bool
 	created bool
 	state   virt.DomainState
-	name    string
-	uuid    string
+	def     *libvirtxml.Domain
 }
 
-func newFakeDomain(dc *FakeDomainConnection, name, uuid string) *FakeDomain {
+func newFakeDomain(dc *FakeDomainConnection, def *libvirtxml.Domain) *FakeDomain {
 	return &FakeDomain{
-		rec:   NewChildRecorder(dc.rec, name),
+		rec:   NewChildRecorder(dc.rec, def.Name),
 		dc:    dc,
 		state: virt.DOMAIN_SHUTOFF,
-		name:  name,
-		uuid:  uuid,
+		def:   def,
 	}
 }
 
 func (d *FakeDomain) Create() error {
 	d.rec.Rec("Create", nil)
+	if d.def.Devices != nil {
+		for _, disk := range d.def.Devices.Disks {
+			if disk.Type != "file" || disk.Source == nil {
+				continue
+			}
+			origPath := disk.Source.File
+			if filepath.Ext(origPath) == ".iso" || strings.HasPrefix(filepath.Base(origPath), "nocloud-iso") {
+				m, err := testutils.IsoToMap(origPath)
+				if err != nil {
+					return fmt.Errorf("bad iso image: %q", origPath)
+				}
+				d.rec.Rec("iso image", m)
+			}
+		}
+	}
 	if d.removed {
-		return fmt.Errorf("Create() called on a removed (undefined) domain %q", d.name)
+		return fmt.Errorf("Create() called on a removed (undefined) domain %q", d.def.Name)
 	}
 	if d.created {
-		return fmt.Errorf("trying to re-create domain %q", d.name)
+		return fmt.Errorf("trying to re-create domain %q", d.def.Name)
 	}
 	if d.state != virt.DOMAIN_SHUTOFF {
 		return fmt.Errorf("invalid domain state %d", d.state)
@@ -201,7 +200,7 @@ func (d *FakeDomain) Create() error {
 func (d *FakeDomain) Destroy() error {
 	d.rec.Rec("Destroy", nil)
 	if d.removed {
-		return fmt.Errorf("Destroy() called on a removed (undefined) domain %q", d.name)
+		return fmt.Errorf("Destroy() called on a removed (undefined) domain %q", d.def.Name)
 	}
 	d.state = virt.DOMAIN_SHUTOFF
 	return nil
@@ -210,7 +209,7 @@ func (d *FakeDomain) Destroy() error {
 func (d *FakeDomain) Undefine() error {
 	d.rec.Rec("Undefine", nil)
 	if d.removed {
-		return fmt.Errorf("Undefine(): domain %q already removed", d.name)
+		return fmt.Errorf("Undefine(): domain %q already removed", d.def.Name)
 	}
 	d.removed = true
 	d.dc.removeDomain(d)
@@ -224,7 +223,7 @@ func (d *FakeDomain) Shutdown() error {
 		d.rec.Rec("Shutdown", nil)
 	}
 	if d.removed {
-		return fmt.Errorf("Shutdown() called on a removed (undefined) domain %q", d.name)
+		return fmt.Errorf("Shutdown() called on a removed (undefined) domain %q", d.def.Name)
 	}
 	if !d.dc.ignoreShutdown {
 		// TODO: need to test DOMAIN_SHUTDOWN stage too
@@ -235,20 +234,24 @@ func (d *FakeDomain) Shutdown() error {
 
 func (d *FakeDomain) State() (virt.DomainState, error) {
 	if d.removed {
-		return virt.DOMAIN_NOSTATE, fmt.Errorf("State() called on a removed (undefined) domain %q", d.name)
+		return virt.DOMAIN_NOSTATE, fmt.Errorf("State() called on a removed (undefined) domain %q", d.def.Name)
 	}
 	return d.state, nil
 }
 
 func (d *FakeDomain) UUIDString() (string, error) {
 	if d.removed {
-		return "", fmt.Errorf("UUIDString() called on a removed (undefined) domain %q", d.name)
+		return "", fmt.Errorf("UUIDString() called on a removed (undefined) domain %q", d.def.Name)
 	}
-	return d.uuid, nil
+	return d.def.UUID, nil
 }
 
 func (d *FakeDomain) Name() (string, error) {
-	return d.name, nil
+	return d.def.Name, nil
+}
+
+func (d *FakeDomain) Xml() (*libvirtxml.Domain, error) {
+	return d.def, nil
 }
 
 type FakeSecret struct {
@@ -274,4 +277,39 @@ func (s *FakeSecret) Remove() error {
 	s.rec.Rec("Remove", nil)
 	s.dc.removeSecret(s)
 	return nil
+}
+
+func copyDomain(def *libvirtxml.Domain) *libvirtxml.Domain {
+	s, err := def.Marshal()
+	if err != nil {
+		log.Panicf("failed to marshal libvirt domain: %v", err)
+	}
+	var copy libvirtxml.Domain
+	if err := copy.Unmarshal(s); err != nil {
+		log.Panicf("failed to unmarshal libvirt domain: %v", err)
+	}
+	return &copy
+}
+
+func assignFakePCIAddressesToControllers(def *libvirtxml.Domain) {
+	if def.Devices == nil {
+		return
+	}
+	domain := uint(0)
+	bus := uint(2)
+	function := uint(0)
+	for n, c := range def.Devices.Controllers {
+		if c.Address != nil {
+			continue
+		}
+		slot := uint(n + 1)
+		c.Address = &libvirtxml.DomainAddress{
+			PCI: &libvirtxml.DomainAddressPCI{
+				Domain:   &domain,
+				Bus:      &bus,
+				Slot:     &slot,
+				Function: &function,
+			},
+		}
+	}
 }

--- a/tests/e2e/volume_mount_test.go
+++ b/tests/e2e/volume_mount_test.go
@@ -37,7 +37,6 @@ var _ = Describe("Container volume mounts", func() {
 		)
 
 		BeforeAll(func() {
-			requireCloudInit()
 			virtletNodeName, err := controller.VirtletNodeName()
 			Expect(err).NotTo(HaveOccurred())
 			nodeExecutor, err = controller.DinDNodeExecutor(virtletNodeName)
@@ -79,7 +78,6 @@ var _ = Describe("Container volume mounts", func() {
 		)
 
 		BeforeAll(func() {
-			requireCloudInit()
 			vm = makeVolumeMountVM(map[string]string{
 				"type":     "qcow2",
 				"capacity": "10MB",
@@ -234,9 +232,13 @@ func makeVolumeMountVM(flexvolOptions map[string]string, nodeName string) *frame
 			MountPath: "/foo",
 		})
 	}
-	vm := controller.VM("ubuntu-vm")
+	vm := controller.VM("mount-vm")
 	vm.Create(VMOptions{
 		NodeName: nodeName,
+		// TODO: should also have an option to test using
+		// ubuntu image with volumes mounted using cloud-init
+		// userdata 'mounts' section
+		UserDataScript: "@virtlet-mount-script@",
 	}.applyDefaults(), time.Minute*5, podCustomization)
 	_, err := vm.Pod()
 	Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/volume_mount_test.go
+++ b/tests/e2e/volume_mount_test.go
@@ -30,14 +30,16 @@ import (
 var _ = Describe("Container volume mounts", func() {
 	Context("Of raw volumes", func() {
 		var (
-			vm           *framework.VMInterface
-			nodeExecutor framework.Executor
-			devPath      string
-			ssh          framework.Executor
+			err             error
+			virtletNodeName string
+			vm              *framework.VMInterface
+			nodeExecutor    framework.Executor
+			devPath         string
+			ssh             framework.Executor
 		)
 
 		BeforeAll(func() {
-			virtletNodeName, err := controller.VirtletNodeName()
+			virtletNodeName, err = controller.VirtletNodeName()
 			Expect(err).NotTo(HaveOccurred())
 			nodeExecutor, err = controller.DinDNodeExecutor(virtletNodeName)
 			Expect(err).NotTo(HaveOccurred())
@@ -48,26 +50,51 @@ var _ = Describe("Container volume mounts", func() {
 			Expect(err).NotTo(HaveOccurred())
 			devPath, err = framework.ExecSimple(nodeExecutor, "losetup", "-f", "/rawdevtest", "--show")
 			Expect(err).NotTo(HaveOccurred())
+		})
 
-			vm = makeVolumeMountVM(map[string]string{
-				"type": "raw",
-				"path": devPath,
-				"part": "0",
-			}, virtletNodeName)
+		AfterEach(func() {
+			if ssh != nil {
+				ssh.Close()
+			}
+			if vm != nil {
+				deleteVM(vm)
+			}
 		})
 
 		AfterAll(func() {
-			deleteVM(vm)
 			// The loopback device is detached by itself upon
 			// success (TODO: check why it happens), so we
 			// ignore errors here
 			framework.ExecSimple(nodeExecutor, "losetup", "-d", devPath)
 		})
 
-		scheduleWaitSSH(&vm, &ssh)
-
 		It("Should be handled inside the VM", func() {
-			shouldBeMounted(ssh)
+			vm = makeVolumeMountVM(virtletNodeName, func(pod *framework.PodInterface) {
+				addFlexvolMount(pod, "blockdev", "/foo", map[string]string{
+					"type": "raw",
+					"path": devPath,
+					"part": "0",
+				})
+			})
+			ssh = waitSSH(vm)
+			shouldBeMounted(ssh, "/foo")
+		})
+
+		It("Should be handled inside the VM together with another volume mount", func() {
+			vm = makeVolumeMountVM(virtletNodeName, func(pod *framework.PodInterface) {
+				addFlexvolMount(pod, "blockdev1", "/foo", map[string]string{
+					"type": "raw",
+					"path": devPath,
+					"part": "0",
+				})
+				addFlexvolMount(pod, "blockdev2", "/bar", map[string]string{
+					"type":     "qcow2",
+					"capacity": "10MB",
+				})
+			})
+			ssh = waitSSH(vm)
+			shouldBeMounted(ssh, "/foo")
+			shouldBeMounted(ssh, "/bar")
 		})
 	})
 
@@ -78,10 +105,12 @@ var _ = Describe("Container volume mounts", func() {
 		)
 
 		BeforeAll(func() {
-			vm = makeVolumeMountVM(map[string]string{
-				"type":     "qcow2",
-				"capacity": "10MB",
-			}, "")
+			vm = makeVolumeMountVM("", func(pod *framework.PodInterface) {
+				addFlexvolMount(pod, "blockdev", "/foo", map[string]string{
+					"type":     "qcow2",
+					"capacity": "10MB",
+				})
+			})
 		})
 
 		AfterAll(func() {
@@ -90,7 +119,7 @@ var _ = Describe("Container volume mounts", func() {
 
 		scheduleWaitSSH(&vm, &ssh)
 		It("Should be handled inside the VM [Conformance]", func() {
-			shouldBeMounted(ssh)
+			shouldBeMounted(ssh, "/foo")
 		})
 	})
 
@@ -216,22 +245,23 @@ var _ = Describe("Container volume mounts", func() {
 
 })
 
-func makeVolumeMountVM(flexvolOptions map[string]string, nodeName string) *framework.VMInterface {
-	podCustomization := func(pod *framework.PodInterface) {
-		pod.Pod.Spec.Volumes = append(pod.Pod.Spec.Volumes, v1.Volume{
-			Name: "blockdev",
-			VolumeSource: v1.VolumeSource{
-				FlexVolume: &v1.FlexVolumeSource{
-					Driver:  "virtlet/flexvolume_driver",
-					Options: flexvolOptions,
-				},
+func addFlexvolMount(pod *framework.PodInterface, name string, mountPath string, flexvolOptions map[string]string) {
+	pod.Pod.Spec.Volumes = append(pod.Pod.Spec.Volumes, v1.Volume{
+		Name: name,
+		VolumeSource: v1.VolumeSource{
+			FlexVolume: &v1.FlexVolumeSource{
+				Driver:  "virtlet/flexvolume_driver",
+				Options: flexvolOptions,
 			},
-		})
-		pod.Pod.Spec.Containers[0].VolumeMounts = append(pod.Pod.Spec.Containers[0].VolumeMounts, v1.VolumeMount{
-			Name:      "blockdev",
-			MountPath: "/foo",
-		})
-	}
+		},
+	})
+	pod.Pod.Spec.Containers[0].VolumeMounts = append(pod.Pod.Spec.Containers[0].VolumeMounts, v1.VolumeMount{
+		Name:      name,
+		MountPath: mountPath,
+	})
+}
+
+func makeVolumeMountVM(nodeName string, podCustomization func(*framework.PodInterface)) *framework.VMInterface {
 	vm := controller.VM("mount-vm")
 	vm.Create(VMOptions{
 		NodeName: nodeName,
@@ -245,8 +275,8 @@ func makeVolumeMountVM(flexvolOptions map[string]string, nodeName string) *frame
 	return vm
 }
 
-func shouldBeMounted(ssh framework.Executor) {
+func shouldBeMounted(ssh framework.Executor, path string) {
 	Eventually(func() (string, error) {
-		return framework.ExecSimple(ssh, "ls -l /foo")
+		return framework.ExecSimple(ssh, "ls -l "+path)
 	}, 60).Should(ContainSubstring("lost+found"))
 }


### PR DESCRIPTION
- [X] add WriteImage phase to VMVolume lifecycle (that can access full domain def retrieved from libvirt)
- [x] use `/dev/disk/by-path` instead of `/dev/sdX` for mounting
- [x] use `/dev/disk/by-path` instead of `/dev/vdX` for mounting
- [x] support mounting on udev-less systems / systems w/o proper userdata support (e.g. CirrOS or VyOS)
- [x] add e2e test that verifies the multiple-volume case
- [x] add documentation notes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/520)
<!-- Reviewable:end -->
