### PR TITLE
Update own cirros image

### DIFF
--- a/contrib/cirros-patches/cirros-repo.diff
+++ b/contrib/cirros-patches/cirros-repo.diff
@@ -1,5 +1,5 @@
 diff --git a/bin/bundle b/bin/bundle
-index 7d801d6..c89fbb3 100755
+index 3df0be9..3a6ed56 100755
 --- a/bin/bundle
 +++ b/bin/bundle
 @@ -21,7 +21,7 @@ source "${0%/*}/common-functions.sh"
@@ -12,7 +12,7 @@ index 7d801d6..c89fbb3 100755
  
  Usage() {
 diff --git a/conf/buildroot-i386.config b/conf/buildroot-i386.config
-index d787ca6..c4f693f 100644
+index d787ca6..8320355 100644
 --- a/conf/buildroot-i386.config
 +++ b/conf/buildroot-i386.config
 @@ -1,19 +1,29 @@
@@ -1035,7 +1035,7 @@ index d787ca6..c4f693f 100644
 +# BR2_PACKAGE_PYTHON_CHEETAH is not set
 +# BR2_PACKAGE_PYTHON_CHERRYPY is not set
 +# BR2_PACKAGE_PYTHON_CLICK is not set
-+BR2_PACKAGE_PYTHON_CLOUD_INIT=y
++# BR2_PACKAGE_PYTHON_CLOUD_INIT is not set
 +# BR2_PACKAGE_PYTHON_COHERENCE is not set
 +BR2_PACKAGE_PYTHON_CONFIGOBJ=y
 +# BR2_PACKAGE_PYTHON_CONFIGSHELL_FB is not set
@@ -2207,7 +2207,7 @@ index d787ca6..c4f693f 100644
  # BR2_PACKAGE_BIND is not set
  # BR2_PACKAGE_BLUEZ_UTILS is not set
  # BR2_PACKAGE_BLUEZ5_UTILS is not set
-@@ -1649,16 +1867,22 @@ BR2_PACKAGE_QEMU_ARCH_SUPPORTS_TARGET=y
+@@ -1649,17 +1867,23 @@ BR2_PACKAGE_QEMU_ARCH_SUPPORTS_TARGET=y
  # BR2_PACKAGE_BOA is not set
  # BR2_PACKAGE_BRIDGE_UTILS is not set
  # BR2_PACKAGE_BWM_NG is not set
@@ -2224,15 +2224,17 @@ index d787ca6..c4f693f 100644
 -# ctorrent needs a toolchain w/ C++
 +# connman-gtk needs libgtk3 and a glibc or uClibc toolchain w/ wchar, threads, resolver, dynamic library
  #
+-# BR2_PACKAGE_DHCPCD is not set
 +# BR2_PACKAGE_CONNTRACK_TOOLS is not set
 +# BR2_PACKAGE_CRDA is not set
 +# BR2_PACKAGE_CTORRENT is not set
 +# BR2_PACKAGE_CUPS is not set
 +# BR2_PACKAGE_DANTE is not set
 +# BR2_PACKAGE_DARKHTTPD is not set
- # BR2_PACKAGE_DHCPCD is not set
++BR2_PACKAGE_DHCPCD=y
  # BR2_PACKAGE_DHCPDUMP is not set
  # BR2_PACKAGE_DNSMASQ is not set
+ # BR2_PACKAGE_DRBD_UTILS is not set
 @@ -1672,20 +1896,28 @@ BR2_PACKAGE_DROPBEAR_SMALL=y
  # BR2_PACKAGE_EBTABLES is not set
  
@@ -2933,13 +2935,41 @@ index d787ca6..c4f693f 100644
  # BR2_PACKAGE_RPM_BZIP2_PAYLOADS is not set
  # BR2_PACKAGE_RPM_XZ_PAYLOADS is not set
  # BR2_PACKAGE_M4 is not set
+diff --git a/patches-buildroot/ifupdown-cirros.patch b/patches-buildroot/ifupdown-cirros.patch
+deleted file mode 100644
+index f778b2d..0000000
+--- a/patches-buildroot/ifupdown-cirros.patch
++++ /dev/null
+@@ -1,21 +0,0 @@
+---- a/package/busybox/busybox-01-ifupdown-cirros.patch	1970-01-01 01:00:00.000000000 +0100
+-+++ b/package/busybox/busybox-01-ifupdown-cirros.patch	2014-07-30 11:49:02.213528074 +0200
+-@@ -0,0 +1,17 @@
+-+Busybox tries several dhcpclients in a specific order, if one is found as
+-+executable it gets the honor of asking for an address. By adding cirros as the
+-+first option we make sure the /sbin/ifupdown script is used.
+-+This depends heavily on CONFIG_FEATURE_IFUPDOWN_EXTERNAL_DHCP=y.
+-+
+-+--- a/networking/ifupdown.c	2014-07-30 11:38:03.708210386 +0200
+-++++ b/networking/ifupdown.c	2014-07-30 11:38:24.106941433 +0200
+-+@@ -521,6 +521,10 @@
+-+ };
+-+ 
+-+ static const struct dhcp_client_t ext_dhcp_clients[] = {
+-++	{ "cirros-dhcpc",
+-++		"cirros-dhcpc up %iface%",
+-++		"cirros-dhcpc down %iface%",
+-++	},
+-+ 	{ "dhcpcd",
+-+ 		"dhcpcd[[ -h %hostname%]][[ -i %vendor%]][[ -I %client%]][[ -l %leasetime%]] %iface%",
+-+ 		"dhcpcd -k %iface%",
 diff --git a/patches-buildroot/series b/patches-buildroot/series
-index 8c03021..8edb287 100644
+index 5a32927..d0a6f69 100644
 --- a/patches-buildroot/series
 +++ b/patches-buildroot/series
-@@ -1,2 +1 @@
- ifupdown-cirros.patch
+@@ -1,3 +1 @@
+-ifupdown-cirros.patch
 -util-linux-2.27.patch
+ ncurses-gcc-5.x.patch
 diff --git a/patches-buildroot/util-linux-2.27.patch b/patches-buildroot/util-linux-2.27.patch
 deleted file mode 100644
 index 4ca8e3e..0000000
@@ -2998,10 +3028,10 @@ index 4ca8e3e..0000000
 - 
 diff --git a/src/etc/cloud/cloud.cfg b/src/etc/cloud/cloud.cfg
 new file mode 100644
-index 0000000..dbe561d
+index 0000000..e3bb3ab
 --- /dev/null
 +++ b/src/etc/cloud/cloud.cfg
-@@ -0,0 +1,74 @@
+@@ -0,0 +1,78 @@
 +## template:jinja
 +# The top level settings are used as module
 +# and system configuration.
@@ -3017,7 +3047,7 @@ index 0000000..dbe561d
 +# This will cause the set+update hostname module to not operate (if true)
 +preserve_hostname: false
 +
-+datasource_list: ['NoCloud']
++datasource_list: ['NoCloud', 'ConfigDrive']
 +# Example datasource config
 +# datasource:
 +#    Ec2:
@@ -3025,12 +3055,16 @@ index 0000000..dbe561d
 +#      timeout: 5 # (defaults to 50 seconds)
 +#      max_wait: 10 # (defaults to 120 seconds)
 +
++mount_default_fields: [ None, None, "auto", "defaults,nofail", "0", "2" ]
++
 +# The modules that run in the 'init' stage
 +cloud_init_modules:
 + - migrator
 + - seed_random
 + - bootcmd
 + - write-files
++ - disk-setup
++ - mounts
 + - set_hostname
 + - update_hostname
 + - update_etc_hosts
@@ -3187,6 +3221,18 @@ index 1c7c90d..e9360d6 100755
  						/sbin/resize-filesystem \
  						/dev/root /run/resize.rootfs /dev/console
  				;;
+diff --git a/src/etc/modules b/src/etc/modules
+index d89f513..a917502 100644
+--- a/src/etc/modules
++++ b/src/etc/modules
+@@ -3,6 +3,7 @@ e1000
+ ne2k-pci           # arch=x86
+ 8139cp             # arch=x86
+ pcnet32            # arch=x86
++ixgbevf            # arch=x86
+ 
+ ## VirtIO
+ 9pnet_virtio
 diff --git a/src/etc/rc3.d/S35-cirros-ds-local b/src/etc/rc3.d/S35-cirros-ds-local
 deleted file mode 120000
 index da67b00..0000000

--- a/deploy/images.yaml
+++ b/deploy/images.yaml
@@ -1,5 +1,5 @@
 translations:
   - name: cirros
-    url: https://github.com/mirantis/virtlet/releases/download/v0.8.2/cirros.img
+    url: https://github.com/mirantis/virtlet/releases/download/v0.9.3/cirros.img
   - name: fedora
     url: https://download.fedoraproject.org/pub/fedora/linux/releases/27/CloudImages/x86_64/images/Fedora-Cloud-Base-27-1.6.x86_64.qcow2

--- a/docs/devel/building-cirros-with-cloud-init.md
+++ b/docs/devel/building-cirros-with-cloud-init.md
@@ -72,7 +72,7 @@ You need to set a correct version of kernel (the versions are listed
 [here](https://launchpad.net/ubuntu/+source/linux)) e.g.:
 
 ```sh
-kver="3.19.0-84.92"
+kver="4.13.0-32.35"
 ./bin/grab-kernels "$kver"
 ```
 


### PR DESCRIPTION
* use newer cirros release (0.4.0)
* use newer kernel (4.13.0-32.35)
* add driver for sriov in guest mode
* add support for ConfigDrive (as additional to NoCloud)
* replace udhcpc with dhcpcd (https://roy.marples.name/projects/dhcpcd)
* update image translations to use url for new image

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/567)
<!-- Reviewable:end -->
