### PR TITLE
Add MountPropagation feature gate to requirements

### DIFF
--- a/deploy/real-cluster.md
+++ b/deploy/real-cluster.md
@@ -5,6 +5,7 @@ on the nodes which will run them:
 
 1. Node names must be resolvable via DNS configured on the nodes
 1. AppArmor and SELinux must be disabled on the nodes
+1. Kubernetes 1.8 and 1.9 must have the MountPropagation=true feature gate enabled in API server and on all kubelet instances
 
 Virtlet deployment consists of preparing the nodes and then deploying
 the Virtlet DaemonSet.


### PR DESCRIPTION
Virtlets creates network namespaces for VM pods. When virtlet runs
as a pod it needs to be able to modify Host namespaces.
Enabling MountPropagation in kubernests and setting MountPropagation:
Bidirectional option for volumeMounts allows to do it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/578)
<!-- Reviewable:end -->
