### PR TITLE
[DNM] PoC of configdrive support

### DIFF
--- a/pkg/libvirttools/cloudinit.go
+++ b/pkg/libvirttools/cloudinit.go
@@ -61,6 +61,8 @@ func (g *CloudInitGenerator) generateMetaData() ([]byte, error) {
 	m := map[string]interface{}{
 		"instance-id":    fmt.Sprintf("%s.%s", g.config.PodName, g.config.PodNamespace),
 		"local-hostname": g.config.PodName,
+		"uuid":           fmt.Sprintf("%s.%s", g.config.PodName, g.config.PodNamespace),
+		"hostname":       g.config.PodName,
 	}
 	if len(g.config.ParsedAnnotations.SSHKeys) != 0 {
 		var keys []string
@@ -117,6 +119,61 @@ func (g *CloudInitGenerator) generateUserData(volumeMap diskPathMap) ([]byte, er
 		}
 	}
 	return []byte("#cloud-config\n" + string(r)), nil
+}
+
+func (g *CloudInitGenerator) generateNetworkConfigurationAsOpenstack() ([]byte, error) {
+	cniResult, err := cni.BytesToResult([]byte(g.config.CNIConfig))
+	if err != nil {
+		return nil, err
+	}
+	if cniResult == nil {
+		// This can only happen during integration tests
+		// where a dummy sandbox is used
+		return []byte("{}"), nil
+	}
+
+	config := make(map[string]interface{})
+
+	// links
+	var links []map[string]interface{}
+	for _, iface := range cniResult.Interfaces {
+		if iface.Sandbox == "" {
+			// skip host interfaces
+			continue
+		}
+		linkConf := map[string]interface{}{
+			"type": "phy",
+			"id":   iface.Name,
+			"ethernet_mac_address": iface.Mac,
+		}
+		links = append(links, linkConf)
+	}
+	config["links"] = links
+
+	var networks []map[string]interface{}
+	for i, ipConfig := range cniResult.IPs {
+		netConf := map[string]interface{}{
+			"id": fmt.Sprintf("net-%d", i),
+			// config from openstack have as network_id network uuid
+			"network_id": fmt.Sprintf("net-%d", i),
+			"type":       fmt.Sprintf("ipv%s", ipConfig.Version),
+			"link":       cniResult.Interfaces[ipConfig.Interface].Name,
+			"ip_address": ipConfig.Address.IP.String(),
+			"netmask":    net.IP(ipConfig.Address.Mask).String(),
+			// TODO: fill all routes there, including default route
+			// using as example data from https://specs.openstack.org/openstack/nova-specs/specs/liberty/implemented/metadata-service-network-info.html
+		}
+		networks = append(networks, netConf)
+	}
+	config["networks"] = networks
+
+	// TODO: add "services" section with dns addresses
+
+	r, err := json.Marshal(config)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling network configuration: %v", err)
+	}
+	return r, nil
 }
 
 func (g *CloudInitGenerator) generateNetworkConfiguration() ([]byte, error) {
@@ -251,22 +308,23 @@ func (g *CloudInitGenerator) GenerateImage(volumeMap diskPathMap) error {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	var metaData, userData []byte //, networkConfiguration []byte
+	var metaData, userData, networkConfiguration []byte
 	metaData, err = g.generateMetaData()
 	if err == nil {
 		userData, err = g.generateUserData(volumeMap)
 	}
-	// if err == nil {
-	// 	networkConfiguration, err = g.generateNetworkConfiguration()
-	// }
+	if err == nil {
+		// networkConfiguration, err = g.generateNetworkConfiguration()
+		networkConfiguration, err = g.generateNetworkConfigurationAsOpenstack()
+	}
 	if err != nil {
 		return err
 	}
 
 	if err := utils.WriteFiles(tmpDir, map[string][]byte{
-		"latest/user_data":      userData,
-		"latest/meta_data.json": metaData,
-		// "network-config": networkConfiguration,
+		"openstack/latest/user_data":         userData,
+		"openstack/latest/meta_data.json":    metaData,
+		"openstack/latest/network_data.json": networkConfiguration,
 	}); err != nil {
 		return fmt.Errorf("can't write user-data: %v", err)
 	}

--- a/pkg/libvirttools/cloudinit.go
+++ b/pkg/libvirttools/cloudinit.go
@@ -251,22 +251,22 @@ func (g *CloudInitGenerator) GenerateImage(volumeMap diskPathMap) error {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	var metaData, userData, networkConfiguration []byte
+	var metaData, userData []byte //, networkConfiguration []byte
 	metaData, err = g.generateMetaData()
 	if err == nil {
 		userData, err = g.generateUserData(volumeMap)
 	}
-	if err == nil {
-		networkConfiguration, err = g.generateNetworkConfiguration()
-	}
+	// if err == nil {
+	// 	networkConfiguration, err = g.generateNetworkConfiguration()
+	// }
 	if err != nil {
 		return err
 	}
 
 	if err := utils.WriteFiles(tmpDir, map[string][]byte{
-		"user-data":      userData,
-		"meta-data":      metaData,
-		"network-config": networkConfiguration,
+		"latest/user_data":      userData,
+		"latest/meta_data.json": metaData,
+		// "network-config": networkConfiguration,
 	}); err != nil {
 		return fmt.Errorf("can't write user-data: %v", err)
 	}
@@ -275,7 +275,7 @@ func (g *CloudInitGenerator) GenerateImage(volumeMap diskPathMap) error {
 		return fmt.Errorf("error making iso directory %q: %v", g.isoDir, err)
 	}
 
-	if err := utils.GenIsoImage(g.IsoPath(), "cidata", tmpDir); err != nil {
+	if err := utils.GenIsoImage(g.IsoPath(), "config-2", tmpDir); err != nil { // cidata
 		if rmErr := os.Remove(g.IsoPath()); rmErr != nil {
 			glog.Warningf("Error removing iso file %s: %v", g.IsoPath(), rmErr)
 		}


### PR DESCRIPTION
DO NOT MERGE - instead of providing a configurable option to choose how configuration should be passed to VM, this PR replaces NoCloud support with Config Drive support.

Network configuration is passed (not fully, no routes, no dns). testuser is properly created and configured under example ubuntu vm.

This can not be easily tested under our cirros vm because it has removed entry for `ConfigDrive` in `datasource_list` in `/etc/cloud/cloud.cfg`. After adding this entry manually (in image or in running system) config drive support is correctly recognized after using `/etc/init.d/cloud-init-local start` command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/549)
<!-- Reviewable:end -->
