### PR TITLE
Add TapFDSource test

### DIFF
--- a/cmd/virtlet/virtlet.go
+++ b/cmd/virtlet/virtlet.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/golang/glog"
 
+	"github.com/Mirantis/virtlet/pkg/cni"
 	"github.com/Mirantis/virtlet/pkg/libvirttools"
 	"github.com/Mirantis/virtlet/pkg/manager"
 	"github.com/Mirantis/virtlet/pkg/metadata"
@@ -115,7 +116,12 @@ func runVirtlet() {
 }
 
 func runTapManager() {
-	src, err := tapmanager.NewTapFDSource(*cniPluginsDir, *cniConfigsDir)
+	cniClient, err := cni.NewClient(*cniPluginsDir, *cniConfigsDir)
+	if err != nil {
+		glog.Errorf("Error initializing CNI client: %v", err)
+		os.Exit(1)
+	}
+	src, err := tapmanager.NewTapFDSource(cniClient)
 	if err != nil {
 		glog.Errorf("Error creating tap fd source: %v", err)
 		os.Exit(1)

--- a/pkg/nettools/nettools.go
+++ b/pkg/nettools/nettools.go
@@ -845,7 +845,7 @@ func TeardownBridge(bridge netlink.Link, links []netlink.Link) error {
 	return netlink.LinkSetDown(bridge)
 }
 
-// ConfigureLink adds to link ip address and routes based on info.
+// ConfigureLink configures a link according to the CNI result
 func ConfigureLink(link netlink.Link, info *cnicurrent.Result) error {
 	linkNo := -1
 	linkMAC := link.Attrs().HardwareAddr.String()

--- a/pkg/nettools/nettools.go
+++ b/pkg/nettools/nettools.go
@@ -45,7 +45,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"syscall"
-	"unsafe"
 
 	"github.com/containernetworking/cni/pkg/ns"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
@@ -99,29 +98,6 @@ type InterfaceInfo struct {
 type ContainerNetwork struct {
 	Info   *cnicurrent.Result
 	DhcpNS ns.NetNS
-}
-
-func OpenTAP(devName string) (*os.File, error) {
-	tapFile, err := os.OpenFile("/dev/net/tun", os.O_RDWR, 0)
-	if err != nil {
-		return nil, err
-	}
-
-	var req ifReq
-
-	// set IFF_NO_PI to not provide packet information
-	// If flag IFF_NO_PI is not set each frame format is:
-	// Flags [2 bytes]
-	// Proto [2 bytes]
-	// Raw protocol ethernet frame.
-	// This extra 4-byte header breaks connectivity as in this case kernel truncates initial package
-	req.Flags = uint16(syscall.IFF_TAP | syscall.IFF_NO_PI | syscall.IFF_ONE_QUEUE)
-	copy(req.Name[:15], devName)
-	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, tapFile.Fd(), uintptr(syscall.TUNSETIFF), uintptr(unsafe.Pointer(&req)))
-	if errno != 0 {
-		return nil, fmt.Errorf("tuntap IOCTL TUNSETIFF failed, errno %v", errno)
-	}
-	return tapFile, nil
 }
 
 func makeVethPair(name, peer string, mtu int) (netlink.Link, error) {
@@ -754,20 +730,9 @@ func SetupContainerSideNetwork(info *cnicurrent.Result, nsPath string, allLinks 
 		}
 
 		tapInterfaceName := fmt.Sprintf(tapInterfaceNameTemplate, i)
-		tap := &netlink.Tuntap{
-			LinkAttrs: netlink.LinkAttrs{
-				Name:  tapInterfaceName,
-				Flags: net.FlagUp,
-				MTU:   link.Attrs().MTU,
-			},
-			Mode: netlink.TUNTAP_MODE_TAP,
-		}
-		if err := netlink.LinkAdd(tap); err != nil {
-			return nil, fmt.Errorf("failed to create tap interface: %v", err)
-		}
-
-		if err := netlink.LinkSetUp(tap); err != nil {
-			return nil, fmt.Errorf("failed to set %q up: %v", tapInterfaceName, err)
+		tap, err := CreateTAP(tapInterfaceName, link.Attrs().MTU)
+		if err != nil {
+			return nil, err
 		}
 
 		containerBridgeName := fmt.Sprintf(containerBridgeNameTemplate, i)

--- a/pkg/nettools/nettools_test.go
+++ b/pkg/nettools/nettools_test.go
@@ -244,7 +244,7 @@ func addTestRoute(t *testing.T, route *netlink.Route) {
 func setupLink(hwAddrAsText string, link netlink.Link) netlink.Link {
 	hwAddr, err := net.ParseMAC(hwAddrAsText)
 	if err != nil {
-		log.Panicf("Error parsing hwaddr %q: %v", hwAddr, err)
+		log.Panicf("Error parsing hwaddr %q: %v", hwAddrAsText, err)
 	}
 	if err := SetHardwareAddr(link, hwAddr); err != nil {
 		log.Panicf("Error setting hardware address: %v", err)

--- a/pkg/nettools/tap.go
+++ b/pkg/nettools/tap.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2017 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nettools
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"syscall"
+	"unsafe"
+
+	"github.com/vishvananda/netlink"
+)
+
+// OpenTAP opens a tap device and returns an os.File for it
+func OpenTAP(devName string) (*os.File, error) {
+	tapFile, err := os.OpenFile("/dev/net/tun", os.O_RDWR, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	var req ifReq
+
+	// set IFF_NO_PI to not provide packet information
+	// If flag IFF_NO_PI is not set each frame format is:
+	// Flags [2 bytes]
+	// Proto [2 bytes]
+	// Raw protocol ethernet frame.
+	// This extra 4-byte header breaks connectivity as in this case kernel truncates initial package
+	req.Flags = uint16(syscall.IFF_TAP | syscall.IFF_NO_PI | syscall.IFF_ONE_QUEUE)
+	copy(req.Name[:15], devName)
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, tapFile.Fd(), uintptr(syscall.TUNSETIFF), uintptr(unsafe.Pointer(&req)))
+	if errno != 0 {
+		return nil, fmt.Errorf("tuntap IOCTL TUNSETIFF failed, errno %v", errno)
+	}
+	return tapFile, nil
+}
+
+// CreateTAP sets up a tap link and brings it up
+func CreateTAP(devName string, mtu int) (netlink.Link, error) {
+	tap := &netlink.Tuntap{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:  devName,
+			Flags: net.FlagUp,
+			MTU:   mtu,
+		},
+		Mode: netlink.TUNTAP_MODE_TAP,
+	}
+
+	if err := netlink.LinkAdd(tap); err != nil {
+		return nil, fmt.Errorf("failed to create tap interface: %v", err)
+	}
+
+	if err := netlink.LinkSetUp(tap); err != nil {
+		return nil, fmt.Errorf("failed to set %q up: %v", devName, err)
+	}
+
+	return tap, nil
+}

--- a/pkg/tapmanager/tapfdsource.go
+++ b/pkg/tapmanager/tapfdsource.go
@@ -92,7 +92,7 @@ type podNetwork struct {
 type TapFDSource struct {
 	sync.Mutex
 
-	cniClient          *cni.Client
+	cniClient          cni.CNIClient
 	dummyNetwork       *cnicurrent.Result
 	dummyNetworkNsPath string
 	fdMap              map[string]*podNetwork
@@ -102,12 +102,7 @@ var _ FDSource = &TapFDSource{}
 
 // NewTapFDSource returns a TapFDSource for the specified CNI plugin &
 // config dir
-func NewTapFDSource(cniPluginsDir, cniConfigsDir string) (*TapFDSource, error) {
-	cniClient, err := cni.NewClient(cniPluginsDir, cniConfigsDir)
-	if err != nil {
-		return nil, err
-	}
-
+func NewTapFDSource(cniClient cni.CNIClient) (*TapFDSource, error) {
 	s := &TapFDSource{
 		cniClient: cniClient,
 		fdMap:     make(map[string]*podNetwork),

--- a/pkg/tapmanager/tapfdsource.go
+++ b/pkg/tapmanager/tapfdsource.go
@@ -36,14 +36,10 @@ import (
 	"github.com/Mirantis/virtlet/pkg/nettools"
 )
 
-// InterfaceType presents type of network interface instance
-type InterfaceType int
-
 const (
-	InterfaceTypeTap    InterfaceType = iota
-	calicoNetType                     = "calico"
-	calicoDefaultSubnet               = 24
-	calicoSubnetVar                   = "VIRTLET_CALICO_SUBNET"
+	calicoNetType       = "calico"
+	calicoDefaultSubnet = 24
+	calicoSubnetVar     = "VIRTLET_CALICO_SUBNET"
 )
 
 // InterfaceDescription contains interface type with additional data

--- a/tests/network/README.md
+++ b/tests/network/README.md
@@ -1,6 +1,8 @@
-This directory contains network tests that make use of network
-namespaces and should not be mixed with non-network-namespace-aware
-tests.
+This directory contains the tests that examine Virtlet networking
+by running a DHCP client and sending actual network packets.
 
-For more info, see containernetworking/cni#262, vishvananda/netns#17
-etc.
+Note that before we switch to Go 1.10, there may be test flakes
+because some goroutines may inherit a network namespace from other
+goroutines unintentionally. Running at least some of the network tests
+separately may help reduce the impact of this problem. For more info,
+see containernetworking/cni#262, vishvananda/netns#17, golang/go#20676

--- a/tests/network/fake_cni_test.go
+++ b/tests/network/fake_cni_test.go
@@ -46,6 +46,7 @@ type FakeCNIClient struct {
 	added                   bool
 	removed                 bool
 	veths                   []FakeCNIVethPair
+	useBadResult            bool
 }
 
 var _ cni.CNIClient = &FakeCNIClient{}
@@ -129,7 +130,11 @@ func (c *FakeCNIClient) AddSandboxToNetwork(podId, podName, podNS string) (*cnic
 	}
 
 	c.added = true
-	return copyCNIResult(c.info), nil
+	r := copyCNIResult(c.info)
+	if c.useBadResult {
+		r.Routes = nil
+	}
+	return r, nil
 }
 
 func (c *FakeCNIClient) RemoveSandboxFromNetwork(podId, podName, podNS string) error {
@@ -199,6 +204,10 @@ func (c *FakeCNIClient) Veths() []FakeCNIVethPair {
 
 func (c *FakeCNIClient) NetworkInfoAfterTeardown() *cnicurrent.Result {
 	return c.infoAfterTeardown
+}
+
+func (c *FakeCNIClient) UseBadResult(useBadResult bool) {
+	c.useBadResult = useBadResult
 }
 
 func copyCNIResult(result *cnicurrent.Result) *cnicurrent.Result {

--- a/tests/network/fake_cni_test.go
+++ b/tests/network/fake_cni_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2017 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"net"
+
+	"github.com/containernetworking/cni/pkg/ns"
+	cnicurrent "github.com/containernetworking/cni/pkg/types/current"
+	"github.com/vishvananda/netlink"
+
+	"github.com/Mirantis/virtlet/pkg/cni"
+	"github.com/Mirantis/virtlet/pkg/nettools"
+)
+
+// FakeCNIVethPair represents a veth pair created by the fake CNI
+type FakeCNIVethPair struct {
+	HostSide netlink.Link
+	ContSide netlink.Link
+}
+
+// FakeCNIClient fakes a CNI client. It's only good for one-time
+// network setup for a single pod network namespace
+type FakeCNIClient struct {
+	info                  *cnicurrent.Result
+	hostNS, contNS        ns.NetNS
+	podId, podName, podNS string
+	added                 bool
+	removed               bool
+	veths                 []FakeCNIVethPair
+}
+
+var _ cni.CNIClient = &FakeCNIClient{}
+
+func NewFakeCNIClient(info *cnicurrent.Result, hostNS ns.NetNS, podId, podName, podNS string) *FakeCNIClient {
+	return &FakeCNIClient{
+		info:    info,
+		hostNS:  hostNS,
+		podId:   podId,
+		podName: podName,
+		podNS:   podNS,
+	}
+}
+
+func (c *FakeCNIClient) GetDummyNetwork() (*cnicurrent.Result, string, error) {
+	return nil, "", errors.New("GetDummyNetwork() is not implemented")
+}
+
+func (c *FakeCNIClient) verifyPod(podId, podName, podNS string) {
+	if podId != c.podId {
+		// we use log.Panicf()/panic() because t.Fatalf() from
+		// testing will not work inside netns' Do() calls
+		log.Panicf("podId mismatch: %q instead of %q", podId, c.podId)
+	}
+	if podName != c.podName {
+		log.Panicf("podName mismatch: %q instead of %q", podId, c.podName)
+	}
+	if podNS != c.podNS {
+		log.Panicf("podNS mismatch: %q instead of %q", podNS, c.podNS)
+	}
+}
+
+func (c *FakeCNIClient) AddSandboxToNetwork(podId, podName, podNS string) (*cnicurrent.Result, error) {
+	c.verifyPod(podId, podName, podNS)
+	if c.added {
+		panic("AddSandboxToNetwork() was already called")
+	}
+
+	for _, iface := range c.info.Interfaces {
+		if iface.Sandbox == "" {
+			continue
+		}
+		if iface.Sandbox != "placeholder" {
+			log.Panicf("bad sandbox %q: expected empty string or \"placeholder\"", iface.Sandbox)
+		}
+
+		nsPath := cni.PodNetNSPath(podId)
+		var err error
+		c.contNS, err = ns.GetNS(nsPath)
+		if err != nil {
+			return nil, fmt.Errorf("can't get pod netns (path %q): %v", nsPath, err)
+		}
+		var vp FakeCNIVethPair
+		if err := c.hostNS.Do(func(ns.NetNS) error {
+			var err error
+			vp.HostSide, vp.ContSide, err = nettools.CreateEscapeVethPair(c.contNS, iface.Name, 1500)
+			return err
+		}); err != nil {
+			return nil, fmt.Errorf("failed to create escape veth pair: %v", err)
+		}
+
+		if err := c.contNS.Do(func(ns.NetNS) error {
+			hwAddr, err := net.ParseMAC(iface.Mac)
+			if err != nil {
+				return fmt.Errorf("error parsing hwaddr %q: %v", iface.Mac, err)
+			}
+			if err := nettools.SetHardwareAddr(vp.ContSide, hwAddr); err != nil {
+				return fmt.Errorf("SetHardwareAddr(): %v", err)
+			}
+			// mac address changed, reload the link
+			vp.ContSide, err = netlink.LinkByIndex(vp.ContSide.Attrs().Index)
+			if err != nil {
+				return fmt.Errorf("can't reload container veth info: %v", err)
+			}
+			if err := nettools.ConfigureLink(vp.ContSide, c.info); err != nil {
+				return fmt.Errorf("error configuring link %q: %v", iface.Name, err)
+			}
+			c.veths = append(c.veths, vp)
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+	}
+
+	c.added = true
+	return c.info, nil
+}
+
+func (c *FakeCNIClient) RemoveSandboxFromNetwork(podId, podName, podNS string) error {
+	c.verifyPod(podId, podName, podNS)
+	if !c.added {
+		panic("RemoveSandboxFromNetwork() was called without prior AddSandboxToNetwork()")
+	}
+	if c.removed {
+		panic("RemoveSandboxFromNetwork() was already called")
+	}
+
+	c.removed = true
+	return nil
+}
+
+func (c *FakeCNIClient) VerifyAdded() {
+	if !c.added {
+		panic("pod sandbox not added to the network")
+	}
+	if c.removed {
+		panic("pod sandbox is already removed")
+	}
+}
+
+func (c *FakeCNIClient) VerifyRemoved() {
+	if !c.removed {
+		panic("pod sandbox not removed from the network")
+	}
+}
+
+func (c *FakeCNIClient) Cleanup() {
+	if c.contNS != nil {
+		c.contNS.Close()
+	}
+}
+
+func (c *FakeCNIClient) Veths() []FakeCNIVethPair {
+	c.VerifyAdded()
+	return c.veths
+}

--- a/tests/network/utils_test.go
+++ b/tests/network/utils_test.go
@@ -76,9 +76,14 @@ func (g *NetTestGroup) Add(netNS ns.NetNS, tester NetTester) chan struct{} {
 		g.fg.Add(1)
 	}
 	go func() {
-		err := netNS.Do(func(ns.NetNS) (err error) {
-			return tester.Run(readyCh, g.stopCh)
-		})
+		var err error
+		if netNS != nil {
+			err = netNS.Do(func(ns.NetNS) (err error) {
+				return tester.Run(readyCh, g.stopCh)
+			})
+		} else {
+			err = tester.Run(readyCh, g.stopCh)
+		}
 		if err != nil {
 			g.errCh <- fmt.Errorf("%s: %v", tester.Name(), err)
 		}

--- a/tests/network/utils_test.go
+++ b/tests/network/utils_test.go
@@ -90,6 +90,8 @@ func (g *NetTestGroup) Add(netNS ns.NetNS, tester NetTester) chan struct{} {
 	}()
 	select {
 	case err := <-g.errCh:
+		close(g.stopCh)
+		g.stopCh = nil
 		g.t.Fatal(err)
 	case <-readyCh:
 	}

--- a/tests/network/vm_network_test.go
+++ b/tests/network/vm_network_test.go
@@ -407,11 +407,11 @@ func TestTapFDSource(t *testing.T) {
 					}
 				}()
 
-				var result *cnicurrent.Result
+				var result, expectedResult *cnicurrent.Result
 				if err := json.Unmarshal(netConfigBytes, &result); err != nil {
 					t.Errorf("error unmarshalling CNI result: %v", err)
 				} else {
-					expectedResult := copyCNIResult(tc.info)
+					expectedResult = copyCNIResult(tc.info)
 					replaceSandboxPlaceholders(expectedResult, podId)
 					verifyNoDiff(t, "cni result", expectedResult, result)
 				}
@@ -453,12 +453,15 @@ func TestTapFDSource(t *testing.T) {
 				}
 				released = true
 				cniClient.VerifyRemoved()
+
+				infoAfterTeardown := cniClient.NetworkInfoAfterTeardown()
+				verifyNoDiff(t, "network info after teardown", expectedResult, infoAfterTeardown)
 			})
 		})
 	}
 }
 
-// TODO: test network teardown
 // TODO: test multiple CNIs
 // TODO: test Calico
 // TODO: test recovering netns
+// TODO: test SR-IOV

--- a/tests/network/vm_network_test.go
+++ b/tests/network/vm_network_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/Mirantis/virtlet/pkg/nettools"
 	"github.com/Mirantis/virtlet/pkg/tapmanager"
+	"github.com/Mirantis/virtlet/pkg/utils"
 )
 
 const (
@@ -39,7 +40,6 @@ const (
 	clientAddr       = "10.1.90.5/24"
 	clientMacAddress = "42:a4:a6:22:80:2e"
 	netTestWaitTime  = 15 * time.Second
-	samplePodId      = "8da3af4b-ff84-48dd-994a-47b166d40819"
 	samplePodName    = "foobar"
 	samplePodNS      = "default"
 	fdKey            = "fdkey"
@@ -307,7 +307,8 @@ func TestTapFDSource(t *testing.T) {
 			vnt := newVMNetworkTester(t)
 			defer vnt.teardown()
 
-			cniClient := NewFakeCNIClient(tc.info, vnt.hostNS, samplePodId, samplePodName, samplePodNS)
+			podId := utils.NewUuid()
+			cniClient := NewFakeCNIClient(tc.info, vnt.hostNS, podId, samplePodName, samplePodNS)
 			defer cniClient.Cleanup()
 
 			src, err := tapmanager.NewTapFDSource(cniClient)
@@ -341,7 +342,7 @@ func TestTapFDSource(t *testing.T) {
 			// TODO: check the returned data
 			if _, err := c.AddFDs(fdKey, &tapmanager.GetFDPayload{
 				Description: &tapmanager.PodNetworkDesc{
-					PodId:   samplePodId,
+					PodId:   podId,
 					PodNs:   samplePodNS,
 					PodName: samplePodName,
 				},
@@ -390,7 +391,6 @@ func TestTapFDSource(t *testing.T) {
 	}
 }
 
-// TODO: in TestTapFDSource, use random pod id
 // TODO: use https://github.com/d4l3k/messagediff to diff cni results
 // TODO: check data returned by AddFDs() / GetFDs()
 // TODO: use table-driven test

--- a/tests/network/vm_network_test.go
+++ b/tests/network/vm_network_test.go
@@ -17,39 +17,32 @@ limitations under the License.
 package network
 
 import (
-	"bytes"
-	"errors"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"os"
-	"os/exec"
-	"strings"
-	"sync"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/containernetworking/cni/pkg/ns"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	cnicurrent "github.com/containernetworking/cni/pkg/types/current"
-	"github.com/golang/glog"
 	"github.com/vishvananda/netlink"
 
 	"github.com/Mirantis/virtlet/pkg/nettools"
+	"github.com/Mirantis/virtlet/pkg/tapmanager"
 )
 
 const (
-	pingPort                  = 4242
-	pingSrcPort               = 4243
-	pingInterval              = 100 * time.Millisecond
-	pingDeadline              = 55 * time.Millisecond
-	pingReceiverCycles        = 100
-	tcpdumpPollPeriod         = 50 * time.Millisecond
-	tcpdumpStartupPollCount   = 100
-	tcpdumpSubstringWaitCount = 100
-	outerAddr                 = "10.1.90.1/24"
-	clientAddr                = "10.1.90.5/24"
-	clientMacAddress          = "42:a4:a6:22:80:2e"
-	netTestWaitTime           = 15 * time.Second
+	sampleOuterAddr  = "10.1.90.1/24"
+	clientAddr       = "10.1.90.5/24"
+	clientMacAddress = "42:a4:a6:22:80:2e"
+	netTestWaitTime  = 15 * time.Second
+	samplePodId      = "8da3af4b-ff84-48dd-994a-47b166d40819"
+	samplePodName    = "foobar"
+	samplePodNS      = "default"
+	fdKey            = "fdkey"
 )
 
 type vmNetworkTester struct {
@@ -66,23 +59,15 @@ func newVMNetworkTester(t *testing.T) *vmNetworkTester {
 		t.Fatalf("Failed to create host ns: %v", err)
 	}
 
-	contNS, err := ns.NewNS()
-	if err != nil {
-		hostNS.Close()
-		t.Fatalf("Failed to create container ns: %v", err)
-	}
-
 	clientNS, err := ns.NewNS()
 	if err != nil {
 		hostNS.Close()
-		contNS.Close()
 		t.Fatalf("Failed to create ns for dhcp client: %v", err)
 	}
 
 	vnt := &vmNetworkTester{
 		t:        t,
 		hostNS:   hostNS,
-		contNS:   contNS,
 		clientNS: clientNS,
 		g:        NewNetTestGroup(t, netTestWaitTime),
 	}
@@ -102,8 +87,7 @@ func (vnt *vmNetworkTester) addTcpdump(link netlink.Link, stopOn, failOn string)
 	vnt.g.Add(vnt.hostNS, tcpdump)
 }
 
-func (vnt *vmNetworkTester) verifyDhcp(info *cnicurrent.Result, expectedSubstrings ...string) {
-	vnt.g.Add(vnt.contNS, NewDhcpServerTester(info))
+func (vnt *vmNetworkTester) verifyDhcp(expectedSubstrings []string) {
 	// wait for dhcp client to complete so we don't interfere
 	// with the network link too early
 	<-vnt.g.Add(vnt.clientNS, NewDhcpClient(expectedSubstrings))
@@ -143,7 +127,6 @@ func (vnt *vmNetworkTester) teardown() {
 		}
 	}
 	vnt.clientNS.Close()
-	vnt.contNS.Close()
 	vnt.hostNS.Close()
 }
 
@@ -173,12 +156,18 @@ func TestVmNetwork(t *testing.T) {
 	vnt := newVMNetworkTester(t)
 	defer vnt.teardown()
 
+	contNS, err := ns.NewNS()
+	if err != nil {
+		t.Fatalf("Failed to create container ns: %v", err)
+	}
+	defer contNS.Close()
+
 	info := &cnicurrent.Result{
 		Interfaces: []*cnicurrent.Interface{
 			{
 				Name:    "eth0",
 				Mac:     clientMacAddress,
-				Sandbox: vnt.contNS.Path(),
+				Sandbox: contNS.Path(),
 			},
 		},
 		IPs: []*cnicurrent.IPConfig{
@@ -212,19 +201,19 @@ func TestVmNetwork(t *testing.T) {
 
 	var hostVeth netlink.Link
 	if err := vnt.hostNS.Do(func(ns.NetNS) (err error) {
-		hostVeth, _, err = nettools.CreateEscapeVethPair(vnt.contNS, "eth0", 1500)
+		hostVeth, _, err = nettools.CreateEscapeVethPair(contNS, "eth0", 1500)
 		return
 	}); err != nil {
 		t.Fatalf("failed to create escape veth pair: %v", err)
 	}
 
 	var csn *nettools.ContainerSideNetwork
-	if err := vnt.contNS.Do(func(ns.NetNS) error {
+	if err := contNS.Do(func(ns.NetNS) error {
 		allLinks, err := netlink.LinkList()
 		if err != nil {
 			return fmt.Errorf("LinkList() failed: %v", err)
 		}
-		csn, err = nettools.SetupContainerSideNetwork(info, vnt.contNS.Path(), allLinks)
+		csn, err = nettools.SetupContainerSideNetwork(info, contNS.Path(), allLinks)
 		if err != nil {
 			return fmt.Errorf("failed to set up container side network: %v", err)
 		}
@@ -236,338 +225,176 @@ func TestVmNetwork(t *testing.T) {
 		t.Fatalf("failed to set up container-side network: %v", err)
 	}
 
-	outerIP := addAddress(t, vnt.hostNS, hostVeth, outerAddr)
+	outerIP := addAddress(t, vnt.hostNS, hostVeth, sampleOuterAddr)
 	vnt.connectTaps(csn.Fds[0])
 	// tcpdump should catch udp 'ping' but should not
 	// see BOOTP/DHCP on the 'outer' link
 	vnt.addTcpdump(hostVeth, "10.1.90.1.4243 > 10.1.90.5.4242: UDP", "BOOTP/DHCP")
-	vnt.verifyDhcp(info,
+	vnt.g.Add(contNS, NewDhcpServerTester(info))
+	vnt.verifyDhcp([]string{
 		"new_classless_static_routes='10.10.42.0/24 10.1.90.90'",
 		"new_ip_address='10.1.90.5'",
 		"new_network_number='10.1.90.0'",
 		"new_routers='10.1.90.1'",
 		"new_subnet_mask='255.255.255.0'",
-		"tap0: offered 10.1.90.5 from 169.254.254.2")
+		"tap0: offered 10.1.90.5 from 169.254.254.2",
+	})
 	vnt.verifyPing(outerIP)
 	vnt.wait()
 }
 
-type pinger struct {
-	localIP, destIP net.IP
-	conn            *net.UDPConn
-}
+func TestTapFDSource(t *testing.T) {
+	for _, tc := range []struct {
+		name                   string
+		interfaceCount         int
+		outerAddr              string
+		info                   *cnicurrent.Result
+		tcpdumpStopOn          string
+		dhcpExpectedSubstrings []string
+	}{
+		{
+			name:           "single cni",
+			interfaceCount: 1,
+			outerAddr:      sampleOuterAddr,
+			info: &cnicurrent.Result{
+				Interfaces: []*cnicurrent.Interface{
+					{
+						Name:    "eth0",
+						Mac:     clientMacAddress,
+						Sandbox: "placeholder",
+					},
+				},
+				IPs: []*cnicurrent.IPConfig{
+					{
+						Version:   "4",
+						Interface: 0,
+						Address: net.IPNet{
+							IP:   net.IP{10, 1, 90, 5},
+							Mask: net.IPMask{255, 255, 255, 0},
+						},
+						Gateway: net.IP{10, 1, 90, 1},
+					},
+				},
+				Routes: []*cnitypes.Route{
+					{
+						Dst: net.IPNet{
+							IP:   net.IP{0, 0, 0, 0},
+							Mask: net.IPMask{0, 0, 0, 0},
+						},
+						GW: net.IP{10, 1, 90, 1},
+					},
+					{
+						Dst: net.IPNet{
+							IP:   net.IP{10, 10, 42, 0},
+							Mask: net.IPMask{255, 255, 255, 0},
+						},
+						GW: net.IP{10, 1, 90, 90},
+					},
+				},
+			},
+			tcpdumpStopOn: "10.1.90.1.4243 > 10.1.90.5.4242: UDP",
+			dhcpExpectedSubstrings: []string{
+				"new_classless_static_routes='10.10.42.0/24 10.1.90.90'",
+				"new_ip_address='10.1.90.5'",
+				"new_network_number='10.1.90.0'",
+				"new_routers='10.1.90.1'",
+				"new_subnet_mask='255.255.255.0'",
+				"tap0: offered 10.1.90.5 from 169.254.254.2",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			vnt := newVMNetworkTester(t)
+			defer vnt.teardown()
 
-var _ NetTester = &pinger{}
+			cniClient := NewFakeCNIClient(tc.info, vnt.hostNS, samplePodId, samplePodName, samplePodNS)
+			defer cniClient.Cleanup()
 
-func newPinger(localIP net.IP, destIP net.IP) *pinger {
-	return &pinger{localIP: localIP, destIP: destIP}
-}
-
-func (p *pinger) Name() string {
-	return fmt.Sprintf("pinger for %v", p.destIP)
-}
-
-func (p *pinger) Fg() bool { return false }
-
-func (p *pinger) dial() error {
-	var laddr *net.UDPAddr
-	if p.localIP != nil {
-		laddr = &net.UDPAddr{IP: p.localIP, Port: pingSrcPort}
-	}
-	raddr := &net.UDPAddr{IP: p.destIP, Port: pingPort}
-	var err error
-	p.conn, err = net.DialUDP("udp4", laddr, raddr)
-	if err != nil {
-		return fmt.Errorf("net.DialUDP(): %v", err)
-	}
-	return nil
-}
-
-func (p *pinger) ping() error {
-	if _, err := p.conn.Write([]byte("hello")); err != nil {
-		return fmt.Errorf("Write(): %v", err)
-	}
-	return nil
-}
-
-func (p *pinger) Run(readyCh, stopCh chan struct{}) error {
-	if err := p.dial(); err != nil {
-		return err
-	}
-	close(readyCh)
-	for {
-		select {
-		case <-stopCh:
-			p.conn.Close()
-			return nil
-		case <-time.After(pingInterval):
-			if err := p.ping(); err != nil {
-				// receiver may not be ready yet, don't fail here
-				glog.V(3).Infof("ping error: %v", err)
+			src, err := tapmanager.NewTapFDSource(cniClient)
+			if err != nil {
+				t.Fatalf("Error creating tap fd source: %v", err)
 			}
-		}
-	}
-}
 
-type pingReceiver struct {
-	localIP net.IP
-	conn    *net.UDPConn
-}
-
-var _ NetTester = &pingReceiver{}
-
-func newPingReceiver(localIP net.IP) *pingReceiver {
-	return &pingReceiver{localIP: localIP}
-}
-
-func (p *pingReceiver) Name() string {
-	return fmt.Sprintf("pingReceiver for %v", p.localIP)
-}
-
-func (p *pingReceiver) Fg() bool { return true }
-
-func (p *pingReceiver) listen() error {
-	var err error
-	p.conn, err = net.ListenUDP("udp4", &net.UDPAddr{IP: p.localIP, Port: pingPort})
-	if err != nil {
-		return fmt.Errorf("net.ListenUDP(): %v", err)
-	}
-	return nil
-}
-
-func (p *pingReceiver) cycle() (bool, error) {
-	if err := p.conn.SetDeadline(time.Now().Add(pingDeadline)); err != nil {
-		return false, err
-	}
-	buf := make([]byte, 16)
-	n, addr, err := p.conn.ReadFromUDP(buf)
-	if err != nil {
-		if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
-			return false, nil
-		}
-		return false, err
-	}
-	glog.V(3).Infof("received udp ping from %v: %q", addr, string(buf[:n]))
-	return true, nil
-}
-
-func (p *pingReceiver) Run(readyCh, stopCh chan struct{}) error {
-	if err := p.listen(); err != nil {
-		return err
-	}
-	close(readyCh)
-	defer p.conn.Close()
-	for n := 0; n < pingReceiverCycles; n++ {
-		select {
-		case <-stopCh:
-			return errors.New("ping receiver stopped before receiving any pings")
-		default:
-		}
-		received, err := p.cycle()
-		if err != nil {
-			return err
-		}
-		if received {
-			return nil
-		}
-	}
-	return errors.New("no pings received")
-}
-
-type safeBuf struct {
-	m sync.Mutex
-	b bytes.Buffer
-}
-
-func (sb *safeBuf) Write(p []byte) (n int, err error) {
-	sb.m.Lock()
-	defer sb.m.Unlock()
-	return sb.b.Write(p)
-}
-
-func (sb *safeBuf) String() string {
-	sb.m.Lock()
-	defer sb.m.Unlock()
-	return sb.b.String()
-}
-
-type tcpdump struct {
-	link           netlink.Link
-	stopOn, failOn string
-	readyCh        chan struct{}
-	bOut, bErr     safeBuf
-	cmd            *exec.Cmd
-	out            string
-}
-
-var _ NetTester = &tcpdump{}
-
-func newTcpdump(link netlink.Link, stopOn, failOn string) *tcpdump {
-	return &tcpdump{
-		link:    link,
-		stopOn:  stopOn,
-		failOn:  failOn,
-		readyCh: make(chan struct{}),
-	}
-}
-
-func (t *tcpdump) Name() string {
-	return fmt.Sprintf("tcpdump on %s", t.link.Attrs().Name)
-}
-
-func (t *tcpdump) Fg() bool { return true }
-
-func (t *tcpdump) gotListeningMsg() bool {
-	idx := strings.Index(t.bErr.String(), "\nlistening on")
-	if idx < 0 {
-		return false
-	}
-	return strings.LastIndex(t.bErr.String(), "\n") > idx
-}
-
-func (t *tcpdump) waitForReady() bool {
-	for n := 0; n < tcpdumpStartupPollCount; n++ {
-		time.Sleep(tcpdumpPollPeriod)
-		if t.gotListeningMsg() {
-			// XXX: the correct way would be to wait for
-			// some traffic here
-			time.Sleep(100 * time.Millisecond)
-			return true
-		}
-	}
-	return false
-}
-
-func (t *tcpdump) waitForSubstring(stopCh chan struct{}) error {
-	for n := 0; n < tcpdumpSubstringWaitCount; n++ {
-		select {
-		case <-stopCh:
-			return fmt.Errorf("tcpdump stopped before producing expected output %q, out:\n", t.stopOn, t.bOut.String())
-		case <-time.After(tcpdumpPollPeriod):
-			s := t.bOut.String()
-			if strings.Contains(s, t.failOn) {
-				return fmt.Errorf("found unexpected %q in tcpdump output:\n%s", t.failOn, s)
+			tmpDir, err := ioutil.TempDir("", "pass-fd-test")
+			if err != nil {
+				t.Fatalf("ioutil.TempDir(): %v", err)
 			}
-			if strings.Contains(s, t.stopOn) {
-				return nil
+			defer os.RemoveAll(tmpDir)
+			socketPath := filepath.Join(tmpDir, "tapfdserver.sock")
+
+			s := tapmanager.NewFDServer(socketPath, src)
+			if err := s.Serve(); err != nil {
+				t.Fatalf("Serve(): %v", err)
 			}
-		}
+			defer s.Stop()
+
+			c := tapmanager.NewFDClient(socketPath)
+			if err := c.Connect(); err != nil {
+				t.Fatalf("Connect(): %v", err)
+			}
+			defer func() {
+				if err := c.Close(); err != nil {
+					t.Errorf("Close(): %v", err)
+				}
+			}()
+
+			// TODO: check the returned data
+			if _, err := c.AddFDs(fdKey, &tapmanager.GetFDPayload{
+				Description: &tapmanager.PodNetworkDesc{
+					PodId:   samplePodId,
+					PodNs:   samplePodNS,
+					PodName: samplePodName,
+				},
+			}); err != nil {
+				t.Fatalf("AddFDs(): %v", err)
+			}
+			released := false
+			defer func() {
+				if !released {
+					c.ReleaseFDs(fdKey)
+				}
+			}()
+			cniClient.VerifyAdded()
+			veths := cniClient.Veths()
+			// TODO: support multiple interfaces
+			if len(veths) != 1 {
+				t.Fatalf("veth count mismatch: %d instead of %d", len(veths), 1)
+			}
+
+			fds, _, err := c.GetFDs(fdKey)
+			if err != nil {
+				t.Fatalf("GetFDs(): %v", err)
+			}
+			// TODO: support multiple interfaces
+			if len(fds) != 1 {
+				t.Fatalf("fd count mismatch: %d instead of %d", len(fds), 1)
+			}
+			vmTap := os.NewFile(uintptr(fds[0]), "tap-fd")
+			defer vmTap.Close()
+
+			outerIP := addAddress(t, vnt.hostNS, veths[0].HostSide, tc.outerAddr)
+			vnt.connectTaps(vmTap)
+			// tcpdump should catch udp 'ping' but should not
+			// see BOOTP/DHCP on the 'outer' link
+			vnt.addTcpdump(veths[0].HostSide, tc.tcpdumpStopOn, "BOOTP/DHCP")
+			vnt.verifyDhcp(tc.dhcpExpectedSubstrings)
+			vnt.verifyPing(outerIP)
+			vnt.wait()
+
+			if err := c.ReleaseFDs(fdKey); err != nil {
+				t.Errorf("ReleaseFDs(): %v", err)
+			}
+			released = true
+			cniClient.VerifyRemoved()
+		})
 	}
-	return fmt.Errorf("timed out waiting for tcpdump output %q, out:\n%s", t.stopOn, t.bOut.String())
 }
 
-func (t *tcpdump) stop() error {
-	// tcpdump exits with status 0 on SIGINT
-	// (if it hasn't exited already)
-	t.cmd.Process.Signal(os.Interrupt)
-	err := t.cmd.Wait()
-	if err != nil {
-		glog.Errorf("tcpdump failed: %v", err)
-	}
-	return err
-}
-
-func (t *tcpdump) Run(readyCh, stopCh chan struct{}) error {
-	// -l stands for 'line buffered'. We want to receive tcpdump
-	// output as soon as it's generated
-	t.cmd = exec.Command("tcpdump", "-l", "-n", "-i", t.link.Attrs().Name, "udp")
-	t.cmd.Stdout = &t.bOut
-	t.cmd.Stderr = &t.bErr
-
-	// make sure we start the process in current network namespace
-	if err := t.cmd.Start(); err != nil {
-		return fmt.Errorf("failed to start tcpdump: %v", err)
-	}
-
-	if t.waitForReady() {
-		close(readyCh)
-	} else {
-		t.stop()
-		return fmt.Errorf("timed out waiting for tcpdump, error output:\n%s", t.bErr.String())
-	}
-
-	if err := t.waitForSubstring(stopCh); err != nil {
-		t.stop()
-		return err
-	}
-
-	err := t.stop()
-	t.out = t.bOut.String()
-	return err
-}
-
-func addAddress(t *testing.T, netNS ns.NetNS, link netlink.Link, addr string) net.IP {
-	parsedAddr, err := netlink.ParseAddr(addr)
-	if err != nil {
-		t.Fatalf("failed to parse snooping address: %v", err)
-	}
-	if err := netNS.Do(func(ns.NetNS) (err error) {
-		return netlink.AddrAdd(link, parsedAddr)
-	}); err != nil {
-		t.Fatalf("failed to add address to snooping veth: %v", err)
-	}
-	return parsedAddr.IP
-}
-
-// tapConnector copies frames between tap interfaces. It returns
-// a channel that should be closed to stop copying and close
-// the tap devices
-type tapConnector struct {
-	tapA, tapB *os.File
-	wg         sync.WaitGroup
-}
-
-var _ NetTester = &tapConnector{}
-
-func newTapConnector(tapA, tapB *os.File) *tapConnector {
-	return &tapConnector{tapA: tapA, tapB: tapB}
-}
-
-func (tc *tapConnector) Name() string { return "tapConnector" }
-func (tc *tapConnector) Fg() bool     { return false }
-
-// copyFrames copies a packets between tap devices. Unlike
-// io.Copy(), it doesn't use buffering and thus keeps frame boundaries
-func (tc *tapConnector) copyFrames(from, to *os.File) {
-	buf := make([]byte, 1600)
-	for {
-		nRead, err := from.Read(buf)
-		if err != nil {
-			glog.Infof("copyFrames(): Read(): %v", err)
-			break
-		}
-		nWritten, err := to.Write(buf[:nRead])
-		if err != nil {
-			glog.Infof("copyFrames(): Write(): %v", err)
-			break
-		}
-		if nWritten < nRead {
-			glog.Warning("copyFrames(): short Write(): %d bytes instead of %d", nWritten, nRead)
-		}
-	}
-	tc.wg.Done()
-}
-
-func (tc *tapConnector) Run(readyCh, stopCh chan struct{}) error {
-	tc.wg.Add(1)
-	go tc.copyFrames(tc.tapA, tc.tapB)
-	tc.wg.Add(1)
-	go tc.copyFrames(tc.tapB, tc.tapA)
-	close(readyCh)
-	<-stopCh
-	// TODO: use SetDeadline() when it's available for os.File
-	// (perhaps in Go 1.10): https://github.com/golang/go/issues/22114
-	tc.tapA.Close()
-	tc.tapB.Close()
-	tc.wg.Wait()
-	return nil
-}
-
-// TODO: document NetTester / NetTestGroup
-// TODO: block ip trafic from br0 ip
-
-// TODO: apply CNI result using ConfigureLink()
+// TODO: in TestTapFDSource, use random pod id
 // TODO: use https://github.com/d4l3k/messagediff to diff cni results
+// TODO: check data returned by AddFDs() / GetFDs()
+// TODO: use table-driven test
 // TODO: test network teardown
 // TODO: test multiple CNIs
 // TODO: test Calico
+// TODO: test recovering netns


### PR DESCRIPTION
- [X] pump frames between taps instead of using veth hack for VM network test
- [X] add initial version of TapFDSource test
- [x] fix container netns cleanup upon TestTapFDSource failure
- [x] in TestTapFDSource, use random pod id to avoid cascading test case failures
- [x] check data returned by AddFDs() / GetFDs()
- [x] verify network teardown
- [x] verify fixing bad CNI info

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/540)
<!-- Reviewable:end -->
