### PR TITLE
Fix compatibility with Docker 18

### DIFF
--- a/build/cmd.sh
+++ b/build/cmd.sh
@@ -150,7 +150,7 @@ function ensure_build_container {
            docker_cert_args=(-e DOCKER_CERT_PATH=/docker-cert)
         fi
         docker run -d --privileged --net=host \
-               -l virtlet_build \
+               -l virtlet_build=1 \
                -v "virtlet_src:${remote_project_dir}" \
                -v "virtlet_pkg:/go/pkg" \
                -v /sys/fs/cgroup:/sys/fs/cgroup \


### PR DESCRIPTION
`docker run -l foo` no longer works, need `-l foo=...`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/635)
<!-- Reviewable:end -->
