### PR TITLE
Use mount propagation

### DIFF
--- a/build/cmd.sh
+++ b/build/cmd.sh
@@ -257,6 +257,12 @@ function start_dind {
         echo >&2 "Installing CRI proxy package the node container..."
         docker exec "${virtlet_node}" /bin/bash -c "curl -sSL '${CRIPROXY_DEB_URL}' >/criproxy.deb && dpkg -i /criproxy.deb && rm /criproxy.deb"
     fi
+
+    docker exec "${virtlet_node}" mount --make-shared /dind
+    docker exec "${virtlet_node}" mount --make-shared /dev
+    docker exec "${virtlet_node}" mount --make-shared /boot
+    docker exec "${virtlet_node}" mount --make-shared /sys/fs/cgroup
+
     if [[ ${VIRTLET_ON_MASTER} ]]; then
         if [[ $(kubectl get node kube-master -o jsonpath='{.spec.taints[?(@.key=="node-role.kubernetes.io/master")]}') ]]; then
             kubectl taint nodes kube-master node-role.kubernetes.io/master-

--- a/deploy/demo.sh
+++ b/deploy/demo.sh
@@ -123,6 +123,14 @@ function demo::install-cri-proxy {
   docker exec "${virtlet_node}" /bin/bash -c "curl -sSL '${CRIPROXY_DEB_URL}' >/criproxy.deb && dpkg -i /criproxy.deb && rm /criproxy.deb"
 }
 
+function demo::fix-mounts {
+  demo::step "Marking mounts used by virtlet as shared in ${virtlet_node} container"
+  docker exec "${virtlet_node}" mount --make-shared /dind
+  docker exec "${virtlet_node}" mount --make-shared /dev
+  docker exec "${virtlet_node}" mount --make-shared /boot
+  docker exec "${virtlet_node}" mount --make-shared /sys/fs/cgroup
+}
+
 function demo::inject-local-image {
   demo::step "Copying local mirantis/virtlet image into ${virtlet_node} container"
   docker save mirantis/virtlet | docker exec -i "${virtlet_node}" docker load
@@ -358,6 +366,7 @@ fi
 
 demo::get-dind-cluster
 demo::start-dind-cluster
+demo::fix-mounts
 demo::install-cri-proxy
 if [[ ${INJECT_LOCAL_IMAGE:-} ]]; then
   demo::inject-local-image

--- a/deploy/virtlet-ds.yaml
+++ b/deploy/virtlet-ds.yaml
@@ -43,6 +43,7 @@ spec:
         - name: k8s-flexvolume-plugins-dir
           mountPath: /kubelet-volume-plugins
         - name: run
+          mountPropagation: Bidirectional
           mountPath: /run
         - name: dockersock
           mountPath: /var/run/docker.sock
@@ -72,6 +73,7 @@ spec:
           readOnly: true
         - mountPath: /run
           name: run
+          mountPropagation: Bidirectional
         - mountPath: /var/lib/virtlet
           name: virtlet
         - mountPath: /var/lib/libvirt
@@ -101,6 +103,7 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: run
+          mountPropagation: Bidirectional
         # /boot and /lib/modules are required by supermin
         - mountPath: /lib/modules
           name: modules
@@ -116,16 +119,9 @@ spec:
           name: libvirt-sockets
         - mountPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
           name: k8s-flexvolume-plugins-dir
-          # `:shared` below is an unofficial way to pass 'shared' option to Docker
-          # which will make it possible for Virtlet to see mounts made by kubelet in
-          # the underlying directories after Virtlet container is created
-        - mountPath: /var/lib/kubelet/pods:shared
+        - mountPath: /var/lib/kubelet/pods
           name: k8s-pods-dir
-          # /var/run/netns must be a shared mount so both Virtlet
-          # and CNI plugins (which run in the host netns) can work
-          # with network namespaces mounted there
-        - mountPath: /var/run/netns:shared
-          name: netns-dir
+          mountPropagation: Bidirectional
         - name: vms-log
           mountPath: /var/log/vms
         - mountPath: /etc/virtlet/images


### PR DESCRIPTION
Starting from now Virtlet will require MountPropagation feature gate enabled in Kubernetes cluster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/573)
<!-- Reviewable:end -->
