### PR TITLE
Don't break ~/.gitconfig in a Golden Master test

### DIFF
--- a/tests/gm/git_test.go
+++ b/tests/gm/git_test.go
@@ -40,6 +40,10 @@ func TestGitDiff(t *testing.T) {
 		t.Fatalf("TempDir(): %v", err)
 	}
 	defer os.RemoveAll(tmpDir)
+	oldHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", oldHome)
+
 	origWd, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("os.Getwd(): %v", err)


### PR DESCRIPTION
This was happening when the test was being run outside the build
container.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/612)
<!-- Reviewable:end -->
