### PR TITLE
Fix network data generation in cloud init

### DIFF
--- a/pkg/libvirttools/cloudinit.go
+++ b/pkg/libvirttools/cloudinit.go
@@ -197,7 +197,8 @@ func (g *CloudInitGenerator) getSubnetsAndGatewaysForNthInterface(interfaceNo in
 		if ipConfig.Interface == interfaceNo {
 			subnet := map[string]interface{}{
 				"type":    "static",
-				"address": ipConfig.Address.String(),
+				"address": ipConfig.Address.IP.String(),
+				"netmask": net.IP(ipConfig.Address.Mask).String(),
 			}
 			if !ipConfig.Gateway.IsUnspecified() {
 				gateways = append(gateways, ipConfig.Gateway)

--- a/pkg/libvirttools/cloudinit_test.go
+++ b/pkg/libvirttools/cloudinit_test.go
@@ -402,7 +402,8 @@ func TestCloudInitGenerator(t *testing.T) {
 						"name":        "cni0",
 						"subnets": []interface{}{
 							map[string]interface{}{
-								"address":         "1.1.1.1/8",
+								"address":         "1.1.1.1",
+								"netmask":         "255.0.0.0",
 								"dns_nameservers": []interface{}{"1.2.3.4"},
 								"dns_search":      []interface{}{"some", "search"},
 								"type":            "static",
@@ -482,7 +483,8 @@ func TestCloudInitGenerator(t *testing.T) {
 						"name":        "cni0",
 						"subnets": []interface{}{
 							map[string]interface{}{
-								"address":         "1.1.1.1/8",
+								"address":         "1.1.1.1",
+								"netmask":         "255.0.0.0",
 								"dns_nameservers": []interface{}{"1.2.3.4"},
 								"dns_search":      []interface{}{"some", "search"},
 								"type":            "static",
@@ -495,7 +497,8 @@ func TestCloudInitGenerator(t *testing.T) {
 						"name":        "cni1",
 						"subnets": []interface{}{
 							map[string]interface{}{
-								"address":         "192.168.100.42/24",
+								"address":         "192.168.100.42",
+								"netmask":         "255.255.255.0",
 								"dns_nameservers": []interface{}{"1.2.3.4"},
 								"dns_search":      []interface{}{"some", "search"},
 								"type":            "static",


### PR DESCRIPTION
Without that - even if http://cloudinit.readthedocs.io/en/latest/topics/network-config-format-v1.html
says that address may include CIDR netmask notation - some cloud init
data generators can produce wrong network configuration - one for fedora is
example one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/555)
<!-- Reviewable:end -->
