### PR TITLE
Fix uclibc in own Cirros

### DIFF
--- a/contrib/cirros-patches/buildroot.diff
+++ b/contrib/cirros-patches/buildroot.diff
@@ -284,3 +284,22 @@ index 0000000..0c26a0c
 +PYTHON_PRETTYTABLE_SETUP_TYPE = setuptools
 +
 +$(eval $(python-package))
+diff --git a/package/uclibc/0004-fix-posix-spawn.patch b/package/uclibc/0004-fix-posix-spawn.patch
+new file mode 100644
+index 0000000..3d4558b
+--- /dev/null
++++ b/package/uclibc/0004-fix-posix-spawn.patch
+@@ -0,0 +1,13 @@
++diff --git a/librt/spawn.c b/librt/spawn.c
++index 25e3994..808c398 100644
++--- a/librt/spawn.c
+++++ b/librt/spawn.c
++@@ -155,7 +155,7 @@ __spawni(pid_t *pid, const char *file,
++ 		memset(&sa, 0, sizeof(sa));
++ 		sa.sa_handler = SIG_DFL;
++ 
++-		for (sig = 1; sig <= _NSIG; ++sig) {
+++		for (sig = 1; sig < _NSIG; ++sig) {
++ 			if (sigismember(&attrp->__sd, sig)) {
++ 				if (sigaction(sig, &sa, NULL) != 0)
++ 					goto error;


### PR DESCRIPTION
uClibc-ng in used 1.0.22 version has a bug in `posix_spawn` which
in effect blocks a possibility to run hooks scripts by dhcpcd.
This change corrects the behavior of `posix_spawn` resulting in
correct using hooks scripts by dhcpcd what in result leads to correct
construction of `/etc/resolv.conf` in the final step.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/579)
<!-- Reviewable:end -->
