### PR TITLE
Mount /lib/modules in vms container too

### DIFF
--- a/deploy/virtlet-ds.yaml
+++ b/deploy/virtlet-ds.yaml
@@ -200,6 +200,8 @@ spec:
           mountPath: /var/log/vms
         - name: dev
           mountPath: /dev
+        - name: modules
+          mountPath: /lib/modules
       volumes:
       # /dev is needed for host raw device access
       - hostPath:


### PR DESCRIPTION
I checked that on Arch based system. For some reason it works on Fedora and Ubuntu without that mount.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/625)
<!-- Reviewable:end -->
