### PR TITLE
Fix Calico detection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,7 +378,7 @@ workflows:
         - build
         filters:
           branches:
-            only: master
+            only: /^master$|^.*-net$/
           tags:
             only:
               - /^v[0-9].*/
@@ -387,7 +387,7 @@ workflows:
         - build
         filters:
           branches:
-            only: master
+            only: /^master$|^.*-net$/
           tags:
             only:
               - /^v[0-9].*/

--- a/pkg/cni/client.go
+++ b/pkg/cni/client.go
@@ -66,20 +66,27 @@ func (c *Client) cniRuntimeConf(podId, podName, podNs string) *libcni.RuntimeCon
 
 // GetDummyNetwork creates a dummy network using CNI plugin.
 // It's used for making a dummy gateway for Calico CNI plugin.
-func (c *Client) GetDummyNetwork() (*cnicurrent.Result, error) {
+func (c *Client) GetDummyNetwork() (*cnicurrent.Result, string, error) {
 	// TODO: virtlet pod restarts should not grab another address for
 	// the gateway. That's not a big problem usually though
 	// as the IPs are not returned to Calico so both old
 	// IPs on existing VMs and new ones should work.
 	podId := utils.NewUuid()
 	if err := CreateNetNS(podId); err != nil {
-		return nil, fmt.Errorf("couldn't create netns for fake pod %q: %v", podId, err)
+		return nil, "", fmt.Errorf("couldn't create netns for fake pod %q: %v", podId, err)
 	}
-	return c.AddSandboxToNetwork(podId, "", "")
+	r, err := c.AddSandboxToNetwork(podId, "", "")
+	if err != nil {
+		return nil, "", fmt.Errorf("couldn't set up CNI for fake pod %q: %v", podId, err)
+	}
+	return r, PodNetNSPath(podId), nil
 }
 
 func (c *Client) AddSandboxToNetwork(podId, podName, podNs string) (*cnicurrent.Result, error) {
 	rtConf := c.cniRuntimeConf(podId, podName, podNs)
+	rtConf.Args = append(rtConf.Args, [2]string{
+		"K8S_ANNOT", `{"cni": "calico"}`,
+	})
 	glog.V(3).Infof("AddSandboxToNetwork: podId %q, podName %q, podNs %q, runtime config:\n%s",
 		podId, podName, podNs, spew.Sdump(rtConf))
 	result, err := c.cniConfig.AddNetworkList(c.netConfigList, rtConf)

--- a/pkg/cni/client.go
+++ b/pkg/cni/client.go
@@ -84,6 +84,7 @@ func (c *Client) GetDummyNetwork() (*cnicurrent.Result, string, error) {
 
 func (c *Client) AddSandboxToNetwork(podId, podName, podNs string) (*cnicurrent.Result, error) {
 	rtConf := c.cniRuntimeConf(podId, podName, podNs)
+	// NOTE: this annotation is only need by CNI Genie
 	rtConf.Args = append(rtConf.Args, [2]string{
 		"K8S_ANNOT", `{"cni": "calico"}`,
 	})

--- a/pkg/nettools/nettools.go
+++ b/pkg/nettools/nettools.go
@@ -1131,7 +1131,6 @@ func getDummyGateway(dummyNetwork *cnicurrent.Result) (net.IP, error) {
 // This function must be called from within the container network
 // namespace.
 func FixCalicoNetworking(netConfig *cnicurrent.Result, getDummyNetwork func() (*cnicurrent.Result, string, error)) error {
-	// linkNameMap := make(map[string]*cnicurrent.IPConfig)
 	for n, ipConfig := range netConfig.IPs {
 		link, err := getLinkForIPConfig(netConfig, n)
 		if err != nil {

--- a/pkg/nettools/nettools.go
+++ b/pkg/nettools/nettools.go
@@ -43,6 +43,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"syscall"
 	"unsafe"
 
@@ -65,6 +66,9 @@ const (
 
 	SizeOfIfReq = 40
 	IFNAMSIZ    = 16
+
+	calicoDefaultSubnet = 24
+	calicoSubnetVar     = "VIRTLET_CALICO_SUBNET"
 )
 
 // InterfaceType presents type of network interface instance
@@ -374,12 +378,11 @@ func ValidateAndFixCNIResult(netConfig *cnicurrent.Result, podNs string, allLink
 		return nil, fmt.Errorf("cni result does not have any IP addresses")
 	}
 
-	// If on list of interfaces are missing elements matching these mentioned
-	// by interface index in elements of ip list and for all elements
-	// of this list which have value -1 for interface index - add them to list
-	// of interfaces and fix its index in ip list entry
+	// Try to fix missing interface references in netConfig.IPs
+	// and add entries to Interfaces for links that need to be
+	// there but aren't
 	if len(netConfig.Interfaces) == 0 {
-		alreadyDefinedLinks, err := GetContainerLinks(netConfig.Interfaces, allLinks)
+		alreadyDefinedLinks, err := GetContainerLinks(netConfig.Interfaces)
 		if err != nil {
 			return nil, err
 		}
@@ -413,25 +416,16 @@ func ValidateAndFixCNIResult(netConfig *cnicurrent.Result, podNs string, allLink
 	return netConfig, nil
 }
 
-func findLinkByName(links []netlink.Link, name string) (netlink.Link, error) {
-	for _, link := range links {
-		if link.Attrs().Name == name {
-			return link, nil
-		}
-	}
-	return nil, fmt.Errorf("interface with name %q not found in container namespace", name)
-}
-
-// GetContainerLinks filters provided list of links looking for container links
-// from provided interfaces list
-func GetContainerLinks(interfaces []*cnicurrent.Interface, allLinks []netlink.Link) ([]netlink.Link, error) {
+// GetContainerLinks finds links that correspond to interfaces in the current
+// network namespace
+func GetContainerLinks(interfaces []*cnicurrent.Interface) ([]netlink.Link, error) {
 	var links []netlink.Link
 	for _, iface := range interfaces {
 		// if Sandbox is empty interface is on host, not in container netns
 		if iface.Sandbox == "" {
 			continue
 		}
-		link, err := findLinkByName(allLinks, iface.Name)
+		link, err := netlink.LinkByName(iface.Name)
 		if err != nil {
 			return nil, err
 		}
@@ -513,6 +507,11 @@ func ExtractLinkInfo(link netlink.Link, nsPath string) (*cnicurrent.Result, erro
 		switch {
 		case route.Protocol == syscall.RTPROT_KERNEL:
 			// route created by kernel
+		case route.Gw == nil:
+			// these routes can't be represented properly
+			// by CNI result because CNI will consider
+			// them having IP's default Gateway value as
+			// Gw
 		case (route.Dst == nil || route.Dst.IP == nil) && route.Gw == nil:
 			// route has only Src
 		case (route.Dst == nil || route.Dst.IP == nil):
@@ -700,7 +699,7 @@ func rebindDriverToDevice(devName string) error {
 // The function should be called from within container namespace.
 // Returns container network struct and an error, if any.
 func SetupContainerSideNetwork(info *cnicurrent.Result, nsPath string, allLinks []netlink.Link) (*ContainerSideNetwork, error) {
-	contLinks, err := GetContainerLinks(info.Interfaces, allLinks)
+	contLinks, err := GetContainerLinks(info.Interfaces)
 	if err != nil {
 		return nil, err
 	}
@@ -826,7 +825,7 @@ func RecreateContainerSideNetwork(info *cnicurrent.Result, nsPath string, allLin
 	}
 
 	// FIXME: this will not work with sr-iov device passed to VM
-	contLinks, err := GetContainerLinks(info.Interfaces, allLinks)
+	contLinks, err := GetContainerLinks(info.Interfaces)
 	if err != nil {
 		return nil, err
 	}
@@ -941,12 +940,8 @@ func (csn *ContainerSideNetwork) Teardown() error {
 	for _, f := range csn.Fds {
 		f.Close()
 	}
-	allLinks, err := netlink.LinkList()
-	if err != nil {
-		return fmt.Errorf("error listing links: %v", err)
-	}
 
-	contLinks, err := GetContainerLinks(csn.Result.Interfaces, allLinks)
+	contLinks, err := GetContainerLinks(csn.Result.Interfaces)
 	if err != nil {
 		return err
 	}
@@ -1060,4 +1055,146 @@ func GenerateMacAddress() (net.HardwareAddr, error) {
 	}
 
 	return mac, nil
+}
+
+var calicoGatewayIP = net.IP{169, 254, 1, 1}
+
+// DetectCalico checks if the specified link in the current network
+// namespace is configured by Calico. It returns two boolean values
+// where the first one denotes whether Calico is used for the specified
+// link and the second one denotes whether Calico's default route
+// needs to be used. This approach is needed for multiple CNI use case
+// when the types of individual CNI plugins are not available.
+func DetectCalico(link netlink.Link) (bool, bool, error) {
+	haveCalico, haveCalicoGateway := false, false
+	routes, err := netlink.RouteList(link, netlink.FAMILY_V4)
+	if err != nil {
+		return false, false, fmt.Errorf("failed to list routes: %v", err)
+	}
+	for _, route := range routes {
+		switch {
+		case route.Protocol == syscall.RTPROT_KERNEL:
+			// route created by kernel
+		case route.LinkIndex == link.Attrs().Index && route.Gw == nil && route.Dst.IP.Equal(calicoGatewayIP):
+			haveCalico = true
+		case (route.Dst == nil || route.Dst.IP == nil) && route.Gw.Equal(calicoGatewayIP):
+			haveCalicoGateway = true
+		}
+	}
+	return haveCalico, haveCalico && haveCalicoGateway, nil
+}
+
+func getLinkForIPConfig(netConfig *cnicurrent.Result, ipConfigIndex int) (netlink.Link, error) {
+	if ipConfigIndex > len(netConfig.IPs) {
+		return nil, fmt.Errorf("ip config index out of range: %d", ipConfigIndex)
+	}
+
+	ipConfig := netConfig.IPs[ipConfigIndex]
+	if ipConfig.Interface >= len(netConfig.Interfaces) {
+		return nil, errors.New("interface index out of range in the CNI result")
+	}
+
+	if ipConfig.Version != "4" {
+		return nil, errors.New("skipping non-IPv4 config")
+	}
+
+	iface := netConfig.Interfaces[ipConfig.Interface]
+	if iface.Sandbox == "" {
+		return nil, errors.New("error: IP config has non-sandboxed interace")
+	}
+
+	link, err := netlink.LinkByName(iface.Name)
+	if err != nil {
+		return nil, fmt.Errorf("can't get link %q: %v", iface.Name, err)
+	}
+
+	return link, nil
+}
+
+func getDummyGateway(dummyNetwork *cnicurrent.Result) (net.IP, error) {
+	for n, ipConfig := range dummyNetwork.IPs {
+		var haveCalico bool
+		link, err := getLinkForIPConfig(dummyNetwork, n)
+		if err == nil {
+			haveCalico, _, err = DetectCalico(link)
+		}
+		if err != nil {
+			glog.Warning("Calico fix: dummy network: skipping link for config %d: %v", n, err)
+			continue
+		}
+		if haveCalico {
+			return ipConfig.Address.IP, nil
+		}
+	}
+	return nil, errors.New("Calico fix: couldn't find dummy gateway")
+}
+
+// FixCalicoNetworking updates netConfig to make Calico work with
+// Virtlet's DHCP-server based scheme. It does so by throwing away
+// Calico's gateway and dev route and using a fake gateway instead.
+// The fake gateway provided by getDummyGateway() is just an IP
+// address allocated by Calico IPAM, it's needed for proper ARP
+// responses for VMs.
+// This function must be called from within the container network
+// namespace.
+func FixCalicoNetworking(netConfig *cnicurrent.Result, getDummyNetwork func() (*cnicurrent.Result, error)) error {
+	// linkNameMap := make(map[string]*cnicurrent.IPConfig)
+	for n, ipConfig := range netConfig.IPs {
+		link, err := getLinkForIPConfig(netConfig, n)
+		if err != nil {
+			glog.Warning("Calico fix: skipping link for config %d: %v", n, err)
+			continue
+		}
+		haveCalico, haveCalicoGateway, err := DetectCalico(link)
+		if err != nil {
+			return err
+		}
+		if !haveCalico {
+			continue
+		}
+		ipConfig.Address.Mask = netmaskForCalico()
+		if haveCalicoGateway {
+			dummyNetwork, err := getDummyNetwork()
+			if err != nil {
+				return err
+			}
+			dummyGateway, err := getDummyGateway(dummyNetwork)
+			if err != nil {
+				return err
+			}
+			ipConfig.Gateway = dummyGateway
+			var newRoutes []*cnitypes.Route
+			// remove the deault gateway
+			for _, r := range netConfig.Routes {
+				if r.Dst.Mask != nil {
+					ones, _ := r.Dst.Mask.Size()
+					if ones == 0 {
+						continue
+					}
+				}
+				newRoutes = append(newRoutes, r)
+			}
+			netConfig.Routes = append(newRoutes, &cnitypes.Route{
+				Dst: net.IPNet{
+					IP:   net.IP{0, 0, 0, 0},
+					Mask: net.IPMask{0, 0, 0, 0},
+				},
+				GW: dummyGateway,
+			})
+		}
+	}
+	return nil
+}
+
+func netmaskForCalico() net.IPMask {
+	n := calicoDefaultSubnet
+	subnetStr := os.Getenv(calicoSubnetVar)
+	if subnetStr != "" {
+		n, err := strconv.Atoi(subnetStr)
+		if err != nil || n <= 0 || n > 30 {
+			glog.Warningf("bad calico subnet %q, using /%d", subnetStr, calicoDefaultSubnet)
+			n = calicoDefaultSubnet
+		}
+	}
+	return net.CIDRMask(n, 32)
 }

--- a/pkg/nettools/nettools.go
+++ b/pkg/nettools/nettools.go
@@ -1112,7 +1112,7 @@ func getDummyGateway(dummyNetwork *cnicurrent.Result) (net.IP, error) {
 			haveCalico, _, err = DetectCalico(link)
 		}
 		if err != nil {
-			glog.Warning("Calico fix: dummy network: skipping link for config %d: %v", n, err)
+			glog.Warningf("Calico fix: dummy network: skipping link for config %d: %v", n, err)
 			continue
 		}
 		if haveCalico {
@@ -1130,12 +1130,12 @@ func getDummyGateway(dummyNetwork *cnicurrent.Result) (net.IP, error) {
 // responses for VMs.
 // This function must be called from within the container network
 // namespace.
-func FixCalicoNetworking(netConfig *cnicurrent.Result, getDummyNetwork func() (*cnicurrent.Result, error)) error {
+func FixCalicoNetworking(netConfig *cnicurrent.Result, getDummyNetwork func() (*cnicurrent.Result, string, error)) error {
 	// linkNameMap := make(map[string]*cnicurrent.IPConfig)
 	for n, ipConfig := range netConfig.IPs {
 		link, err := getLinkForIPConfig(netConfig, n)
 		if err != nil {
-			glog.Warning("Calico fix: skipping link for config %d: %v", n, err)
+			glog.Warningf("Calico fix: skipping link for config %d: %v", n, err)
 			continue
 		}
 		haveCalico, haveCalicoGateway, err := DetectCalico(link)
@@ -1147,17 +1147,35 @@ func FixCalicoNetworking(netConfig *cnicurrent.Result, getDummyNetwork func() (*
 		}
 		ipConfig.Address.Mask = netmaskForCalico()
 		if haveCalicoGateway {
-			dummyNetwork, err := getDummyNetwork()
+			dummyNetwork, nsPath, err := getDummyNetwork()
 			if err != nil {
 				return err
 			}
-			dummyGateway, err := getDummyGateway(dummyNetwork)
+			dummyNS, err := ns.GetNS(nsPath)
 			if err != nil {
 				return err
 			}
-			ipConfig.Gateway = dummyGateway
+			if err := dummyNS.Do(func(ns.NetNS) error {
+				allLinks, err := netlink.LinkList()
+				if err != nil {
+					return fmt.Errorf("failed to list links inside the dummy netns: %v", err)
+				}
+				dummyNetwork, err := ValidateAndFixCNIResult(dummyNetwork, nsPath, allLinks)
+				if err != nil {
+					return err
+				}
+				dummyGateway, err := getDummyGateway(dummyNetwork)
+				if err != nil {
+					return err
+				}
+				ipConfig.Gateway = dummyGateway
+				return nil
+			}); err != nil {
+				return err
+			}
+
 			var newRoutes []*cnitypes.Route
-			// remove the deault gateway
+			// remove the default gateway
 			for _, r := range netConfig.Routes {
 				if r.Dst.Mask != nil {
 					ones, _ := r.Dst.Mask.Size()
@@ -1172,7 +1190,7 @@ func FixCalicoNetworking(netConfig *cnicurrent.Result, getDummyNetwork func() (*
 					IP:   net.IP{0, 0, 0, 0},
 					Mask: net.IPMask{0, 0, 0, 0},
 				},
-				GW: dummyGateway,
+				GW: ipConfig.Gateway,
 			})
 		}
 	}

--- a/pkg/nettools/nettools.go
+++ b/pkg/nettools/nettools.go
@@ -355,8 +355,9 @@ func findLinkByAddress(links []netlink.Link, address net.IPNet) (netlink.Link, e
 func ValidateAndFixCNIResult(netConfig *cnicurrent.Result, podNs string, allLinks []netlink.Link) (*cnicurrent.Result, error) {
 	// If there are no routes provided, we consider it a broken
 	// config and extract interface config instead. That's the
-	// case with Weave CNI plugin.
-	if cni.GetPodIP(netConfig) == "" || len(netConfig.Routes) == 0 {
+	// case with Weave CNI plugin. We don't do this for multiple CNI
+	// at this point.
+	if len(netConfig.IPs) == 1 && (cni.GetPodIP(netConfig) == "" || len(netConfig.Routes) == 0) {
 		dnsInfo := netConfig.DNS
 
 		veth, err := FindVeth(allLinks)

--- a/pkg/nettools/nettools_test.go
+++ b/pkg/nettools/nettools_test.go
@@ -36,8 +36,8 @@ const (
 	outerHwAddr       = "42:b5:b7:33:91:3f"
 	secondInnerHwAddr = "42:a4:a6:22:80:2f"
 	secondOuterHwAddr = "42:b5:b7:33:91:3e"
-	dummyInnerHwAddr  = "42:a4:a6:22:80:30"
-	dummyOuterHwAddr  = "42:b5:b7:33:91:3f"
+	dummyInnerHwAddr  = "42:a4:a6:22:80:40"
+	dummyOuterHwAddr  = "42:b5:b7:33:91:4f"
 )
 
 func expectedExtractedLinkInfo(contNsPath string) *cnicurrent.Result {

--- a/pkg/nettools/nettools_test.go
+++ b/pkg/nettools/nettools_test.go
@@ -276,16 +276,20 @@ func withFakeCNIVeth(t *testing.T, toRun func(hostNS, contNS ns.NetNS, origHostV
 				log.Panicf("failed to add addr for origContVeth: %v", err)
 			}
 
-			gwAddr := parseAddr("10.1.90.1/24")
-
-			addTestRoute(t, &netlink.Route{
-				LinkIndex: origContVeth.Attrs().Index,
-				Gw:        gwAddr.IPNet.IP,
-				Scope:     netlink.SCOPE_UNIVERSE,
-			})
-
 			toRun(hostNS, contNS, origHostVeth, origContVeth)
 		})
+	})
+}
+
+func withFakeCNIVethAndGateway(t *testing.T, toRun func(hostNS, contNS ns.NetNS, origHostVeth, origContVeth netlink.Link)) {
+	withFakeCNIVeth(t, func(hostNS, contNS ns.NetNS, origHostVeth, origContVeth netlink.Link) {
+		addTestRoute(t, &netlink.Route{
+			LinkIndex: origContVeth.Attrs().Index,
+			Gw:        parseAddr("10.1.90.1/24").IPNet.IP,
+			Scope:     netlink.SCOPE_UNIVERSE,
+		})
+
+		toRun(hostNS, contNS, origHostVeth, origContVeth)
 	})
 }
 
@@ -304,7 +308,7 @@ func verifyNoAddressAndRoutes(t *testing.T, link netlink.Link) {
 }
 
 func TestFindVeth(t *testing.T) {
-	withFakeCNIVeth(t, func(hostNS, contNS ns.NetNS, origHostVeth, origContVeth netlink.Link) {
+	withFakeCNIVethAndGateway(t, func(hostNS, contNS ns.NetNS, origHostVeth, origContVeth netlink.Link) {
 		allLinks, err := netlink.LinkList()
 		if err != nil {
 			log.Panicf("LinkList() failed: %v", err)
@@ -321,7 +325,7 @@ func TestFindVeth(t *testing.T) {
 }
 
 func TestStripLink(t *testing.T) {
-	withFakeCNIVeth(t, func(hostNS, contNS ns.NetNS, origHostVeth, origContVeth netlink.Link) {
+	withFakeCNIVethAndGateway(t, func(hostNS, contNS ns.NetNS, origHostVeth, origContVeth netlink.Link) {
 		if err := StripLink(origContVeth); err != nil {
 			log.Panicf("StripLink() failed: %v", err)
 		}
@@ -330,7 +334,7 @@ func TestStripLink(t *testing.T) {
 }
 
 func TestExtractLinkInfo(t *testing.T) {
-	withFakeCNIVeth(t, func(hostNS, contNS ns.NetNS, origHostVeth, origContVeth netlink.Link) {
+	withFakeCNIVethAndGateway(t, func(hostNS, contNS ns.NetNS, origHostVeth, origContVeth netlink.Link) {
 		info, err := ExtractLinkInfo(origContVeth, contNS.Path())
 		if err != nil {
 			log.Panicf("failed to grab interface info: %v", err)
@@ -394,7 +398,7 @@ func verifyContainerSideNetwork(t *testing.T, origContVeth netlink.Link, contNsP
 }
 
 func TestSetUpContainerSideNetworkWithInfo(t *testing.T) {
-	withFakeCNIVeth(t, func(hostNS, contNS ns.NetNS, origHostVeth, origContVeth netlink.Link) {
+	withFakeCNIVethAndGateway(t, func(hostNS, contNS ns.NetNS, origHostVeth, origContVeth netlink.Link) {
 		if err := StripLink(origContVeth); err != nil {
 			log.Panicf("StripLink() failed: %v", err)
 		}
@@ -403,7 +407,7 @@ func TestSetUpContainerSideNetworkWithInfo(t *testing.T) {
 }
 
 func TestLoopbackInterface(t *testing.T) {
-	withFakeCNIVeth(t, func(hostNS, contNS ns.NetNS, origHostVeth, origContVeth netlink.Link) {
+	withFakeCNIVethAndGateway(t, func(hostNS, contNS ns.NetNS, origHostVeth, origContVeth netlink.Link) {
 		verifyContainerSideNetwork(t, origContVeth, contNS.Path())
 		if out, err := exec.Command("ping", "-c", "1", "127.0.0.1").CombinedOutput(); err != nil {
 			log.Panicf("ping 127.0.0.1 failed:\n%s", out)
@@ -479,7 +483,7 @@ func verifyVethHaveConfiguration(t *testing.T, info *cnicurrent.Result) {
 }
 
 func TestTeardownContainerSideNetwork(t *testing.T) {
-	withFakeCNIVeth(t, func(hostNS, contNS ns.NetNS, origHostVeth, origContVeth netlink.Link) {
+	withFakeCNIVethAndGateway(t, func(hostNS, contNS ns.NetNS, origHostVeth, origContVeth netlink.Link) {
 		if err := StripLink(origContVeth); err != nil {
 			log.Panicf("StripLink() failed: %v", err)
 		}
@@ -634,6 +638,144 @@ func TestMultiInterfacesWithMissingInterface(t *testing.T) {
 		if !reflect.DeepEqual(result, expectedInfo) {
 			t.Errorf("result different than expected: %\nActual:\n%s\nExpected:\n%s",
 				spew.Sdump(result), spew.Sdump(expectedInfo))
+		}
+	})
+}
+
+func TestCalicoDetection(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		routes            []netlink.Route
+		haveCalico        bool
+		haveCalicoGateway bool
+	}{
+		{
+			name:              "no routes",
+			haveCalico:        false,
+			haveCalicoGateway: false,
+		},
+		{
+			name: "non-calico default route",
+			routes: []netlink.Route{
+				{
+					// LinkIndex: origContVeth.Attrs().Index,
+					Gw:    parseAddr("10.1.90.1/24").IPNet.IP,
+					Scope: netlink.SCOPE_UNIVERSE,
+				},
+			},
+			haveCalico:        false,
+			haveCalicoGateway: false,
+		},
+		{
+			name: "calico w/o default gw",
+			routes: []netlink.Route{
+				{
+					Dst:   parseAddr("169.254.1.1/32").IPNet,
+					Scope: netlink.SCOPE_LINK,
+				},
+			},
+			haveCalico:        true,
+			haveCalicoGateway: false,
+		},
+		{
+			name: "calico w/o default gw",
+			routes: []netlink.Route{
+				{
+					Dst:   parseAddr("169.254.1.1/32").IPNet,
+					Scope: netlink.SCOPE_LINK,
+				},
+				{
+					Gw:    parseAddr("169.254.1.1/32").IPNet.IP,
+					Scope: netlink.SCOPE_UNIVERSE,
+				},
+			},
+			haveCalico:        true,
+			haveCalicoGateway: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			withFakeCNIVeth(t, func(hostNS, contNS ns.NetNS, origHostVeth, origContVeth netlink.Link) {
+				for _, r := range tc.routes {
+					r.LinkIndex = origContVeth.Attrs().Index
+					addTestRoute(t, &r)
+				}
+				haveCalico, haveCalicoGateway, err := DetectCalico(origContVeth)
+				if err != nil {
+					log.Panicf("DetectCalico(): %v", err)
+				}
+				if haveCalico != tc.haveCalico {
+					log.Panicf("haveCalico is expected to be %v but is %v", haveCalico, tc.haveCalico)
+				}
+				if haveCalicoGateway != tc.haveCalicoGateway {
+					log.Panicf("haveCalico is expected to be %v but is %v", haveCalicoGateway, tc.haveCalicoGateway)
+				}
+			})
+		})
+	}
+}
+
+func TestFixCalicoNetworking(t *testing.T) {
+	withFakeCNIVeth(t, func(hostNS, contNS ns.NetNS, origHostVeth, origContVeth netlink.Link) {
+		for _, r := range []netlink.Route{
+			{
+				Dst:   parseAddr("169.254.1.1/32").IPNet,
+				Scope: netlink.SCOPE_LINK,
+			},
+			{
+				Gw:    parseAddr("169.254.1.1/32").IPNet.IP,
+				Scope: netlink.SCOPE_UNIVERSE,
+			},
+		} {
+			r.LinkIndex = origContVeth.Attrs().Index
+			addTestRoute(t, &r)
+		}
+		var infos [2]*cnicurrent.Result
+		for i := 0; i < 2; i++ {
+			var err error
+			infos[i], err = ExtractLinkInfo(origContVeth, contNS.Path())
+			if err != nil {
+				log.Panicf("failed to grab interface info: %v", err)
+			}
+		}
+		// reuse 2nd copy of the CNI result as the dummy network config
+		infos[1].IPs[0].Address.IP = net.IP{10, 1, 90, 100}
+		if err := FixCalicoNetworking(infos[0], func() (*cnicurrent.Result, error) {
+			return infos[1], nil
+		}); err != nil {
+			log.Panicf("FixCalicoNetworking(): %v", err)
+		}
+		expectedResult := &cnicurrent.Result{
+			Interfaces: []*cnicurrent.Interface{
+				{
+					Name:    "eth0",
+					Mac:     innerHwAddr,
+					Sandbox: contNS.Path(),
+				},
+			},
+			IPs: []*cnicurrent.IPConfig{
+				{
+					Version:   "4",
+					Interface: 0,
+					Address: net.IPNet{
+						IP:   net.IP{10, 1, 90, 5},
+						Mask: net.IPMask{255, 255, 255, 0},
+					},
+					Gateway: net.IP{10, 1, 90, 100},
+				},
+			},
+			Routes: []*cnitypes.Route{
+				{
+					Dst: net.IPNet{
+						IP:   net.IP{0, 0, 0, 0},
+						Mask: net.IPMask{0, 0, 0, 0},
+					},
+					GW: net.IP{10, 1, 90, 100},
+				},
+			},
+		}
+		if !reflect.DeepEqual(infos[0], expectedResult) {
+			t.Errorf("interface info mismatch. Expected:\n%s\nActual:\n%s",
+				spew.Sdump(expectedResult), spew.Sdump(infos[0]))
 		}
 	})
 }

--- a/pkg/nettools/nettools_test.go
+++ b/pkg/nettools/nettools_test.go
@@ -671,7 +671,6 @@ func TestMultiInterfaces(t *testing.T) {
 }
 
 func TestMultiInterfacesWithMissingInterface(t *testing.T) {
-	t.Skip("Temporary skip for missing functionality")
 	withMultipleInterfacesConfigured(t, func(contNS ns.NetNS, innerLinks []netlink.Link) {
 		infoToFix := expectedExtractedLinkInfoForMultipleInterfaces(contNS.Path())
 		expectedInfo := expectedExtractedLinkInfoForMultipleInterfaces(contNS.Path())

--- a/pkg/tapmanager/tapfdsource.go
+++ b/pkg/tapmanager/tapfdsource.go
@@ -92,9 +92,10 @@ type podNetwork struct {
 type TapFDSource struct {
 	sync.Mutex
 
-	cniClient    *cni.Client
-	dummyNetwork *cnicurrent.Result
-	fdMap        map[string]*podNetwork
+	cniClient          *cni.Client
+	dummyNetwork       *cnicurrent.Result
+	dummyNetworkNsPath string
+	fdMap              map[string]*podNetwork
 }
 
 var _ FDSource = &TapFDSource{}
@@ -115,17 +116,17 @@ func NewTapFDSource(cniPluginsDir, cniConfigsDir string) (*TapFDSource, error) {
 	return s, nil
 }
 
-func (s *TapFDSource) getDummyNetwork() (*cnicurrent.Result, error) {
+func (s *TapFDSource) getDummyNetwork() (*cnicurrent.Result, string, error) {
 	if s.dummyNetwork == nil {
 		var err error
-		s.dummyNetwork, err = s.cniClient.GetDummyNetwork()
+		s.dummyNetwork, s.dummyNetworkNsPath, err = s.cniClient.GetDummyNetwork()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
 		// s.dummyGateway = dummyResult.IPs[0].Address.IP
 
 	}
-	return s.dummyNetwork, nil
+	return s.dummyNetwork, s.dummyNetworkNsPath, nil
 }
 
 // GetFDs implements GetFDs method of FDSource interface

--- a/pkg/tapmanager/tapfdsource.go
+++ b/pkg/tapmanager/tapfdsource.go
@@ -18,11 +18,8 @@ package tapmanager
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
-	"os"
-	"strconv"
 	"sync"
 	"syscall"
 	"time"
@@ -39,10 +36,14 @@ import (
 	"github.com/Mirantis/virtlet/pkg/nettools"
 )
 
+// InterfaceType presents type of network interface instance
+type InterfaceType int
+
 const (
-	calicoNetType       = "calico"
-	calicoDefaultSubnet = 24
-	calicoSubnetVar     = "VIRTLET_CALICO_SUBNET"
+	InterfaceTypeTap    InterfaceType = iota
+	calicoNetType                     = "calico"
+	calicoDefaultSubnet               = 24
+	calicoSubnetVar                   = "VIRTLET_CALICO_SUBNET"
 )
 
 // InterfaceDescription contains interface type with additional data
@@ -92,7 +93,7 @@ type TapFDSource struct {
 	sync.Mutex
 
 	cniClient    *cni.Client
-	dummyGateway net.IP
+	dummyNetwork *cnicurrent.Result
 	fdMap        map[string]*podNetwork
 }
 
@@ -111,23 +112,20 @@ func NewTapFDSource(cniPluginsDir, cniConfigsDir string) (*TapFDSource, error) {
 		fdMap:     make(map[string]*podNetwork),
 	}
 
-	// Calico needs special treatment here.
-	// We need to make network config DHCP-compatible by throwing away
-	// Calico's gateway and dev route and using a fake gateway instead.
-	// The fake gateway is just an IP address allocated by Calico IPAM,
-	// it's needed for proper ARP resppnses for VMs.
-	if cniClient.Type() == calicoNetType {
-		dummyResult, err := cniClient.GetDummyNetwork()
+	return s, nil
+}
+
+func (s *TapFDSource) getDummyNetwork() (*cnicurrent.Result, error) {
+	if s.dummyNetwork == nil {
+		var err error
+		s.dummyNetwork, err = s.cniClient.GetDummyNetwork()
 		if err != nil {
 			return nil, err
 		}
-		if len(dummyResult.IPs) != 1 {
-			return nil, fmt.Errorf("expected 1 ip for the dummy network, but got %d", len(dummyResult.IPs))
-		}
-		s.dummyGateway = dummyResult.IPs[0].Address.IP
-	}
+		// s.dummyGateway = dummyResult.IPs[0].Address.IP
 
-	return s, nil
+	}
+	return s.dummyNetwork, nil
 }
 
 // GetFDs implements GetFDs method of FDSource interface
@@ -161,26 +159,6 @@ func (s *TapFDSource) GetFDs(key string, data []byte) ([]int, []byte, error) {
 
 	netConfig := payload.CNIConfig
 
-	// Calico needs network config to be adjusted for DHCP compatibility
-	if s.dummyGateway != nil {
-		if len(netConfig.IPs) != 1 {
-			return nil, nil, errors.New("didn't expect more than one IP config")
-		}
-		if netConfig.IPs[0].Version != "4" {
-			return nil, nil, errors.New("IPv4 config was expected")
-		}
-		netConfig.IPs[0].Gateway = s.dummyGateway
-		netConfig.Routes = []*cnitypes.Route{
-			{
-				Dst: net.IPNet{
-					IP:   net.IP{0, 0, 0, 0},
-					Mask: net.IPMask{0, 0, 0, 0},
-				},
-				GW: s.dummyGateway,
-			},
-		}
-	}
-
 	netNSPath := cni.PodNetNSPath(pnd.PodId)
 	vmNS, err := ns.GetNS(netNSPath)
 	if err != nil {
@@ -213,8 +191,9 @@ func (s *TapFDSource) GetFDs(key string, data []byte) ([]int, []byte, error) {
 		if netConfig, err = nettools.ValidateAndFixCNIResult(netConfig, pnd.PodNs, allLinks); err != nil {
 			return fmt.Errorf("error in fixing cni configuration: %v", err)
 		}
-		if s.dummyGateway != nil {
-			netConfig.IPs[0].Address.Mask = netmaskForCalico()
+		if err := nettools.FixCalicoNetworking(netConfig, s.getDummyNetwork); err != nil {
+			// don't fail in this case because there may be even no Calico
+			glog.Warningf("Calico detection/fix didn't work: %v", err)
 		}
 		glog.V(3).Infof("CNI Result after fix:\n%s", spew.Sdump(netConfig))
 
@@ -336,17 +315,4 @@ func (s *TapFDSource) GetInfo(key string) ([]byte, error) {
 		return nil, fmt.Errorf("interface descriptions marshaling error: %v", err)
 	}
 	return data, nil
-}
-
-func netmaskForCalico() net.IPMask {
-	n := calicoDefaultSubnet
-	subnetStr := os.Getenv(calicoSubnetVar)
-	if subnetStr != "" {
-		n, err := strconv.Atoi(subnetStr)
-		if err != nil || n <= 0 || n > 30 {
-			glog.Warningf("bad calico subnet %q, using /%d", subnetStr, calicoDefaultSubnet)
-			n = calicoDefaultSubnet
-		}
-	}
-	return net.CIDRMask(n, 32)
 }

--- a/pkg/tapmanager/tapfdsource.go
+++ b/pkg/tapmanager/tapfdsource.go
@@ -185,11 +185,10 @@ func (s *TapFDSource) GetFDs(key string, data []byte) ([]int, []byte, error) {
 		}
 		allLinks, err := netlink.LinkList()
 		if err != nil {
-			return fmt.Errorf("error listing links: %v", err)
+			return fmt.Errorf("error listing the links: %v", err)
 		}
-
-		if netConfig, err = nettools.ValidateAndFixCNIResult(netConfig, pnd.PodNs, allLinks); err != nil {
-			return fmt.Errorf("error in fixing cni configuration: %v", err)
+		if netConfig, err = nettools.ValidateAndFixCNIResult(netConfig, netNSPath, allLinks); err != nil {
+			return fmt.Errorf("error fixing cni configuration: %v", err)
 		}
 		if err := nettools.FixCalicoNetworking(netConfig, s.getDummyNetwork); err != nil {
 			// don't fail in this case because there may be even no Calico


### PR DESCRIPTION
Make it compatible with CNI Genie
- [X] implement Calico detection based on Calico-specific routes
- [X] run e2e with weave and flannel for branches ending with `-net`
- [X] test with CNI Genie
- [X] clean up code & commits
- [X] add testing instructions

Testing instructions:

1. Start k-d-c:
```
~/dind-cluster-v1.8.sh up
```
1. Start CNI genie using https://raw.githubusercontent.com/Huawei-PaaS/CNI-Genie/master/conf/1.8/genie.yaml with the container image changed to `lukaszo/cnigenie:env`:
   ```
   kubectl apply -f genie.yaml
   ```
1. Deploy Calico:
   ```
   kubectl apply -f https://docs.projectcalico.org/v2.6/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
   ```
1. Wait for Calico & Genie pods to become `Running`: 
   ```
   kubectl get pods -n kube-system -o wide -w
   ```
1. Update CNI configuration to make it support bridge & calico with default gw via Calico only:
   ```
   docker exec -i kube-node-1 /bin/bash -s <<"EOF"
   set -u -e
   jqm() {
       jq "$1" "$2" >/tmp/x
       mv /tmp/x "$2"
   }
   jqm ".cniVersion|=\"0.3.1\"" /etc/cni/net.d/00-genie.conf
   mv /etc/cni/net.d/{cni.conf,20-bridge.conf}
   jqm ".cniVersion|=\"0.3.0\"" /etc/cni/net.d/10-calico.conf
   jqm "del(.ipam.gateway,.ipam.routes)|.cniVersion|=\"0.3.0\"" /etc/cni/net.d/20-bridge.conf
   EOF
   ```
1. Build and start Virtlet, wait for its pod to become `Running`:
   ```
   build/cmd.sh build
   build/cmd.sh copy-dind
   FORCE_UPDATE_IMAGE=1 build/cmd.sh start-dind
   kubectl get pods -n kube-system -o wide -w
   ```
1. Start Ubuntu VM with `cni: bridge,calico` annotation added and wait for it to become `Running`:
   ```
   kubectl convert --local -o json -f examples/ubuntu-vm.yaml |
     jq '.metadata.annotations.cni="bridge,calico"' |
     kubectl create -f -
   kubectl get pods -o wide -w
   ```
1. If Ubuntu pods starts correctly, it should get an IP address like `10.192.2.x`, e.g. `10.192.2.3`:
   ```
   ubuntu-vm   1/1       Running   0         1m        10.192.2.3   kube-node-1
   ```
1. Perform a quick check of Ubuntu VM:
   ```
   examples/vmssh.sh testuser@ubuntu-vm \
     'ip a; ip r; curl http://kubernetes-dashboard.kube-system.svc.cluster.local; ping -c 1 8.8.8.8'
   ```
   This should give you output like this:
   ```
   1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1
       link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
       inet 127.0.0.1/8 scope host lo
          valid_lft forever preferred_lft forever
       inet6 ::1/128 scope host
          valid_lft forever preferred_lft forever
   2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
       link/ether 0a:58:0a:c0:02:03 brd ff:ff:ff:ff:ff:ff
       inet 10.192.2.3/16 brd 10.192.255.255 scope global eth0
          valid_lft forever preferred_lft forever
       inet6 fe80::858:aff:fec0:203/64 scope link
          valid_lft forever preferred_lft forever
   3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
       link/ether 3a:ac:e9:39:40:df brd ff:ff:ff:ff:ff:ff
       inet 192.168.135.129/24 brd 192.168.135.255 scope global eth1
          valid_lft forever preferred_lft forever
       inet6 fe80::38ac:e9ff:fe39:40df/64 scope link
          valid_lft forever preferred_lft forever
   default via 192.168.135.130 dev eth1
   10.192.0.0/16 dev eth0  proto kernel  scope link  src 10.192.2.3
   192.168.135.0/24 dev eth1  proto kernel  scope link  src 192.168.135.129
     % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                    Dload  Upload   Total   Spent    Left  Speed
     0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0 <!doctype html> <html ng-app="kubernetesDashboard"> <head> <meta charset="utf-8"> <title ng-controller="kdTitle as $ctrl" ng-bind="$ctrl.title()"></title> <link rel="icon" type="image/png" href="assets/images/kubernetes-logo.png"> <meta name="viewport" content="width=device-width"> <link rel="stylesheet" href="static/vendor.4f4b705f.css"> <link rel="stylesheet" href="static/app.93b90a74.css"> </head> <body> <!--[if lt IE 10]>
         <p class="browsehappy">You are using an <strong>outdated</strong> browser.
         Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your
         experience.</p>
       <![endif]--> <kd-chrome layout="column" layout-fill> </kd-chrome> <script src="static/vendor.6952e31e.js"></script> <script src="api/appConfig.json"></script> <script src="static/app.8a6b8127.js"></script> </body> </html> PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
   64 bytes from 8.8.8.8: icmp_seq=1 ttl=57 time=4.34 ms
   
   --- 8.8.8.8 ping statistics ---
   1 packets transmitted, 1 received, 0% packet loss, time 0ms
   rtt min/avg/max/mdev = 4.342/4.342/4.342/0.000 ms
   100   848  100   848    0     0  95570      0 --:--:-- --:--:-- --:--:--  103k
   ```
1. Set up CirrOS VM with bridge+calico:
   ```
   kubectl convert --local -o json -f examples/cirros-vm.yaml |
     jq '.metadata.annotations.cni="bridge,calico"' |
     kubectl create -f -
   kubectl get pods -o wide -w
   ```
1. Activate udhcpc on `eth1` which corresponds to Calico:
   ```
   examples/vmssh.sh cirros@cirros-vm 'sudo /sbin/udhcpc -R -n -T 60 -i eth1 -s /sbin/cirros-dhcpc -O mtu -O staticroutes -x hostname cirros'
   ```
   This should produce the output like this:
   ```
   udhcpc: started, v1.26.2
   udhcpc: sending discover
   udhcpc: sending select for 192.168.135.132
   udhcpc: lease of 192.168.135.132 obtained, lease time 86400
   ```
   This step is needed because CirrOS' cloud-init can't set up the
   network properly.
1. Verify the network inside CirrOS VM:
   ```
   examples/vmssh.sh cirros@cirros-vm \
     '/sbin/ip a; /sbin/ip r; curl http://kubernetes-dashboard.kube-system.svc.cluster.local; ping -c 1 8.8.8.8'
   ```
   The output looks like this:
   ```
   1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue
       link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
       inet 127.0.0.1/8 scope host lo
          valid_lft forever preferred_lft forever
       inet6 ::1/128 scope host
          valid_lft forever preferred_lft forever
   2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast qlen 1000
       link/ether 0a:58:0a:c0:02:05 brd ff:ff:ff:ff:ff:ff
       inet 10.192.2.5/16 brd 10.192.255.255 scope global eth0
          valid_lft forever preferred_lft forever
       inet6 fe80::858:aff:fec0:205/64 scope link
          valid_lft forever preferred_lft forever
   3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast qlen 1000
       link/ether da:9a:dc:8a:08:6d brd ff:ff:ff:ff:ff:ff
       inet 192.168.135.132/24 brd 192.168.135.255 scope global eth1
          valid_lft forever preferred_lft forever
       inet6 fe80::d89a:dcff:fe8a:86d/64 scope link
          valid_lft forever preferred_lft forever
   default via 192.168.135.130 dev eth1
   10.192.0.0/16 dev eth0  src 10.192.2.5
   192.168.135.0/24 dev eth1  src 192.168.135.132
     % Total  <!doctype html> <html ng-app="kubernetesDashboard"> <head> <meta charset="utf-8"> <title ng-controller="kdTitle as $ctrl" ng-bind="$ctrl.title()"></title> <link rel="icon" type="image/png" href="assets/images/kubernetes-logo.png"> <meta name="viewport" content="width=device-width"> <link rel="stylesheet" href="static/vendor.4f4b705f.css"> <link rel="stylesheet" href="static/app.93b90a74.css"> </head> <body> <!--[if lt IE 10]>
         <p class="browsehappy">You are using an <strong>outdated</strong> browser.
         Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your
         experience.</p>
       <![endif]--> <kd-chrome layout="column" layout-fill> </kd-chrome> <script src="static/vendor.6952e31e.js"></script> <script src="api/appConfig.json"></script> <script src="static/app.8a6b8127.js"></script> </body> </html> PING 8.8.8.8 (8.8.8.8): 56 data bytes
   64 bytes from 8.8.8.8: seq=0 ttl=57 time=4.325 ms
   
   --- 8.8.8.8 ping statistics ---
   1 packets transmitted, 1 packets received, 0% packet loss
   round-trip min/avg/max = 4.325/4.325/4.325 ms
      % Received % Xferd  Average Speed   Time    Time     Time  Current
                                    Dload  Upload   Total   Spent    Left  Speed
   100   848  100   848    0     0   131k      0 --:--:-- --:--:-- --:--:--  207k
   ```
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/523)
<!-- Reviewable:end -->
