### PR TITLE
Fix TapFDSource netns recovery

### DIFF
--- a/pkg/libvirttools/cloudinit.go
+++ b/pkg/libvirttools/cloudinit.go
@@ -349,7 +349,7 @@ func routesForIP(sourceIP net.IPNet, allRoutes []*cnitypes.Route) []map[string]i
 	return routes
 }
 
-func mtuForMacAddress(mac string, ifaces []network.InterfaceDescription) (uint16, error) {
+func mtuForMacAddress(mac string, ifaces []*network.InterfaceDescription) (uint16, error) {
 	for _, iface := range ifaces {
 		if iface.HardwareAddr.String() == mac {
 			return iface.MTU, nil

--- a/pkg/libvirttools/cloudinit_test.go
+++ b/pkg/libvirttools/cloudinit_test.go
@@ -65,11 +65,11 @@ func newFakeFlexvolume(t *testing.T, parentDir string, uuid string, part int) *f
 }
 
 func buildNetworkedPodConfig(cniResult *cnicurrent.Result, imageType string) *VMConfig {
-	var descs []network.InterfaceDescription
+	var descs []*network.InterfaceDescription
 	for _, iface := range cniResult.Interfaces {
 		if iface.Sandbox != "" {
 			mac, _ := net.ParseMAC(iface.Mac)
-			descs = append(descs, network.InterfaceDescription{
+			descs = append(descs, &network.InterfaceDescription{
 				HardwareAddr: mac,
 				MTU:          1500,
 			})

--- a/pkg/manager/recovernetns.go
+++ b/pkg/manager/recovernetns.go
@@ -40,7 +40,7 @@ func recoverNetworkNamespaces(metadataStore metadata.MetadataStore, fdManager ta
 			continue
 		}
 
-		if _, err := fdManager.AddFDs(
+		if err := fdManager.Recover(
 			s.GetID(),
 			tapmanager.GetFDPayload{
 				ContainerSideNetwork: psi.ContainerSideNetwork,

--- a/pkg/network/csn.go
+++ b/pkg/network/csn.go
@@ -57,5 +57,5 @@ type ContainerSideNetwork struct {
 	NsPath string
 	// Interfaces contains a list of interfaces with data needed
 	// to configure them
-	Interfaces []InterfaceDescription
+	Interfaces []*InterfaceDescription
 }

--- a/pkg/network/csn.go
+++ b/pkg/network/csn.go
@@ -35,7 +35,9 @@ type InterfaceDescription struct {
 	// Type contains interface type designator
 	Type InterfaceType
 	// Fo contains open File object pointing to tap device inside network
-	// namespace or to control file in sysfs for sr-iov VF
+	// namespace or to control file in sysfs for sr-iov VF.
+	// It may be nil if the interface was recovered after restarting Virtlet.
+	// It's only needed during the initial VM startup
 	Fo *os.File
 	// Name containes original interface name for sr-iov interface
 	Name string

--- a/pkg/tapmanager/fdserver.go
+++ b/pkg/tapmanager/fdserver.go
@@ -39,18 +39,28 @@ const (
 	fdAdd               = 0
 	fdRelease           = 1
 	fdGet               = 2
+	fdRecover           = 3
 	fdResponse          = 0x80
 	fdAddResponse       = fdAdd | fdResponse
 	fdReleaseResponse   = fdRelease | fdResponse
 	fdGetResponse       = fdGet | fdResponse
+	fdRecoverResponse   = fdRecover | fdResponse
 	fdError             = 0xff
 )
 
 // FDManager denotes an object that provides 'master'-side
 // functionality of FDClient
 type FDManager interface {
+	// AddFDs adds new file descriptor to the FDManager and returns
+	// the associated data
 	AddFDs(key string, data interface{}) ([]byte, error)
+	// ReleaseFDs makes FDManager close the file descriptor and destroy
+	// any associated resources
 	ReleaseFDs(key string) error
+	// Recover recovers the state regarding the
+	// specified key. It's intended to be called after
+	// Virtlet restart.
+	Recover(key string, data interface{}) error
 }
 
 type fdHeader struct {
@@ -92,6 +102,10 @@ type FDSource interface {
 	// GetInfo returns the information which needs to be
 	// propagated back the FDClient upon GetFDs() call
 	GetInfo(key string) ([]byte, error)
+	// Recover recovers FDSource's state regarding the
+	// specified key. It's intended to be called after
+	// Virtlet restart.
+	Recover(key string, data []byte) error
 	// Stop stops any goroutines associated with FDSource
 	// but doesn't release the namespaces
 	Stop() error
@@ -149,6 +163,16 @@ func (s *FDServer) getFDs(key string) ([]int, error) {
 		return nil, fmt.Errorf("bad fd key: %q", key)
 	}
 	return fds, nil
+}
+
+func (s *FDServer) markAsRecovered(key string) error {
+	s.Lock()
+	defer s.Unlock()
+	if _, found := s.fds[key]; found {
+		return fmt.Errorf("fd key %q is already present and thus can't be properly recovered", key)
+	}
+	s.fds[key] = nil
+	return nil
 }
 
 // Serve makes FDServer listen on its socket in a new goroutine.
@@ -271,6 +295,27 @@ func (s *FDServer) serveGet(c *net.UnixConn, hdr *fdHeader) (*fdHeader, []byte, 
 	}, info, rights, nil
 }
 
+func (s *FDServer) serveRecover(c *net.UnixConn, hdr *fdHeader) (*fdHeader, error) {
+	data := make([]byte, hdr.DataSize)
+	if len(data) > 0 {
+		if _, err := io.ReadFull(c, data); err != nil {
+			return nil, fmt.Errorf("error reading payload: %v", err)
+		}
+	}
+	key := hdr.getKey()
+	if err := s.source.Recover(key, data); err != nil {
+		return nil, fmt.Errorf("error recovering %q: %v", key, err)
+	}
+	if err := s.markAsRecovered(key); err != nil {
+		return nil, err
+	}
+	return &fdHeader{
+		Magic:   fdMagic,
+		Command: fdRecoverResponse,
+		Key:     hdr.Key,
+	}, nil
+}
+
 func (s *FDServer) serveConn(c *net.UnixConn) error {
 	defer c.Close()
 	for {
@@ -295,6 +340,8 @@ func (s *FDServer) serveConn(c *net.UnixConn) error {
 			respHdr, err = s.serveRelease(&hdr)
 		case fdGet:
 			respHdr, data, oobData, err = s.serveGet(c, &hdr)
+		case fdRecover:
+			respHdr, err = s.serveRecover(c, &hdr)
 		default:
 			err = errors.New("bad command")
 		}
@@ -437,7 +484,7 @@ func (c *FDClient) request(hdr *fdHeader, data []byte) (*fdHeader, []byte, []byt
 }
 
 // AddFDs requests the FDServer to add a new file descriptor
-// using its FDSource. It returns the CSN which is returned
+// using its FDSource. It returns the data which are returned
 // by FDSource's GetFDs() call
 func (c *FDClient) AddFDs(key string, data interface{}) ([]byte, error) {
 	bs, ok := data.([]byte)
@@ -462,19 +509,25 @@ func (c *FDClient) AddFDs(key string, data interface{}) ([]byte, error) {
 	return respData, nil
 }
 
-// ReleaseFDs makes FDServer to close the file descriptor and destroy
+// ReleaseFDs makes FDServer close the file descriptor and destroy
 // any associated resources
 func (c *FDClient) ReleaseFDs(key string) error {
-	_, _, _, err := c.request(&fdHeader{
+	respHdr, _, _, err := c.request(&fdHeader{
 		Command: fdRelease,
 		Key:     fdKey(key),
 	}, nil)
-	return err
+	if err != nil {
+		return err
+	}
+	if respHdr.getKey() != key {
+		return fmt.Errorf("fd key mismatch in the server response")
+	}
+	return nil
 }
 
 // GetFDs requests file descriptors from the FDServer. It returns a
 // list of file descriptors which is valid for current process and any
-// associated data that was returned from FDSource's GetInfo() call
+// associated data that was returned from FDSource's GetInfo() call.
 func (c *FDClient) GetFDs(key string) ([]int, []byte, error) {
 	_, respData, oobData, err := c.request(&fdHeader{
 		Command: fdGet,
@@ -497,4 +550,29 @@ func (c *FDClient) GetFDs(key string) ([]int, []byte, error) {
 		return nil, nil, fmt.Errorf("can't decode file descriptors: %v", err)
 	}
 	return fds, respData, nil
+}
+
+// Recover requests FDServer to recover the state regarding the
+// specified key. It's intended to be called after Virtlet restart.
+func (c *FDClient) Recover(key string, data interface{}) error {
+	bs, ok := data.([]byte)
+	if !ok {
+		var err error
+		bs, err = json.Marshal(data)
+		if err != nil {
+			return fmt.Errorf("error marshalling json: %v", err)
+		}
+	}
+	respHdr, _, _, err := c.request(&fdHeader{
+		Command:  fdRecover,
+		DataSize: uint32(len(bs)),
+		Key:      fdKey(key),
+	}, bs)
+	if err != nil {
+		return err
+	}
+	if respHdr.getKey() != key {
+		return fmt.Errorf("fd key mismatch in the server response")
+	}
+	return nil
 }

--- a/pkg/tapmanager/tapfdsource.go
+++ b/pkg/tapmanager/tapfdsource.go
@@ -128,116 +128,51 @@ func (s *TapFDSource) GetFDs(key string, data []byte) ([]int, []byte, error) {
 		return nil, nil, fmt.Errorf("error unmarshalling GetFD payload: %v", err)
 	}
 	pnd := payload.Description
-	csn := payload.ContainerSideNetwork
-
-	recover := csn != nil
-	var netConfig *cnicurrent.Result
-
-	if !recover {
-		if err := cni.CreateNetNS(pnd.PodId); err != nil {
-			return nil, nil, fmt.Errorf("error creating new netns for pod %s (%s): %v", pnd.PodName, pnd.PodId, err)
-		}
-
-		cniResult, err := s.cniClient.AddSandboxToNetwork(pnd.PodId, pnd.PodName, pnd.PodNs)
-		if err != nil {
-			return nil, nil, fmt.Errorf("error adding pod %s (%s) to CNI network: %v", pnd.PodName, pnd.PodId, err)
-		}
-		glog.V(3).Infof("CNI configuration for pod %s (%s): %s", pnd.PodName, pnd.PodId, spew.Sdump(cniResult))
-
-		if payload.Description.DNS != nil {
-			cniResult.DNS.Nameservers = pnd.DNS.Nameservers
-			cniResult.DNS.Search = pnd.DNS.Search
-			cniResult.DNS.Options = pnd.DNS.Options
-		}
-		netConfig = cniResult
-	} else {
-		netConfig = payload.ContainerSideNetwork.Result
+	if err := cni.CreateNetNS(pnd.PodId); err != nil {
+		return nil, nil, fmt.Errorf("error creating new netns for pod %s (%s): %v", pnd.PodName, pnd.PodId, err)
 	}
 
-	netNSPath := cni.PodNetNSPath(pnd.PodId)
-	vmNS, err := ns.GetNS(netNSPath)
+	netConfig, err := s.cniClient.AddSandboxToNetwork(pnd.PodId, pnd.PodName, pnd.PodNs)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to open network namespace at %q: %v", netNSPath, err)
+		return nil, nil, fmt.Errorf("error adding pod %s (%s) to CNI network: %v", pnd.PodName, pnd.PodId, err)
+	}
+	glog.V(3).Infof("CNI configuration for pod %s (%s): %s", pnd.PodName, pnd.PodId, spew.Sdump(netConfig))
+
+	if netConfig == nil {
+		netConfig = &cnicurrent.Result{}
 	}
 
-	var dhcpServer *dhcp.Server
-	doneCh := make(chan error)
-	if err := vmNS.Do(func(ns.NetNS) error {
-		// switch /sys to corresponding one in netns
-		if err := mountSysfs(); err != nil {
-			return err
-		}
-		defer func() {
-			if err := unmountSysfs(); err != nil {
-				glog.V(3).Infof("Warning, error during umount of /sys: %v", err)
-			}
-		}()
+	if payload.Description.DNS != nil {
+		netConfig.DNS.Nameservers = pnd.DNS.Nameservers
+		netConfig.DNS.Search = pnd.DNS.Search
+		netConfig.DNS.Options = pnd.DNS.Options
+	}
 
-		if netConfig == nil {
-			netConfig = &cnicurrent.Result{}
+	var fds []int
+	var respData []byte
+	if err := s.setupNetNS(key, pnd, func(netNSPath string, allLinks []netlink.Link) (*network.ContainerSideNetwork, error) {
+		if netConfig, err = nettools.ValidateAndFixCNIResult(netConfig, netNSPath, allLinks); err != nil {
+			return nil, fmt.Errorf("error fixing cni configuration: %v", err)
 		}
+		if err := nettools.FixCalicoNetworking(netConfig, s.getDummyNetwork); err != nil {
+			// don't fail in this case because there may be even no Calico
+			glog.Warningf("Calico detection/fix didn't work: %v", err)
+		}
+		glog.V(3).Infof("CNI Result after fix:\n%s", spew.Sdump(netConfig))
+		csn, err := nettools.SetupContainerSideNetwork(netConfig, netNSPath, allLinks)
 
-		allLinks, err := netlink.LinkList()
-		if err != nil {
-			return fmt.Errorf("error listing the links: %v", err)
-		}
-
-		if recover {
-			err = nettools.RecreateContainerSideNetwork(csn, netNSPath, allLinks)
-		} else {
-			if netConfig, err = nettools.ValidateAndFixCNIResult(netConfig, netNSPath, allLinks); err != nil {
-				return fmt.Errorf("error fixing cni configuration: %v", err)
-			}
-			if err := nettools.FixCalicoNetworking(netConfig, s.getDummyNetwork); err != nil {
-				// don't fail in this case because there may be even no Calico
-				glog.Warningf("Calico detection/fix didn't work: %v", err)
-			}
-			glog.V(3).Infof("CNI Result after fix:\n%s", spew.Sdump(netConfig))
-			csn, err = nettools.SetupContainerSideNetwork(netConfig, netNSPath, allLinks)
-		}
-		if err != nil {
-			return err
+		if respData, err = json.Marshal(csn); err != nil {
+			return nil, fmt.Errorf("error marshalling net config: %v", err)
 		}
 
-		dhcpServer = dhcp.NewServer(csn)
-		if err := dhcpServer.SetupListener("0.0.0.0"); err != nil {
-			return fmt.Errorf("Failed to set up dhcp listener: %v", err)
+		for _, i := range csn.Interfaces {
+			fds = append(fds, int(i.Fo.Fd()))
 		}
-		go func() {
-			doneCh <- vmNS.Do(func(ns.NetNS) error {
-				err := dhcpServer.Serve()
-				if err != nil {
-					glog.Errorf("dhcp server error: %v", err)
-				}
-				return err
-			})
-		}()
-		// FIXME: there's some very small possibility for a race here
-		// (happens if the VM makes DHCP request before DHCP server is ready)
-		// For now, let's make the probability of such problem even smaller
-		time.Sleep(500 * time.Millisecond)
-		return nil
+		return csn, nil
 	}); err != nil {
 		return nil, nil, err
 	}
 
-	respData, err := json.Marshal(csn)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error marshalling net config: %v", err)
-	}
-
-	s.Lock()
-	defer s.Unlock()
-	s.fdMap[key] = &podNetwork{
-		pnd:        *pnd,
-		csn:        csn,
-		dhcpServer: dhcpServer,
-		doneCh:     doneCh,
-	}
-	var fds []int
-	for _, i := range csn.Interfaces {
-		fds = append(fds, int(i.Fo.Fd()))
-	}
 	return fds, respData, nil
 }
 
@@ -331,6 +266,94 @@ func (s *TapFDSource) Stop() error {
 	s.fdMap = make(map[string]*podNetwork)
 	if errors != nil {
 		return fmt.Errorf("Errors while stopping TapFDSource:\n%s", strings.Join(errors, "\n"))
+	}
+	return nil
+}
+
+// Recover recovers the state for the netns after Virtlet restart
+func (s *TapFDSource) Recover(key string, data []byte) error {
+	var payload GetFDPayload
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return fmt.Errorf("error unmarshalling GetFD payload: %v", err)
+	}
+	pnd := payload.Description
+	csn := payload.ContainerSideNetwork
+	if csn == nil {
+		return fmt.Errorf("ContainerSideNetwork not passed to Recover()")
+	}
+	netConfig := payload.ContainerSideNetwork.Result
+	if netConfig == nil {
+		netConfig = &cnicurrent.Result{}
+	}
+	return s.setupNetNS(key, pnd, func(netNSPath string, allLinks []netlink.Link) (*network.ContainerSideNetwork, error) {
+		if err := nettools.RecoverContainerSideNetwork(csn, netNSPath, allLinks); err != nil {
+			return nil, err
+		}
+		return csn, nil
+	})
+}
+
+func (s *TapFDSource) setupNetNS(key string, pnd *PodNetworkDesc, initNet func(netNSPath string, allLinks []netlink.Link) (*network.ContainerSideNetwork, error)) error {
+	netNSPath := cni.PodNetNSPath(pnd.PodId)
+	vmNS, err := ns.GetNS(netNSPath)
+	if err != nil {
+		return fmt.Errorf("failed to open network namespace at %q: %v", netNSPath, err)
+	}
+
+	var csn *network.ContainerSideNetwork
+	var dhcpServer *dhcp.Server
+	doneCh := make(chan error)
+	if err := vmNS.Do(func(ns.NetNS) error {
+		// switch /sys to corresponding one in netns
+		// to have the correct items under /sys/class/net
+		if err := mountSysfs(); err != nil {
+			return err
+		}
+		defer func() {
+			if err := unmountSysfs(); err != nil {
+				glog.V(3).Infof("Warning, error during umount of /sys: %v", err)
+			}
+		}()
+
+		allLinks, err := netlink.LinkList()
+		if err != nil {
+			return fmt.Errorf("error listing the links: %v", err)
+		}
+
+		if csn, err = initNet(netNSPath, allLinks); err != nil {
+			return err
+		}
+
+		dhcpServer = dhcp.NewServer(csn)
+		if err := dhcpServer.SetupListener("0.0.0.0"); err != nil {
+			return fmt.Errorf("Failed to set up dhcp listener: %v", err)
+		}
+		go func() {
+			doneCh <- vmNS.Do(func(ns.NetNS) error {
+				err := dhcpServer.Serve()
+				if err != nil {
+					glog.Errorf("dhcp server error: %v", err)
+				}
+				return err
+			})
+		}()
+
+		// FIXME: there's some very small possibility for a race here
+		// (happens if the VM makes DHCP request before DHCP server is ready)
+		// For now, let's make the probability of such problem even smaller
+		time.Sleep(500 * time.Millisecond)
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	s.Lock()
+	defer s.Unlock()
+	s.fdMap[key] = &podNetwork{
+		pnd:        *pnd,
+		csn:        csn,
+		dhcpServer: dhcpServer,
+		doneCh:     doneCh,
 	}
 	return nil
 }

--- a/tests/integration/manager.go
+++ b/tests/integration/manager.go
@@ -51,6 +51,10 @@ func (m *fakeFDManager) ReleaseFDs(key string) error {
 	return nil
 }
 
+func (m *fakeFDManager) Recover(key string, data interface{}) error {
+	return nil
+}
+
 type fakeImageFileSystem struct {
 	t     *testing.T
 	inner http.FileSystem

--- a/tests/network/dhcp_test.go
+++ b/tests/network/dhcp_test.go
@@ -78,7 +78,7 @@ func TestDhcpServer(t *testing.T) {
 						},
 					},
 				},
-				Interfaces: []network.InterfaceDescription{
+				Interfaces: []*network.InterfaceDescription{
 					{
 						HardwareAddr: clientMac,
 						MTU:          9000,


### PR DESCRIPTION
Don't try to "fix" the CNI result during the recovery.
Don't lose hwaddrs of VM network interfaces during the recovery.
Make VM network tests examine netns recovery.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/563)
<!-- Reviewable:end -->
