### PR TITLE
Fix Virtlet startup race

### DIFF
--- a/deploy/virtlet-ds.yaml
+++ b/deploy/virtlet-ds.yaml
@@ -52,6 +52,8 @@ spec:
         # for ensuring that /var/lib/libvirt/images exists on node
         - name: var-lib
           mountPath: /host-var-lib
+        - name: dev
+          mountPath: /dev
         securityContext:
           privileged: true
 

--- a/images/image_skel/libvirt.sh
+++ b/images/image_skel/libvirt.sh
@@ -13,22 +13,6 @@ if [[ -f /dind/vmwrapper ]]; then
   ln -fs /dind/vmwrapper /vmwrapper
 fi
 
-if [[ ! ${VIRTLET_DISABLE_KVM:-} ]]; then
-  if ! kvm-ok >&/dev/null; then
-    # try to fix the environment by loading appropriate modules
-    modprobe kvm || ((echo "Missing kvm module on the host" >&2 && exit 1))
-    if grep vmx /proc/cpuinfo &>/dev/null; then
-      modprobe kvm_intel || (echo "Missing kvm_intel module on the host" >&2 && exit 1)
-    elif grep svm /proc/cpuinfo &>/dev/null; then
-      modprobe kvm_amd || (echo "Missing kvm_amd module on the host" >&2 && exit 1)
-    fi
-  fi
-  if ! kvm-ok; then
-    echo "*** VIRTLET_DISABLE_KVM is not set but KVM extensions are not available ***" >&2
-    echo "*** Virtlet startup failed ***" >&2
-    exit 1
-  fi
-fi
 
 chown root:root /etc/libvirt/libvirtd.conf
 chown root:root /etc/libvirt/qemu.conf
@@ -50,10 +34,6 @@ if [[ ${novirtlet} ]]; then
   # leftover socket prevents libvirt from initializing correctly
   rm -f /var/lib/libvirt/qemu/capabilities.monitor.sock
   daemon="--daemon"
-fi
-
-if [[ ! ${VIRTLET_DISABLE_KVM:-} ]]; then
-  chown root:kvm /dev/kvm
 fi
 
 # export LIBVIRT_LOG_FILTERS="1:qemu.qemu_process 1:qemu.qemu_command 1:qemu.qemu_domain"

--- a/images/image_skel/start.sh
+++ b/images/image_skel/start.sh
@@ -17,12 +17,6 @@ fi
 PROTOCOL="${VIRTLET_DOWNLOAD_PROTOCOL:-https}"
 IMAGE_TRANSLATIONS_DIR="${IMAGE_TRANSLATIONS_DIR:-}"
 
-FLEXVOLUME_DIR=/usr/libexec/kubernetes/kubelet-plugins/volume/exec
-if [ ! -d ${FLEXVOLUME_DIR}/virtlet~flexvolume_driver ]; then
-    mkdir ${FLEXVOLUME_DIR}/virtlet~flexvolume_driver
-    cp /flexvolume_driver ${FLEXVOLUME_DIR}/virtlet~flexvolume_driver/flexvolume_driver
-fi
-
 while [ ! -S /var/run/libvirt/libvirt-sock ] ; do
   echo >&1 "Waiting for libvirt..."
   sleep 0.3

--- a/images/image_skel/vms.sh
+++ b/images/image_skel/vms.sh
@@ -4,12 +4,5 @@ set -o nounset
 set -o pipefail
 set -o errtrace
 
-if lsmod | grep '\<kvm\>' > /dev/null &&
-   ! ([[ -e /dev/kvm ]] || mknod /dev/kvm c 10 $(grep '\<kvm\>' /proc/misc | cut -d" " -f1)); then
-  echo >&2 "warning: can't create /dev/kvm"
-elif [[ -e /dev/kvm ]]; then
-  chown libvirt-qemu.kvm /dev/kvm
-fi
-
 echo "$$ $(cut -d' ' -f22 /proc/$$/stat)" >/var/lib/virtlet/vms.procfile
 sleep Infinity


### PR DESCRIPTION
Set up /dev/kvm and its permissions in prepare-node.sh
Don't do flexvolume driver setup in the libvirt startup script

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/580)
<!-- Reviewable:end -->
