### PR TITLE
Run CNI plugins in the host mount namespace

### DIFF
--- a/cmd/virtlet/virtlet.go
+++ b/cmd/virtlet/virtlet.go
@@ -32,6 +32,7 @@ import (
 	"github.com/Mirantis/virtlet/pkg/metadata"
 	"github.com/Mirantis/virtlet/pkg/stream"
 	"github.com/Mirantis/virtlet/pkg/tapmanager"
+	"github.com/Mirantis/virtlet/pkg/utils"
 )
 
 var (
@@ -158,6 +159,7 @@ func startTapManagerProcess() {
 }
 
 func main() {
+	utils.HandleNsFixReexec()
 	flag.Parse()
 	rand.Seed(time.Now().UnixNano())
 	if os.Getenv(WantTapManagerEnv) == "" {

--- a/cmd/vmwrapper/vmwrapper.go
+++ b/cmd/vmwrapper/vmwrapper.go
@@ -70,7 +70,7 @@ func main() {
 	utils.HandleNsFixReexec()
 
 	// configure glog (apparently no better way to do it ...)
-	flag.CommandLine.Parse([]string{"-v=3", "-alsologtostderr=true"})
+	flag.CommandLine.Parse([]string{"-v=3", "-logtostderr=true"})
 
 	runInAnotherContainer := os.Getuid() != 0
 

--- a/cmd/vmwrapper/vmwrapper.go
+++ b/cmd/vmwrapper/vmwrapper.go
@@ -32,102 +32,6 @@ import (
 	"github.com/Mirantis/virtlet/pkg/utils"
 )
 
-// Here we use cgo constructor trick to avoid threading-related problems
-// (not being able to enter the mount namespace)
-// when working with process uids/gids and namespaces
-// https://github.com/golang/go/issues/8676#issuecomment-66098496
-
-/*
-#define _GNU_SOURCE
-
-#include <stdlib.h>
-#include <stdio.h>
-#include <fcntl.h>
-#include <sched.h>
-#include <unistd.h>
-#include <sys/mount.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <linux/limits.h>
-
-static void vmwrapper_perr(const char* msg) {
-	perror(msg);
-	exit(1);
-}
-
-static void vmwrapper_setns(int my_pid, int target_pid, int nstype, const char* nsname) {
-	int my_ns_inode, fd;
-        struct stat st;
-	char my_ns_path[PATH_MAX], target_ns_path[PATH_MAX];
-	snprintf(my_ns_path, sizeof(my_ns_path), "/proc/%u/ns/%s", my_pid, nsname);
-	snprintf(target_ns_path, sizeof(target_ns_path), "/proc/%u/ns/%s", target_pid, nsname);
-	if (stat(my_ns_path, &st) < 0) {
-		vmwrapper_perr("stat() my ns");
-	}
-	my_ns_inode = st.st_ino;
-	if (stat(target_ns_path, &st) < 0) {
-		vmwrapper_perr("stat() target ns");
-	}
-
-	// Check if that's the same namespace
-	// (actually only critical for CLONE_NEWUSER)
-	if (my_ns_inode == st.st_ino)
-		return;
-
-	if ((fd = open(target_ns_path, O_RDONLY)) < 0) {
-		vmwrapper_perr("open() target ns");
-	}
-
-	if (setns(fd, nstype) < 0) {
-		vmwrapper_perr("setns()");
-	}
-}
-
-// This function is a high-priority constructor that will be invoked
-// before any Go code starts.
-__attribute__((constructor (200))) void vmwrapper_handle_reexec(void) {
-	int my_pid, target_pid;
-	char* pid_str;
-	if ((pid_str = getenv("VMWRAPPER_NS_PID")) == NULL)
-		return;
-
-	my_pid = getpid();
-        target_pid = atoi(pid_str);
-
-        // Other namespaces:
-        // cgroup, user - not touching
-        // pid - host pid namespace is used by virtlet
-        // net - host network is used by virtlet
-	fprintf(stderr, "vmwrapper reexec: entering vms container namespaces\n");
-	vmwrapper_setns(my_pid, target_pid, CLONE_NEWNS, "mnt");
-	vmwrapper_setns(my_pid, target_pid, CLONE_NEWUTS, "uts");
-	vmwrapper_setns(my_pid, target_pid, CLONE_NEWIPC, "ipc");
-
-	// remount /sys for the new netns
-	if (umount2("/sys", MNT_DETACH) < 0)
-		vmwrapper_perr("umount2()");
-	if (mount("none", "/sys", "sysfs", 0, NULL) < 0)
-		vmwrapper_perr("mount()");
-
-	// Permanently drop privs unless not to do so.
-	// Currently we don't drop privs when SR-IOV support is enabled
-	// because of an unresolved emulator permission problem.
-	if (getenv("VMWRAPPER_KEEP_PRIVS") == NULL) {
-		fprintf(stderr, "vmwrapper reexec: dropping privs\n");
-		if (setgid(getgid()) < 0)
-			vmwrapper_perr("setgid()");
-		if (setuid(getuid()) < 0)
-			vmwrapper_perr("setuid()");
-	} else {
-		if (setgid(0) < 0)
-			vmwrapper_perr("setgid()");
-		if (setuid(0) < 0)
-			vmwrapper_perr("setuid()");
-	}
-}
-*/
-import "C"
-
 const (
 	fdSocketPath    = "/var/lib/virtlet/tapfdserver.sock"
 	defaultEmulator = "/usr/bin/qemu-system-x86_64" // FIXME
@@ -149,16 +53,24 @@ func extractLastUsedPCIAddress(args []string) int {
 	return lastUsed
 }
 
+type reexecArg struct {
+	Args []string
+}
+
+func handleReexec(arg interface{}) (interface{}, error) {
+	args := arg.(*reexecArg).Args
+	if err := syscall.Exec(args[0], args, os.Environ()); err != nil {
+		return nil, fmt.Errorf("Can't exec emulator: %v", err)
+	}
+	return nil, nil // unreachable
+}
+
 func main() {
+	utils.RegisterNsFixReexec("vmwrapper", handleReexec, reexecArg{})
+	utils.HandleNsFixReexec()
+
 	// configure glog (apparently no better way to do it ...)
 	flag.CommandLine.Parse([]string{"-v=3", "-alsologtostderr=true"})
-
-	if os.Getenv("VMWRAPPER_NS_PID") != "" {
-		if err := syscall.Exec(os.Args[1], os.Args[1:], os.Environ()); err != nil {
-			glog.Errorf("Can't exec emulator: %v", err)
-			os.Exit(1)
-		}
-	}
 
 	runInAnotherContainer := os.Getuid() != 0
 
@@ -238,16 +150,19 @@ func main() {
 	args = append(args, netArgs...)
 	env := os.Environ()
 	if runInAnotherContainer {
-		// re-execute itself because entering mount namespace
-		// is impossible after Go runtime spawns some threads
-		env = append(env, fmt.Sprintf("VMWRAPPER_NS_PID=%d", pid))
-		args = append([]string{os.Args[0]}, args...)
-	}
-
-	// below log hides any possible error in returned by libvirt virError
-	// glog.V(0).Infof("Executing emulator: %s", strings.Join(args, " "))
-	if err := syscall.Exec(args[0], args, env); err != nil {
-		glog.Errorf("Can't exec emulator: %v", err)
-		os.Exit(1)
+		// Currently we don't drop privs when SR-IOV support is enabled
+		// because of an unresolved emulator permission problem.
+		dropPrivs := os.Getenv("VMWRAPPER_KEEP_PRIVS") == ""
+		if err := utils.SwitchToNamespaces(pid, "vmwrapper", &reexecArg{args}, dropPrivs); err != nil {
+			glog.Fatalf("Error reexecuting vmwrapper: %v", err)
+		}
+	} else {
+		// this log hides errors returned by libvirt virError
+		// because of libvirt's output parsing approach
+		// glog.V(0).Infof("Executing emulator: %s", strings.Join(args, " "))
+		if err := syscall.Exec(args[0], args, env); err != nil {
+			glog.Errorf("Can't exec emulator: %v", err)
+			os.Exit(1)
+		}
 	}
 }

--- a/deploy/virtlet-ds.yaml
+++ b/deploy/virtlet-ds.yaml
@@ -112,21 +112,20 @@ spec:
           name: virtlet
         - mountPath: /var/lib/libvirt
           name: libvirt
-        - mountPath: /etc/cni
-          name: cniconf
-        - mountPath: /opt/cni/bin.orig
-          name: cnibin
         - mountPath: /var/run/libvirt
           name: libvirt-sockets
-        - mountPath: /var/lib/cni
-          name: cnidata
         - mountPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
           name: k8s-flexvolume-plugins-dir
-          # below `:shared` is unofficial way to pass this option docker
-          # which then will allow virtlet to see what kubelet mounts in
-          # underlaying directories, after virtlet container is created
+          # `:shared` below is an unofficial way to pass 'shared' option to Docker
+          # which will make it possible for Virtlet to see mounts made by kubelet in
+          # the underlying directories after Virtlet container is created
         - mountPath: /var/lib/kubelet/pods:shared
           name: k8s-pods-dir
+          # /var/run/netns must be a shared mount so both Virtlet
+          # and CNI plugins (which run in the host netns) can work
+          # with network namespaces mounted there
+        - mountPath: /var/run/netns:shared
+          name: netns-dir
         - name: vms-log
           mountPath: /var/log/vms
         - mountPath: /etc/virtlet/images
@@ -226,15 +225,6 @@ spec:
           path: /var/lib/libvirt
         name: libvirt
       - hostPath:
-          path: /etc/cni
-        name: cniconf
-      - hostPath:
-          path: /opt/cni/bin
-        name: cnibin
-      - hostPath:
-          path: /var/lib/cni
-        name: cnidata
-      - hostPath:
           path: /var/log
         name: log
       - hostPath:
@@ -255,6 +245,9 @@ spec:
       - hostPath:
           path: /var/log/pods
         name: pods-log
+      - hostPath:
+          path: /var/run/netns
+        name: netns-dir
       - configMap:
           name: virtlet-image-translations
         name: image-name-translations

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -1,13 +1,13 @@
 # Networking
 
 For now the only supported configuration is the use of
-[CNI plugins](https://github.com/containernetworking/cni). To use
-custom CNI configuration, mount your `/etc/cni` and optionally
-`/opt/cni` into the virtlet container.
+[CNI plugins](https://github.com/containernetworking/cni).
 
 Virtlet have the same behavior and default values for `--cni-bin-dir`
 and `--cni-conf-dir` as described in kubelet network plugins
 [documentation](http://kubernetes.io/docs/admin/network-plugins/).
+These parameters refer to paths on the host, it's not necessary to
+have them mounted into the Virtlet container.
 
 ## VM Network Setup Diagram
 

--- a/images/image_skel/start.sh
+++ b/images/image_skel/start.sh
@@ -23,20 +23,9 @@ if [ ! -d ${FLEXVOLUME_DIR}/virtlet~flexvolume_driver ]; then
     cp /flexvolume_driver ${FLEXVOLUME_DIR}/virtlet~flexvolume_driver/flexvolume_driver
 fi
 
-
 while [ ! -S /var/run/libvirt/libvirt-sock ] ; do
   echo >&1 "Waiting for libvirt..."
   sleep 0.3
 done
-
-# FIXME: make tapfdsource do netns stuff in a separate process
-if [ -d /opt/cni/bin.orig ]; then
-  mkdir /opt/cni/bin
-  find /opt/cni/bin.orig -maxdepth 1 -executable \( -type f -o -type l \) | while read p; do
-    newname="/opt/cni/bin/$(basename "$p")"
-    echo -e "#!/bin/sh\nexec /usr/bin/nsenter -t 1 -n ${p} \"\$@\"" >"${newname}"
-    chmod +x "${newname}"
-  done
-fi
 
 /usr/local/bin/virtlet -v=${VIRTLET_LOGLEVEL:-3} -logtostderr=true -image-download-protocol="${PROTOCOL}" -image-translations-dir="${IMAGE_TRANSLATIONS_DIR}" "${RAW_DEVICES}"

--- a/pkg/cni/client.go
+++ b/pkg/cni/client.go
@@ -154,14 +154,14 @@ func handleAddSandboxToNetwork(arg interface{}) (interface{}, error) {
 	rtConf.Args = append(rtConf.Args, [2]string{
 		"K8S_ANNOT", `{"cni": "calico"}`,
 	})
-	glog.V(3).Infof("AddSandboxToNetwork: req.PodId %q, req.PodName %q, req.PodNs %q, runtime config:\n%s",
+	glog.V(3).Infof("AddSandboxToNetwork: PodId %q, PodName %q, PodNs %q, runtime config:\n%s",
 		req.PodId, req.PodName, req.PodNs, spew.Sdump(rtConf))
 	result, err := c.cniConfig.AddNetworkList(c.netConfigList, rtConf)
 	if err == nil {
-		glog.V(3).Infof("AddSandboxToNetwork: req.PodId %q, req.PodName %q, req.PodNs %q: result:\n%s",
+		glog.V(3).Infof("AddSandboxToNetwork: PodId %q, PodName %q, PodNs %q: result:\n%s",
 			req.PodId, req.PodName, req.PodNs, spew.Sdump(result))
 	} else {
-		glog.V(3).Infof("AddSandboxToNetwork: req.PodId %q, req.PodName %q, req.PodNs %q: error: %v",
+		glog.V(3).Infof("AddSandboxToNetwork: PodId %q, PodName %q, PodNs %q: error: %v",
 			req.PodId, req.PodName, req.PodNs, err)
 		return nil, err
 	}
@@ -179,13 +179,13 @@ func handleRemoveSandboxFromNetwork(arg interface{}) (interface{}, error) {
 		return nil, err
 	}
 
-	glog.V(3).Infof("RemoveSandboxFromNetwork: req.PodId %q, req.PodName %q, req.PodNs %q", req.PodId, req.PodName, req.PodNs)
+	glog.V(3).Infof("RemoveSandboxFromNetwork: PodId %q, PodName %q, PodNs %q", req.PodId, req.PodName, req.PodNs)
 	err = c.cniConfig.DelNetworkList(c.netConfigList, c.cniRuntimeConf(req.PodId, req.PodName, req.PodNs))
 	if err == nil {
-		glog.V(3).Infof("RemoveSandboxFromNetwork: req.PodId %q, req.PodName %q, req.PodNs %q: success",
+		glog.V(3).Infof("RemoveSandboxFromNetwork: PodId %q, PodName %q, PodNs %q: success",
 			req.PodId, req.PodName, req.PodNs)
 	} else {
-		glog.V(3).Infof("RemoveSandboxFromNetwork: req.PodId %q, req.PodName %q, req.PodNs %q: error: %v",
+		glog.V(3).Infof("RemoveSandboxFromNetwork: PodId %q, PodName %q, PodNs %q: error: %v",
 			req.PodId, req.PodName, req.PodNs, err)
 	}
 	return nil, err

--- a/pkg/cni/client.go
+++ b/pkg/cni/client.go
@@ -72,13 +72,15 @@ func (c *Client) GetDummyNetwork() (*cnicurrent.Result, string, error) {
 // AddSandboxToNetwork implements AddSandboxToNetwork method of CNIClient interface
 func (c *Client) AddSandboxToNetwork(podId, podName, podNs string) (*cnicurrent.Result, error) {
 	var r cnicurrent.Result
-	if err := utils.SpawnInNamespaces(1, "cniAddSandboxToNetwork", cniRequest{
-		PluginsDir: c.pluginsDir,
-		ConfigsDir: c.configsDir,
-		PodId:      podId,
-		PodName:    podName,
-		PodNs:      podNs,
-	}, false, &r); err != nil {
+	if err := utils.NewNsFixCall("cniAddSandboxToNetwork").
+		Arg(cniRequest{
+			PluginsDir: c.pluginsDir,
+			ConfigsDir: c.configsDir,
+			PodId:      podId,
+			PodName:    podName,
+			PodNs:      podNs,
+		}).
+		SpawnInNamespaces(&r); err != nil {
 		return nil, err
 	}
 	return &r, nil
@@ -86,13 +88,15 @@ func (c *Client) AddSandboxToNetwork(podId, podName, podNs string) (*cnicurrent.
 
 // RemoveSandboxFromNetwork implements RemoveSandboxFromNetwork method of CNIClient interface
 func (c *Client) RemoveSandboxFromNetwork(podId, podName, podNs string) error {
-	return utils.SpawnInNamespaces(1, "cniRemoveSandboxToNetwork", cniRequest{
-		PluginsDir: c.pluginsDir,
-		ConfigsDir: c.configsDir,
-		PodId:      podId,
-		PodName:    podName,
-		PodNs:      podNs,
-	}, false, nil)
+	return utils.NewNsFixCall("cniRemoveSandboxToNetwork").
+		Arg(cniRequest{
+			PluginsDir: c.pluginsDir,
+			ConfigsDir: c.configsDir,
+			PodId:      podId,
+			PodName:    podName,
+			PodNs:      podNs,
+		}).
+		SpawnInNamespaces(nil)
 }
 
 type cniRequest struct {

--- a/pkg/cni/client.go
+++ b/pkg/cni/client.go
@@ -39,40 +39,17 @@ type CNIClient interface {
 }
 
 type Client struct {
-	cniConfig     *libcni.CNIConfig
-	netConfigList *libcni.NetworkConfigList
+	pluginsDir string
+	configsDir string
 }
 
 var _ CNIClient = &Client{}
 
 func NewClient(pluginsDir, configsDir string) (*Client, error) {
-	netConfigList, err := ReadConfiguration(configsDir)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read CNI configuration %q: %v", configsDir, err)
-	}
-	glog.V(3).Infof("CNI config: name: %q type: %q", netConfigList.Plugins[0].Network.Name, netConfigList.Plugins[0].Network.Type)
-
 	return &Client{
-		cniConfig:     &libcni.CNIConfig{Path: []string{pluginsDir}},
-		netConfigList: netConfigList,
+		pluginsDir: pluginsDir,
+		configsDir: configsDir,
 	}, nil
-}
-
-func (c *Client) cniRuntimeConf(podId, podName, podNs string) *libcni.RuntimeConf {
-	r := &libcni.RuntimeConf{
-		ContainerID: podId,
-		NetNS:       PodNetNSPath(podId),
-		IfName:      "virtlet-eth0",
-	}
-	if podName != "" && podNs != "" {
-		r.Args = [][2]string{
-			{"IgnoreUnknown", "1"},
-			{"K8S_POD_NAMESPACE", podNs},
-			{"K8S_POD_NAME", podName},
-			{"K8S_POD_INFRA_CONTAINER_ID", podId},
-		}
-	}
-	return r
 }
 
 // GetDummyNetwork implements GetDummyNetwork method of CNIClient interface
@@ -94,20 +71,94 @@ func (c *Client) GetDummyNetwork() (*cnicurrent.Result, string, error) {
 
 // AddSandboxToNetwork implements AddSandboxToNetwork method of CNIClient interface
 func (c *Client) AddSandboxToNetwork(podId, podName, podNs string) (*cnicurrent.Result, error) {
-	rtConf := c.cniRuntimeConf(podId, podName, podNs)
+	var r cnicurrent.Result
+	if err := utils.SpawnInNamespaces(1, "cniAddSandboxToNetwork", cniRequest{
+		PluginsDir: c.pluginsDir,
+		ConfigsDir: c.configsDir,
+		PodId:      podId,
+		PodName:    podName,
+		PodNs:      podNs,
+	}, false, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+// RemoveSandboxFromNetwork implements RemoveSandboxFromNetwork method of CNIClient interface
+func (c *Client) RemoveSandboxFromNetwork(podId, podName, podNs string) error {
+	return utils.SpawnInNamespaces(1, "cniRemoveSandboxToNetwork", cniRequest{
+		PluginsDir: c.pluginsDir,
+		ConfigsDir: c.configsDir,
+		PodId:      podId,
+		PodName:    podName,
+		PodNs:      podNs,
+	}, false, nil)
+}
+
+type cniRequest struct {
+	PluginsDir string
+	ConfigsDir string
+	PodId      string
+	PodName    string
+	PodNs      string
+}
+
+type realCNIClient struct {
+	cniConfig     *libcni.CNIConfig
+	netConfigList *libcni.NetworkConfigList
+}
+
+func newRealCNIClient(pluginsDir, configsDir string) (*realCNIClient, error) {
+	netConfigList, err := ReadConfiguration(configsDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CNI configuration %q: %v", configsDir, err)
+	}
+	glog.V(3).Infof("CNI config: name: %q type: %q", netConfigList.Plugins[0].Network.Name, netConfigList.Plugins[0].Network.Type)
+
+	return &realCNIClient{
+		cniConfig:     &libcni.CNIConfig{Path: []string{pluginsDir}},
+		netConfigList: netConfigList,
+	}, nil
+}
+
+func (c *realCNIClient) cniRuntimeConf(podId, podName, podNs string) *libcni.RuntimeConf {
+	r := &libcni.RuntimeConf{
+		ContainerID: podId,
+		NetNS:       PodNetNSPath(podId),
+		IfName:      "virtlet-eth0",
+	}
+	if podName != "" && podNs != "" {
+		r.Args = [][2]string{
+			{"IgnoreUnknown", "1"},
+			{"K8S_POD_NAMESPACE", podNs},
+			{"K8S_POD_NAME", podName},
+			{"K8S_POD_INFRA_CONTAINER_ID", podId},
+		}
+	}
+	return r
+}
+
+func handleAddSandboxToNetwork(arg interface{}) (interface{}, error) {
+	req := arg.(*cniRequest)
+	c, err := newRealCNIClient(req.PluginsDir, req.ConfigsDir)
+	if err != nil {
+		return nil, err
+	}
+
+	rtConf := c.cniRuntimeConf(req.PodId, req.PodName, req.PodNs)
 	// NOTE: this annotation is only need by CNI Genie
 	rtConf.Args = append(rtConf.Args, [2]string{
 		"K8S_ANNOT", `{"cni": "calico"}`,
 	})
-	glog.V(3).Infof("AddSandboxToNetwork: podId %q, podName %q, podNs %q, runtime config:\n%s",
-		podId, podName, podNs, spew.Sdump(rtConf))
+	glog.V(3).Infof("AddSandboxToNetwork: req.PodId %q, req.PodName %q, req.PodNs %q, runtime config:\n%s",
+		req.PodId, req.PodName, req.PodNs, spew.Sdump(rtConf))
 	result, err := c.cniConfig.AddNetworkList(c.netConfigList, rtConf)
 	if err == nil {
-		glog.V(3).Infof("AddSandboxToNetwork: podId %q, podName %q, podNs %q: result:\n%s",
-			podId, podName, podNs, spew.Sdump(result))
+		glog.V(3).Infof("AddSandboxToNetwork: req.PodId %q, req.PodName %q, req.PodNs %q: result:\n%s",
+			req.PodId, req.PodName, req.PodNs, spew.Sdump(result))
 	} else {
-		glog.V(3).Infof("AddSandboxToNetwork: podId %q, podName %q, podNs %q: error: %v",
-			podId, podName, podNs, err)
+		glog.V(3).Infof("AddSandboxToNetwork: req.PodId %q, req.PodName %q, req.PodNs %q: error: %v",
+			req.PodId, req.PodName, req.PodNs, err)
 		return nil, err
 	}
 	r, err := cnicurrent.NewResultFromResult(result)
@@ -117,16 +168,26 @@ func (c *Client) AddSandboxToNetwork(podId, podName, podNs string) (*cnicurrent.
 	return r, err
 }
 
-// RemoveSandboxFromNetwork implements RemoveSandboxFromNetwork method of CNIClient interface
-func (c *Client) RemoveSandboxFromNetwork(podId, podName, podNs string) error {
-	glog.V(3).Infof("RemoveSandboxFromNetwork: podId %q, podName %q, podNs %q", podId, podName, podNs)
-	err := c.cniConfig.DelNetworkList(c.netConfigList, c.cniRuntimeConf(podId, podName, podNs))
-	if err == nil {
-		glog.V(3).Infof("RemoveSandboxFromNetwork: podId %q, podName %q, podNs %q: success",
-			podId, podName, podNs)
-	} else {
-		glog.V(3).Infof("RemoveSandboxFromNetwork: podId %q, podName %q, podNs %q: error: %v",
-			podId, podName, podNs, err)
+func handleRemoveSandboxFromNetwork(arg interface{}) (interface{}, error) {
+	req := arg.(*cniRequest)
+	c, err := newRealCNIClient(req.PluginsDir, req.ConfigsDir)
+	if err != nil {
+		return nil, err
 	}
-	return err
+
+	glog.V(3).Infof("RemoveSandboxFromNetwork: req.PodId %q, req.PodName %q, req.PodNs %q", req.PodId, req.PodName, req.PodNs)
+	err = c.cniConfig.DelNetworkList(c.netConfigList, c.cniRuntimeConf(req.PodId, req.PodName, req.PodNs))
+	if err == nil {
+		glog.V(3).Infof("RemoveSandboxFromNetwork: req.PodId %q, req.PodName %q, req.PodNs %q: success",
+			req.PodId, req.PodName, req.PodNs)
+	} else {
+		glog.V(3).Infof("RemoveSandboxFromNetwork: req.PodId %q, req.PodName %q, req.PodNs %q: error: %v",
+			req.PodId, req.PodName, req.PodNs, err)
+	}
+	return nil, err
+}
+
+func init() {
+	utils.RegisterNsFixReexec("cniAddSandboxToNetwork", handleAddSandboxToNetwork, cniRequest{})
+	utils.RegisterNsFixReexec("cniRemoveSandboxFromNetwork", handleAddSandboxToNetwork, cniRequest{})
 }

--- a/pkg/stream/listener_test.go
+++ b/pkg/stream/listener_test.go
@@ -20,10 +20,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
+
+	testutils "github.com/Mirantis/virtlet/pkg/utils/testing"
 )
 
 func getServer() *UnixServer {
@@ -119,17 +120,13 @@ func TestCleaningReader(t *testing.T) {
 
 	// setup client
 	containerID := "1123ab2-baed-32e7-6d1d-13110da12345"
-	cmd := exec.Command("nc", "-U", u.SocketPath)
-	cmd.Env = append(os.Environ(),
+	tc := testutils.RunProcess(t, "nc", []string{"-U", u.SocketPath}, []string{
 		"VIRTLET_POD_UID=8c8e8cf1-acea-11e7-8e0e-02420ac00002",
 		"VIRTLET_CONTAINER_NAME=ubuntu",
 		fmt.Sprintf("VIRTLET_CONTAINER_ID=%s", containerID),
 		"CONTAINER_ATTEMPTS=0",
-	)
-	if err := cmd.Start(); err != nil {
-		t.Errorf("Error when starting command: %v", err)
-	}
-	defer cmd.Process.Kill()
+	})
+	defer tc.Stop()
 
 	u.Stop()
 	outputReaders, ok := u.outputReaders[containerID]

--- a/pkg/stream/utils_test.go
+++ b/pkg/stream/utils_test.go
@@ -20,10 +20,11 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
-	"os/exec"
 	"runtime"
 	"testing"
 	"time"
+
+	testutils "github.com/Mirantis/virtlet/pkg/utils/testing"
 )
 
 func TestGetPidFromConnection(t *testing.T) {
@@ -34,12 +35,10 @@ func TestGetPidFromConnection(t *testing.T) {
 	defer os.Remove(socket.Name())
 	socketPath := socket.Name()
 
-	cmd := exec.Command("nc", "-l", "-U", socketPath)
-	if err := cmd.Start(); err != nil {
-		t.Errorf("Error when starting command: %v", err)
-	}
-	defer cmd.Process.Kill()
-	//wait for nc to start
+	tc := testutils.RunProcess(t, "nc", []string{"-l", "-U", socketPath}, nil)
+	defer tc.Stop()
+
+	// wait for nc to start
 	time.Sleep(2 * time.Second)
 
 	conn, err := net.DialUnix("unix", nil, &net.UnixAddr{socketPath, "unix"})
@@ -52,8 +51,8 @@ func TestGetPidFromConnection(t *testing.T) {
 	if err != nil {
 		t.Errorf("Couldn't get pid from Unix socket: %v", err)
 	}
-	if pid != int32(cmd.Process.Pid) {
-		t.Errorf("Wrong pid from getPidFromConnection. Expected: %d, got %d", cmd.Process.Pid, pid)
+	if pid != int32(tc.Pid()) {
+		t.Errorf("Wrong pid from getPidFromConnection. Expected: %d, got %d", tc.Pid(), pid)
 	}
 }
 
@@ -61,16 +60,13 @@ func TestGetProcessEnvironment(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("getProcessEnvironment only works on Linux")
 	}
-	cmd := exec.Command("sleep", "10")
-	cmd.Env = append(os.Environ(),
+
+	tc := testutils.RunProcess(t, "sleep", []string{"10"}, []string{
 		"FOO=1",
 		"BAR=asd",
-	)
-	if err := cmd.Start(); err != nil {
-		t.Errorf("Error when starting command: %v", err)
-	}
-	defer cmd.Process.Kill()
-	env, err := getProcessEnvironment(int32(cmd.Process.Pid))
+	})
+	defer tc.Stop()
+	env, err := getProcessEnvironment(int32(tc.Pid()))
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/utils/nsfix.go
+++ b/pkg/utils/nsfix.go
@@ -30,6 +30,12 @@ import (
 	"github.com/golang/glog"
 )
 
+// NsFixReexecHandler is a function that can be passed to
+// RegisterNsFixReexec to be executed my nsfix mechanism after
+// self-reexec. arg can be safely casted to the type of arg
+// passed to RegisterNsFixReexec plus one level of pointer
+// inderection, i.e. if you pass somestruct{} to RegisterNsFixReexec
+// you may cast arg safely to *somestruct.
 type NsFixReexecHandler func(arg interface{}) (interface{}, error)
 
 type nsFixHandlerEntry struct {
@@ -47,8 +53,8 @@ type retStruct struct {
 
 // RegisterNsFixReexec registers the specified function as a reexec handler.
 // arg specifies the argument type to pass. Note that if you pass somestruct{}
-// as arg, the handler will receive somestruct* as its argument (i.e. a level
-// of pointer indirection is added)
+// as arg, the handler will receive *somestruct as its argument (i.e. a level
+// of pointer indirection is added).
 func RegisterNsFixReexec(name string, handler NsFixReexecHandler, arg interface{}) {
 	reexecMap[name] = nsFixHandlerEntry{handler, reflect.TypeOf(arg)}
 }

--- a/pkg/utils/nsfix.go
+++ b/pkg/utils/nsfix.go
@@ -185,12 +185,12 @@ func getEnvForExec(targetPid int, handlerName string, arg interface{}, dropPrivs
 		fmt.Sprintf("NSFIX_LOG_LEVEL=%d", getGlogLevel())), nil
 }
 
-// SwitchToNamespaces executes the specified handler using mount, UTS
-// and IPC namespaces of the specified process. It passes arg to the
-// handler using JSON serialization. The current process gets replaced
-// by the new one. If dropPrivs is true, the new process will execute
-// using non-root uid/gid (using real uid/gid of the process if
-// they're non-zero or 65534 which is nobody/nogroup)
+// SwitchToNamespaces executes the specified handler using network,
+// mount, UTS and IPC namespaces of the specified process. It passes
+// arg to the handler using JSON serialization. The current process
+// gets replaced by the new one. If dropPrivs is true, the new process
+// will execute using non-root uid/gid (using real uid/gid of the
+// process if they're non-zero or 65534 which is nobody/nogroup)
 func SwitchToNamespaces(targetPid int, handlerName string, arg interface{}, dropPrivs bool) error {
 	env, err := getEnvForExec(targetPid, handlerName, arg, dropPrivs, false)
 	if err != nil {
@@ -199,10 +199,10 @@ func SwitchToNamespaces(targetPid int, handlerName string, arg interface{}, drop
 	return syscall.Exec(os.Args[0], os.Args[:1], env)
 }
 
-// SpawnInNamespaces executes the specified handler using mount, UTS
-// and IPC namespaces of the specified process. It passes arg to the
-// handler using JSON serialization. It then returns the value
-// returned by the handler (also via JSON serialization +
+// SpawnInNamespaces executes the specified handler using network,
+// mount, UTS and IPC namespaces of the specified process. It passes
+// arg to the handler using JSON serialization. It then returns the
+// value returned by the handler (also via JSON serialization +
 // deserialization). If dropPrivs is true, the new process will
 // execute using non-root uid/gid (using real uid/gid of the process
 // if they're non-zero or 65534 which is nobody/nogroup)

--- a/pkg/utils/nsfix.go
+++ b/pkg/utils/nsfix.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2018 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"reflect"
+	"strings"
+	"syscall"
+
+	"github.com/golang/glog"
+)
+
+type NsFixReexecHandler func(arg interface{}) (interface{}, error)
+
+type nsFixHandlerEntry struct {
+	handler NsFixReexecHandler
+	argType reflect.Type
+}
+
+var reexecMap = map[string]nsFixHandlerEntry{}
+
+type retStruct struct {
+	Success bool
+	Result  json.RawMessage
+	Error   string
+}
+
+// RegisterNsFixReexec registers the specified function as a reexec handler.
+// arg specifies the argument type to pass. Note that if you pass somestruct{}
+// as arg, the handler will receive somestruct* as its argument (i.e. a level
+// of pointer indirection is added)
+func RegisterNsFixReexec(name string, handler NsFixReexecHandler, arg interface{}) {
+	reexecMap[name] = nsFixHandlerEntry{handler, reflect.TypeOf(arg)}
+}
+
+func getGlogLevel() int {
+	// XXX: apparently there's no better way to get the log level
+	i := 0
+	for ; i < 100; i++ {
+		if !glog.V(glog.Level(i)) {
+			return i - 1
+		}
+	}
+	return i
+}
+
+func restoreGlogLevel() {
+	logLevelStr := os.Getenv("NSFIX_LOG_LEVEL")
+	if logLevelStr == "" {
+		logLevelStr = "1"
+	}
+	// configure glog (apparently no better way to do it ...)
+	flag.CommandLine.Parse([]string{"-v=" + logLevelStr, "-alsologtostderr=true"})
+}
+
+func marshalResult(ret interface{}, retErr error) ([]byte, error) {
+	var r retStruct
+	if retErr != nil {
+		r.Error = retErr.Error()
+	} else {
+		resultBytes, err := json.Marshal(ret)
+		if err != nil {
+			return nil, fmt.Errorf("error marshalling the result: %v", err)
+		}
+
+		r.Success = true
+		r.Result = json.RawMessage(resultBytes)
+	}
+	retBytes, err := json.Marshal(r)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling retStruct: %v", err)
+	}
+	return retBytes, nil
+}
+
+func unmarshalResult(retBytes []byte, ret interface{}) error {
+	var r retStruct
+	if err := json.Unmarshal(retBytes, &r); err != nil {
+		return fmt.Errorf("error unmarshalling the result: %v", err)
+	}
+	if !r.Success {
+		return errors.New(r.Error)
+	}
+	if err := json.Unmarshal(r.Result, ret); err != nil {
+		return fmt.Errorf("error unmarshalling the result: %v", err)
+	}
+	return nil
+}
+
+// HandleNsFixReexec handles executing the code in another namespace.
+// If reexcution is requested, the function calls os.Exit() after
+// handling it.
+func HandleNsFixReexec() {
+	if os.Getenv("NSFIX_NS_PID") == "" {
+		return
+	}
+
+	restoreGlogLevel()
+	handlerName := os.Getenv("NSFIX_HANDLER")
+	if handlerName == "" {
+		glog.Fatal("NSFIX_HANDLER not set")
+	}
+	entry, found := reexecMap[handlerName]
+	if !found {
+		glog.Fatalf("Bad NSFIX_HANDLER %q", handlerName)
+	}
+
+	arg := reflect.New(entry.argType).Interface()
+	argStr := os.Getenv("NSFIX_ARG")
+	if argStr != "" {
+		if err := json.Unmarshal([]byte(argStr), arg); err != nil {
+			glog.Fatalf("Can't unmarshal NSFIX_ARG (NSFIX_HANDLER %q):\n%s\n", handlerName, argStr)
+		}
+	}
+
+	spawned := os.Getenv("NSFIX_SPAWN") != ""
+	switch ret, err := entry.handler(arg); {
+	case err != nil && !spawned:
+		glog.Fatalf("Error invoking NSFIX_HANDLER %q: %v\nNSFIX_ARG:\n%s\n", handlerName, err, argStr)
+	case err == nil && !spawned:
+		os.Exit(0)
+	default:
+		outBytes, err := marshalResult(ret, err)
+		if err != nil {
+			glog.Fatalf("Error marshalling the result from NSFIX_HANDLER %q: %v", handlerName, err)
+		}
+		os.Stdout.Write(outBytes)
+		os.Exit(0)
+	}
+}
+
+func getEnvForExec(targetPid int, handlerName string, arg interface{}, dropPrivs, spawn bool) ([]string, error) {
+	env := os.Environ()
+	filteredEnv := []string{}
+	for _, envItem := range env {
+		if !strings.HasPrefix(envItem, "NSFIX_") {
+			filteredEnv = append(filteredEnv, envItem)
+		}
+	}
+
+	if arg != nil {
+		argBytes, err := json.Marshal(arg)
+		if err != nil {
+			return nil, fmt.Errorf("error marshalling handler arg: %v", err)
+		}
+		filteredEnv = append(filteredEnv, fmt.Sprintf("NSFIX_ARG=%s", argBytes))
+	}
+
+	if dropPrivs {
+		filteredEnv = append(filteredEnv, "NSFIX_DROP_PRIVS=1")
+	}
+
+	if spawn {
+		filteredEnv = append(filteredEnv, "NSFIX_SPAWN=1")
+	}
+
+	return append(filteredEnv,
+		fmt.Sprintf("NSFIX_NS_PID=%d", targetPid),
+		fmt.Sprintf("NSFIX_HANDLER=%s", handlerName),
+		fmt.Sprintf("NSFIX_LOG_LEVEL=%d", getGlogLevel())), nil
+}
+
+// SwitchToNamespaces executes the specified handler using mount, UTS
+// and IPC namespaces of the specified process. It passes arg to the
+// handler using JSON serialization. The current process gets replaced
+// by the new one. If dropPrivs is true, the new process will execute
+// using non-root uid/gid (using real uid/gid of the process if
+// they're non-zero or 65534 which is nobody/nogroup)
+func SwitchToNamespaces(targetPid int, handlerName string, arg interface{}, dropPrivs bool) error {
+	env, err := getEnvForExec(targetPid, handlerName, arg, dropPrivs, false)
+	if err != nil {
+		return err
+	}
+	return syscall.Exec(os.Args[0], os.Args[:1], env)
+}
+
+// SpawnInNamespaces executes the specified handler using mount, UTS
+// and IPC namespaces of the specified process. It passes arg to the
+// handler using JSON serialization. It then returns the value
+// returned by the handler (also via JSON serialization +
+// deserialization). If dropPrivs is true, the new process will
+// execute using non-root uid/gid (using real uid/gid of the process
+// if they're non-zero or 65534 which is nobody/nogroup)
+func SpawnInNamespaces(targetPid int, handlerName string, arg interface{}, dropPrivs bool, ret interface{}) error {
+	env, err := getEnvForExec(targetPid, handlerName, arg, dropPrivs, true)
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command(os.Args[0])
+	cmd.Env = env
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("reexec caused error: %v", err)
+	}
+
+	return unmarshalResult(out, ret)
+}

--- a/pkg/utils/nsfix.go
+++ b/pkg/utils/nsfix.go
@@ -70,7 +70,7 @@ func restoreGlogLevel() {
 		logLevelStr = "1"
 	}
 	// configure glog (apparently no better way to do it ...)
-	flag.CommandLine.Parse([]string{"-v=" + logLevelStr, "-alsologtostderr=true"})
+	flag.CommandLine.Parse([]string{"-v=" + logLevelStr, "-logtostderr=true"})
 }
 
 func marshalResult(ret interface{}, retErr error) ([]byte, error) {

--- a/pkg/utils/nsfix_linux.go
+++ b/pkg/utils/nsfix_linux.go
@@ -88,6 +88,7 @@ __attribute__((constructor (200))) void nsfix_handle_reexec(void) {
 	nsfix_setns(my_pid, target_pid, CLONE_NEWNS, "mnt");
 	nsfix_setns(my_pid, target_pid, CLONE_NEWUTS, "uts");
 	nsfix_setns(my_pid, target_pid, CLONE_NEWIPC, "ipc");
+	nsfix_setns(my_pid, target_pid, CLONE_NEWNET, "net");
 
 	// remount /sys for the new netns
 	if (umount2("/sys", MNT_DETACH) < 0)

--- a/pkg/utils/nsfix_linux.go
+++ b/pkg/utils/nsfix_linux.go
@@ -1,0 +1,115 @@
+// +build linux
+
+/*
+Copyright 2018 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+// Here we use cgo constructor trick to avoid threading-related problems
+// (not being able to enter the mount namespace)
+// when working with process uids/gids and namespaces
+// https://github.com/golang/go/issues/8676#issuecomment-66098496
+
+/*
+#define _GNU_SOURCE
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <sched.h>
+#include <unistd.h>
+#include <sys/mount.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <linux/limits.h>
+
+static void nsfix_perr(const char* msg) {
+	perror(msg);
+	exit(1);
+}
+
+static void nsfix_setns(int my_pid, int target_pid, int nstype, const char* nsname) {
+	int my_ns_inode, fd;
+        struct stat st;
+	char my_ns_path[PATH_MAX], target_ns_path[PATH_MAX];
+	snprintf(my_ns_path, sizeof(my_ns_path), "/proc/%u/ns/%s", my_pid, nsname);
+	snprintf(target_ns_path, sizeof(target_ns_path), "/proc/%u/ns/%s", target_pid, nsname);
+	if (stat(my_ns_path, &st) < 0) {
+		nsfix_perr("stat() my ns");
+	}
+	my_ns_inode = st.st_ino;
+	if (stat(target_ns_path, &st) < 0) {
+		nsfix_perr("stat() target ns");
+	}
+
+	// Check if that's the same namespace
+	// (actually only critical for CLONE_NEWUSER)
+	if (my_ns_inode == st.st_ino)
+		return;
+
+	if ((fd = open(target_ns_path, O_RDONLY)) < 0) {
+		nsfix_perr("open() target ns");
+	}
+
+	if (setns(fd, nstype) < 0) {
+		nsfix_perr("setns()");
+	}
+}
+
+// This function is a high-priority constructor that will be invoked
+// before any Go code starts.
+__attribute__((constructor (200))) void nsfix_handle_reexec(void) {
+	int my_pid, target_pid, target_uid, target_gid;
+	char* pid_str;
+	if ((pid_str = getenv("NSFIX_NS_PID")) == NULL)
+		return;
+
+	my_pid = getpid();
+        target_pid = atoi(pid_str);
+
+        // Other namespaces:
+        // cgroup, user - not touching
+        // pid - host pid namespace is used by virtlet
+        // net - host network is used by virtlet
+	fprintf(stderr, "nsfix reexec: pid %d: entering the namespaces of target pid %d\n", getpid(), target_pid);
+	nsfix_setns(my_pid, target_pid, CLONE_NEWNS, "mnt");
+	nsfix_setns(my_pid, target_pid, CLONE_NEWUTS, "uts");
+	nsfix_setns(my_pid, target_pid, CLONE_NEWIPC, "ipc");
+
+	// remount /sys for the new netns
+	if (umount2("/sys", MNT_DETACH) < 0)
+		nsfix_perr("umount2()");
+	if (mount("none", "/sys", "sysfs", 0, NULL) < 0)
+		nsfix_perr("mount()");
+
+	// Permanently drop privs if asked to do so
+	if (getenv("NSFIX_DROP_PRIVS") != NULL) {
+		fprintf(stderr, "nsfix reexec: dropping privs\n");
+		target_gid = getgid();
+		if (setgid(target_gid ? target_gid : 65534) < 0)
+			nsfix_perr("setgid()");
+		target_uid = getuid();
+		if (setuid(target_uid ? target_uid : 65534) < 0)
+			nsfix_perr("setuid()");
+	} else {
+		if (setgid(0) < 0)
+			nsfix_perr("setgid()");
+		if (setuid(0) < 0)
+			nsfix_perr("setuid()");
+	}
+}
+*/
+import "C"

--- a/pkg/utils/nsfix_linux.go
+++ b/pkg/utils/nsfix_linux.go
@@ -80,7 +80,7 @@ __attribute__((constructor (200))) void nsfix_handle_reexec(void) {
 	my_pid = getpid();
         target_pid = atoi(pid_str);
 
-        // Other namespaces:
+	// Other namespaces:
         // cgroup, user - not touching
         // pid - host pid namespace is used by virtlet
         // net - host network is used by virtlet
@@ -90,11 +90,13 @@ __attribute__((constructor (200))) void nsfix_handle_reexec(void) {
 	nsfix_setns(my_pid, target_pid, CLONE_NEWIPC, "ipc");
 	nsfix_setns(my_pid, target_pid, CLONE_NEWNET, "net");
 
-	// remount /sys for the new netns
-	if (umount2("/sys", MNT_DETACH) < 0)
-		nsfix_perr("umount2()");
-	if (mount("none", "/sys", "sysfs", 0, NULL) < 0)
-		nsfix_perr("mount()");
+	if (getenv("NSFIX_REMOUNT_SYS") != NULL) {
+		// remount /sys for the new netns
+		if (umount2("/sys", MNT_DETACH) < 0)
+			nsfix_perr("umount2()");
+		if (mount("none", "/sys", "sysfs", 0, NULL) < 0)
+			nsfix_perr("mount()");
+	}
 
 	// Permanently drop privs if asked to do so
 	if (getenv("NSFIX_DROP_PRIVS") != NULL) {

--- a/pkg/utils/nsfix_test.go
+++ b/pkg/utils/nsfix_test.go
@@ -78,7 +78,16 @@ func handleNsFixTest2(data interface{}) (interface{}, error) {
 	return nil, nil
 }
 
-func TestNsFix(t *testing.T) {
+func handleNsFixWithNilArg(data interface{}) (interface{}, error) {
+	return 42, nil
+}
+
+func handleNsFixWithNilResult(data interface{}) (interface{}, error) {
+	targetPath := data.(*string)
+	return nil, os.Mkdir(filepath.Join(*targetPath, "foobar"), 0777)
+}
+
+func verifyNsFix(t *testing.T, toRun func(tmpDir string, dirs map[string]string, pids []int)) {
 	if runtime.GOOS != "linux" {
 		t.Skip("The namespace fix only works on Linux")
 	}
@@ -96,21 +105,29 @@ func TestNsFix(t *testing.T) {
 		t.Fatalf("Chown(): %v", err)
 	}
 
+	// TEST_NSFIX is handled by init() below
+	os.Setenv("TEST_NSFIX", "1")
+	defer os.Setenv("TEST_NSFIX", "")
+
 	dirA := filepath.Join(tmpDir, "a")
-	dirB := filepath.Join(tmpDir, "b")
-	dirC := filepath.Join(dirA, "c")
 	dirD := filepath.Join(tmpDir, "d")
-	dirE := filepath.Join(dirD, "e")
-	for _, p := range []string{dirA, dirB, dirC, dirD, dirE} {
-		if err := os.Mkdir(p, 0777); err != nil {
+	dirs := map[string]string{
+		"a": dirA,
+		"b": filepath.Join(tmpDir, "b"),
+		"c": filepath.Join(dirA, "c"),
+		"d": dirD,
+		"e": filepath.Join(dirD, "e"),
+	}
+	for _, p := range []string{"a", "b", "c", "d", "e"} {
+		if err := os.Mkdir(dirs[p], 0777); err != nil {
 			t.Fatalf("Can't create dir %q: %v", p, err)
 		}
 	}
 
 	var pids []int
 	for _, cmd := range []string{
-		fmt.Sprintf("mount --bind %q %q && sleep 10000", dirA, dirB),
-		fmt.Sprintf("mount --bind %q %q && sleep 10000", dirD, dirB),
+		fmt.Sprintf("mount --bind %q %q && sleep 10000", dirs["a"], dirs["b"]),
+		fmt.Sprintf("mount --bind %q %q && sleep 10000", dirs["d"], dirs["b"]),
 	} {
 		tc := testutils.RunProcess(t, "unshare", []string{
 			"-m", "/bin/bash", "-c", cmd,
@@ -119,57 +136,84 @@ func TestNsFix(t *testing.T) {
 		pids = append(pids, tc.Pid())
 	}
 
-	// TEST_NSFIX is handled by init() below
-	os.Setenv("TEST_NSFIX", "1")
-	defer os.Setenv("TEST_NSFIX", "")
+	toRun(tmpDir, dirs, pids)
+}
 
-	var r nsFixTestRet
-	if err := SpawnInNamespaces(pids[0], "nsfixtest1", nsFixTestArg{dirB}, false, &r); err != nil {
-		t.Fatalf("SpawnInNamespaces(): %v", err)
-	}
-	resultStr := strings.Join(r.Files, "\n")
-	expectedResultStr := "c"
-	if resultStr != expectedResultStr {
-		t.Errorf("Bad result from SpawnInNamespaces(): %q instead of %q", resultStr, expectedResultStr)
-	}
-	if !r.IsRoot {
-		t.Errorf("SpawnInNamespaces dropped privs when not requested to do so")
-	}
-
-	if err := SpawnInNamespaces(pids[1], "nsfixtest1", nsFixTestArg{dirB}, true, &r); err != nil {
-		t.Fatalf("SpawnInNamespaces(): %v", err)
-	}
-	resultStr = strings.Join(r.Files, "\n")
-	expectedResultStr = "e"
-	if resultStr != expectedResultStr {
-		t.Errorf("Bad result from SpawnInNamespaces(): %q instead of %q", resultStr, expectedResultStr)
-	}
-	if r.IsRoot {
-		t.Errorf("SpawnInNamespaces didn't drop privs not requested to do so")
-	}
-
-	// we examine SwitchToNamespace in the same test to make
-	// sure the calls don't interfere between themselves
-	cmd := exec.Command(os.Args[0])
-	cmd.Stderr = os.Stderr
-	cmd.Stdout = os.Stdout
-	cmd.Env = append(os.Environ(), fmt.Sprintf("TEST_NSFIX_SWITCH=%d:%s", pids[1], dirB))
-	if err := cmd.Run(); err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			t.Errorf("Error rerunning the test executable: %v\nstderr:\n%s", err, exitErr.Stderr)
-		} else {
-			t.Errorf("Error rerunning the test executable: %v", err)
+func TestNsFix(t *testing.T) {
+	verifyNsFix(t, func(tmpDir string, dirs map[string]string, pids []int) {
+		var r nsFixTestRet
+		if err := SpawnInNamespaces(pids[0], "nsFixTest1", nsFixTestArg{dirs["b"]}, false, &r); err != nil {
+			t.Fatalf("SpawnInNamespaces(): %v", err)
 		}
-	}
+		resultStr := strings.Join(r.Files, "\n")
+		expectedResultStr := "c"
+		if resultStr != expectedResultStr {
+			t.Errorf("Bad result from SpawnInNamespaces(): %q instead of %q", resultStr, expectedResultStr)
+		}
+		if !r.IsRoot {
+			t.Errorf("SpawnInNamespaces dropped privs when not requested to do so")
+		}
 
-	outPath := filepath.Join(dirD, "out")
-	expectedContents := "e"
-	switch outStr, err := ioutil.ReadFile(outPath); {
-	case err != nil:
-		t.Errorf("Error reading %q: %v", outPath, err)
-	case string(outStr) != expectedContents:
-		t.Errorf("bad out file contents: %q instead of %q", outStr, expectedContents)
-	}
+		if err := SpawnInNamespaces(pids[1], "nsFixTest1", nsFixTestArg{dirs["b"]}, true, &r); err != nil {
+			t.Fatalf("SpawnInNamespaces(): %v", err)
+		}
+		resultStr = strings.Join(r.Files, "\n")
+		expectedResultStr = "e"
+		if resultStr != expectedResultStr {
+			t.Errorf("Bad result from SpawnInNamespaces(): %q instead of %q", resultStr, expectedResultStr)
+		}
+		if r.IsRoot {
+			t.Errorf("SpawnInNamespaces didn't drop privs not requested to do so")
+		}
+
+		// we examine SwitchToNamespace in the same test to make
+		// sure the calls don't interfere between themselves
+		cmd := exec.Command(os.Args[0])
+		cmd.Stderr = os.Stderr
+		cmd.Stdout = os.Stdout
+		cmd.Env = append(os.Environ(), fmt.Sprintf("TEST_NSFIX_SWITCH=%d:%s", pids[1], dirs["b"]))
+		if err := cmd.Run(); err != nil {
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				t.Errorf("Error rerunning the test executable: %v\nstderr:\n%s", err, exitErr.Stderr)
+			} else {
+				t.Errorf("Error rerunning the test executable: %v", err)
+			}
+		}
+
+		outPath := filepath.Join(dirs["d"], "out")
+		expectedContents := "e"
+		switch outStr, err := ioutil.ReadFile(outPath); {
+		case err != nil:
+			t.Errorf("Error reading %q: %v", outPath, err)
+		case string(outStr) != expectedContents:
+			t.Errorf("bad out file contents: %q instead of %q", outStr, expectedContents)
+		}
+	})
+}
+
+func TestNsFixWithNilArg(t *testing.T) {
+	verifyNsFix(t, func(tmpDir string, dirs map[string]string, pids []int) {
+		var r int
+		if err := SpawnInNamespaces(pids[0], "nsFixTestNilArg", nil, false, &r); err != nil {
+			t.Fatalf("SpawnInNamespaces(): %v", err)
+		}
+		expectedResult := 42
+		if r != expectedResult {
+			t.Errorf("Bad result from SpawnInNamespaces(): %d instead of %d", r, expectedResult)
+		}
+	})
+}
+
+func TestNsFixWithNilResult(t *testing.T) {
+	verifyNsFix(t, func(tmpDir string, dirs map[string]string, pids []int) {
+		if err := SpawnInNamespaces(pids[0], "nsFixTestNilResult", dirs["b"], false, nil); err != nil {
+			t.Fatalf("SpawnInNamespaces(): %v", err)
+		}
+		// dirs["a"] is bind-mounted under dirs["b"]
+		if _, err := os.Stat(filepath.Join(dirs["a"], "foobar")); err != nil {
+			t.Errorf("Stat(): %v", err)
+		}
+	})
 }
 
 func init() {
@@ -183,12 +227,14 @@ func init() {
 		if err != nil {
 			glog.Fatalf("bad TEST_NSFIX_SWITCH: %q", switchStr)
 		}
-		if err := SwitchToNamespaces(pid, "nsfixtest2", nsFixTestArg{parts[1]}, false); err != nil {
+		if err := SwitchToNamespaces(pid, "nsFixTest2", nsFixTestArg{parts[1]}, false); err != nil {
 			glog.Fatalf("SwitchToNamespace(): %v", err)
 		}
 	}
-	RegisterNsFixReexec("nsfixtest1", handleNsFixTest1, nsFixTestArg{})
-	RegisterNsFixReexec("nsfixtest2", handleNsFixTest2, nsFixTestArg{})
+	RegisterNsFixReexec("nsFixTest1", handleNsFixTest1, nsFixTestArg{})
+	RegisterNsFixReexec("nsFixTest2", handleNsFixTest2, nsFixTestArg{})
+	RegisterNsFixReexec("nsFixTestNilArg", handleNsFixWithNilArg, nil)
+	RegisterNsFixReexec("nsFixTestNilResult", handleNsFixWithNilResult, "")
 	if os.Getenv("TEST_NSFIX") != "" {
 		// NOTE: this is not a recommended way to invoke
 		// reexec, but may be the easiest one for testing

--- a/pkg/utils/nsfix_test.go
+++ b/pkg/utils/nsfix_test.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2018 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/golang/glog"
+
+	testutils "github.com/Mirantis/virtlet/pkg/utils/testing"
+)
+
+type nsFixTestArg struct {
+	DirPath string
+}
+
+type nsFixTestRet struct {
+	Files  []string
+	IsRoot bool
+}
+
+func listFiles(dirPath string) ([]string, error) {
+	matches, err := filepath.Glob(filepath.Join(dirPath, "*"))
+	if err != nil {
+		return nil, fmt.Errorf("Glob(): %v", err)
+	}
+
+	var r []string
+	for _, m := range matches {
+		r = append(r, filepath.Base(m))
+	}
+	return r, nil
+}
+
+func handleNsFixTest1(data interface{}) (interface{}, error) {
+	arg := data.(*nsFixTestArg)
+	files, err := listFiles(arg.DirPath)
+	if err != nil {
+		return nil, err
+	}
+	return nsFixTestRet{files, os.Getuid() == 0}, nil
+}
+
+func handleNsFixTest2(data interface{}) (interface{}, error) {
+	arg := data.(*nsFixTestArg)
+	files, err := listFiles(arg.DirPath)
+	if err != nil {
+		return nil, err
+	}
+
+	contents := []byte(strings.Join(files, "\n"))
+	if err := ioutil.WriteFile(filepath.Join(arg.DirPath, "out"), contents, 0666); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func TestNsFix(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("The namespace fix only works on Linux")
+	}
+	if os.Getuid() != 0 {
+		t.Skip("This test requires root privs")
+	}
+
+	tmpDir, err := ioutil.TempDir("", "nsfix-")
+	if err != nil {
+		t.Fatalf("Can't create temp dir for config image: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	if err := os.Chmod(tmpDir, 0755); err != nil {
+		t.Fatalf("Chown(): %v", err)
+	}
+
+	dirA := filepath.Join(tmpDir, "a")
+	dirB := filepath.Join(tmpDir, "b")
+	dirC := filepath.Join(dirA, "c")
+	dirD := filepath.Join(tmpDir, "d")
+	dirE := filepath.Join(dirD, "e")
+	for _, p := range []string{dirA, dirB, dirC, dirD, dirE} {
+		if err := os.Mkdir(p, 0777); err != nil {
+			t.Fatalf("Can't create dir %q: %v", p, err)
+		}
+	}
+
+	var pids []int
+	for _, cmd := range []string{
+		fmt.Sprintf("mount --bind %q %q && sleep 10000", dirA, dirB),
+		fmt.Sprintf("mount --bind %q %q && sleep 10000", dirD, dirB),
+	} {
+		tc := testutils.RunProcess(t, "unshare", []string{
+			"-m", "/bin/bash", "-c", cmd,
+		}, nil)
+		defer tc.Stop()
+		pids = append(pids, tc.Pid())
+	}
+
+	// TEST_NSFIX is handled by init() below
+	os.Setenv("TEST_NSFIX", "1")
+	defer os.Setenv("TEST_NSFIX", "")
+
+	var r nsFixTestRet
+	if err := SpawnInNamespaces(pids[0], "nsfixtest1", nsFixTestArg{dirB}, false, &r); err != nil {
+		t.Fatalf("SpawnInNamespaces(): %v", err)
+	}
+	resultStr := strings.Join(r.Files, "\n")
+	expectedResultStr := "c"
+	if resultStr != expectedResultStr {
+		t.Errorf("Bad result from SpawnInNamespaces(): %q instead of %q", resultStr, expectedResultStr)
+	}
+	if !r.IsRoot {
+		t.Errorf("SpawnInNamespaces dropped privs when not requested to do so")
+	}
+
+	if err := SpawnInNamespaces(pids[1], "nsfixtest1", nsFixTestArg{dirB}, true, &r); err != nil {
+		t.Fatalf("SpawnInNamespaces(): %v", err)
+	}
+	resultStr = strings.Join(r.Files, "\n")
+	expectedResultStr = "e"
+	if resultStr != expectedResultStr {
+		t.Errorf("Bad result from SpawnInNamespaces(): %q instead of %q", resultStr, expectedResultStr)
+	}
+	if r.IsRoot {
+		t.Errorf("SpawnInNamespaces didn't drop privs not requested to do so")
+	}
+
+	// we examine SwitchToNamespace in the same test to make
+	// sure the calls don't interfere between themselves
+	cmd := exec.Command(os.Args[0])
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	cmd.Env = append(os.Environ(), fmt.Sprintf("TEST_NSFIX_SWITCH=%d:%s", pids[1], dirB))
+	if err := cmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			t.Errorf("Error rerunning the test executable: %v\nstderr:\n%s", err, exitErr.Stderr)
+		} else {
+			t.Errorf("Error rerunning the test executable: %v", err)
+		}
+	}
+
+	outPath := filepath.Join(dirD, "out")
+	expectedContents := "e"
+	switch outStr, err := ioutil.ReadFile(outPath); {
+	case err != nil:
+		t.Errorf("Error reading %q: %v", outPath, err)
+	case string(outStr) != expectedContents:
+		t.Errorf("bad out file contents: %q instead of %q", outStr, expectedContents)
+	}
+}
+
+func init() {
+	if switchStr := os.Getenv("TEST_NSFIX_SWITCH"); switchStr != "" {
+		os.Setenv("TEST_NSFIX_SWITCH", "")
+		parts := strings.SplitN(switchStr, ":", 2)
+		if len(parts) != 2 {
+			glog.Fatalf("bad TEST_NSFIX_SWITCH: %q", switchStr)
+		}
+		pid, err := strconv.Atoi(parts[0])
+		if err != nil {
+			glog.Fatalf("bad TEST_NSFIX_SWITCH: %q", switchStr)
+		}
+		if err := SwitchToNamespaces(pid, "nsfixtest2", nsFixTestArg{parts[1]}, false); err != nil {
+			glog.Fatalf("SwitchToNamespace(): %v", err)
+		}
+	}
+	RegisterNsFixReexec("nsfixtest1", handleNsFixTest1, nsFixTestArg{})
+	RegisterNsFixReexec("nsfixtest2", handleNsFixTest2, nsFixTestArg{})
+	if os.Getenv("TEST_NSFIX") != "" {
+		// NOTE: this is not a recommended way to invoke
+		// reexec, but may be the easiest one for testing
+		HandleNsFixReexec()
+	}
+}

--- a/pkg/utils/testing/runprocess.go
+++ b/pkg/utils/testing/runprocess.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2018 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"os/exec"
+	"testing"
+)
+
+type TestCommand struct {
+	t       *testing.T
+	Command *exec.Cmd
+}
+
+// RunProcess runs a background process with specified args and
+// appending env to the current environment.
+func RunProcess(t *testing.T, command string, args []string, env []string) *TestCommand {
+	cmd := exec.Command(command, args...)
+	if env != nil {
+		cmd.Env = env
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Error when starting the command %q: %v", command, err)
+	}
+	return &TestCommand{t, cmd}
+}
+
+func (tc *TestCommand) Stop() {
+	if err := tc.Command.Process.Kill(); err != nil {
+		tc.t.Errorf("failed to kill the child process: %v", err)
+	}
+
+	err := tc.Command.Wait()
+	if err == nil {
+		return
+	}
+	if _, ok := err.(*exec.ExitError); ok {
+		return
+	}
+	tc.t.Errorf("Wait() failed: %v", err)
+}
+
+func (tc *TestCommand) Pid() int {
+	return tc.Command.Process.Pid
+}


### PR DESCRIPTION
As of now, a hack is being used with nsenter-based wrapper scripts being generated for every file in `/opt/cni/bin` which may not be compatible with all CNI plugins. The script makes sure the plugin runs in the host network namespace (it's invoked from TapFDSource so it may start in another netns). It also depends on CNI plugins not requiring anything from the host filesystem besides `/etc/cni` and `/opt/cni/bin`, which may fail in some cases.
Let's just handle the namespaces in C/Go code instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/561)
<!-- Reviewable:end -->
