### PR TITLE
Fix handling of missing link and rest of SR-IOV teardown

### DIFF
--- a/pkg/nettools/nettools.go
+++ b/pkg/nettools/nettools.go
@@ -1015,7 +1015,7 @@ func (csn *ContainerSideNetwork) Teardown() error {
 // ReconstructVFs iterates over stored PCI addresses, rebinding each
 // corresponding interface to its host driver, changing its MAC address
 // to the stored value and then moving it into the container namespace
-func (csn *ContainerSideNetwork) ReconstructVFs(ns ns.NetNS) error {
+func (csn *ContainerSideNetwork) ReconstructVFs(netns ns.NetNS) error {
 	for i, ifType := range csn.InterfaceTypes {
 		if ifType != InterfaceTypeVF {
 			continue
@@ -1029,17 +1029,22 @@ func (csn *ContainerSideNetwork) ReconstructVFs(ns ns.NetNS) error {
 		}
 		link, err := netlink.LinkByName(devName)
 		if err != nil {
-			return err
+			return fmt.Errorf("can't find link with name %q: %v", err)
 		}
 		if err := netlink.LinkSetHardwareAddr(link, csn.HardwareAddrs[i]); err != nil {
-			return err
+			return fmt.Errorf("can't set hwaddr %q on device %q: %v", csn.HardwareAddrs[i], devName, err)
 		}
-		if err := netlink.LinkSetName(link, csn.InterfaceNames[i]); err != nil {
-			return err
+		if err := netlink.LinkSetNsFd(link, int(netns.Fd())); err != nil {
+			return fmt.Errorf("can't move link %q to netns %q: %v", csn.InterfaceNames[i], netns.Path(), err)
 		}
-		if err := netlink.LinkSetNsFd(link, int(ns.Fd())); err != nil {
-			return err
-		}
+		netns.Do(func(ns.NetNS) error {
+			if link.Attrs().Name != csn.InterfaceNames[i] {
+				if err := netlink.LinkSetName(link, csn.InterfaceNames[i]); err != nil {
+					return fmt.Errorf("can't rename device %q to %q: %v", devName, csn.InterfaceNames[i], err)
+				}
+			}
+			return nil
+		})
 	}
 
 	return nil

--- a/pkg/nettools/nettools.go
+++ b/pkg/nettools/nettools.go
@@ -660,7 +660,9 @@ func getDevNameByPCIAddress(address string) (string, error) {
 	}
 	for _, fi := range devices {
 		linkDestination, err := os.Readlink(filepath.Join("/sys/class/net", fi.Name(), "device"))
-		if err != nil {
+		if os.IsNotExist(err) {
+			continue
+		} else if err != nil {
 			return "", err
 		}
 		if linkDestination == desiredLinkLocation {


### PR DESCRIPTION
Netdevs like `docker0` do not have a `device` link. This patch fixes
handling of them.
Later commit fixes rest of remains needed for successful SR-IOV teardown.
 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/535)
<!-- Reviewable:end -->
