### PR TITLE
Fix calico netmask calculation

### DIFF
--- a/pkg/nettools/nettools.go
+++ b/pkg/nettools/nettools.go
@@ -1112,7 +1112,8 @@ func netmaskForCalico() net.IPMask {
 	n := calicoDefaultSubnet
 	subnetStr := os.Getenv(calicoSubnetVar)
 	if subnetStr != "" {
-		n, err := strconv.Atoi(subnetStr)
+		var err error
+		n, err = strconv.Atoi(subnetStr)
 		if err != nil || n <= 0 || n > 30 {
 			glog.Warningf("bad calico subnet %q, using /%d", subnetStr, calicoDefaultSubnet)
 			n = calicoDefaultSubnet


### PR DESCRIPTION
Found by `ineffassign` in https://goreportcard.com/report/github.com/Mirantis/virtlet

WIP, because for sure it desires a coverage by separate test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/590)
<!-- Reviewable:end -->
