### PR TITLE
remove the duplicate validatePodSandboxConfig

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -171,11 +171,6 @@ func (v *VirtletManager) RunPodSandbox(ctx context.Context, in *kubeapi.RunPodSa
 	glog.V(3).Infof("RunPodSandbox: %s", spew.Sdump(in))
 	glog.V(2).Infof("Sandbox config annotations: %v", config.GetAnnotations())
 
-	if err := validatePodSandboxConfig(config); err != nil {
-		glog.Errorf("Invalid pod config while creating pod sandbox for pod %s (%s): %v", podName, podId, err)
-		return nil, err
-	}
-
 	state := kubeapi.PodSandboxState_SANDBOX_READY
 	pnd := &tapmanager.PodNetworkDesc{
 		PodId:   podId,


### PR DESCRIPTION
Signed-off-by: yanxuean <yan.xuean@zte.com.cn>

the duplicate  	validatePodSandboxConfig check.

https://github.com/Mirantis/virtlet/blob/bff613a8c6b817a0ccc5eed50d957af493650e3f/pkg/manager/manager.go#L163
https://github.com/Mirantis/virtlet/blob/bff613a8c6b817a0ccc5eed50d957af493650e3f/pkg/manager/manager.go#L174

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/570)
<!-- Reviewable:end -->
