### PR TITLE
tapmanager panic when ReadConfiguration fail

### DIFF
--- a/pkg/cni/client.go
+++ b/pkg/cni/client.go
@@ -47,10 +47,10 @@ var _ CNIClient = &Client{}
 
 func NewClient(pluginsDir, configsDir string) (*Client, error) {
 	netConfigList, err := ReadConfiguration(configsDir)
-	glog.V(3).Infof("CNI config: name: %q type: %q", netConfigList.Plugins[0].Network.Name, netConfigList.Plugins[0].Network.Type)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read CNI configuration: %v", err)
+		return nil, fmt.Errorf("failed to read CNI configuration %q: %v", configsDir, err)
 	}
+	glog.V(3).Infof("CNI config: name: %q type: %q", netConfigList.Plugins[0].Network.Name, netConfigList.Plugins[0].Network.Type)
 
 	return &Client{
 		cniConfig:     &libcni.CNIConfig{Path: []string{pluginsDir}},


### PR DESCRIPTION
Signed-off-by: yanxuean <yan.xuean@zte.com.cn>

```
$ kubectl logs  virtlet-rhj5f -c virtlet -n kube-system
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x1250235]

goroutine 1 [running]:
github.com/Mirantis/virtlet/pkg/cni.NewClient(0x208216d, 0xc, 0x2084b0a, 0xe, 0xc420645ee0, 0xc420645f10, 0x4a053c)
        /go/src/github.com/Mirantis/virtlet/pkg/cni/client.go:50 +0xb5
main.runTapManager()
        /go/src/github.com/Mirantis/virtlet/cmd/virtlet/virtlet.go:118 +0x63
main.main()
        /go/src/github.com/Mirantis/virtlet/cmd/virtlet/virtlet.go:164 +0x93

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/565)
<!-- Reviewable:end -->
