### PR TITLE
Fix cni teardown

### DIFF
--- a/pkg/cni/client.go
+++ b/pkg/cni/client.go
@@ -92,7 +92,7 @@ func (c *client) AddSandboxToNetwork(podID, podName, podNs string) (*cnicurrent.
 
 // RemoveSandboxFromNetwork implements RemoveSandboxFromNetwork method of Client interface.
 func (c *client) RemoveSandboxFromNetwork(podID, podName, podNs string) error {
-	return utils.NewNsFixCall("cniRemoveSandboxToNetwork").
+	return utils.NewNsFixCall("cniRemoveSandboxFromNetwork").
 		Arg(cniRequest{
 			PluginsDir: c.pluginsDir,
 			ConfigsDir: c.configsDir,


### PR DESCRIPTION
There was a typo that was causing CNI resource leak.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/630)
<!-- Reviewable:end -->
