### PR TITLE
 improve the error message for ScanFlexVolumes

### DIFF
--- a/pkg/flexvolume/flexvolume.go
+++ b/pkg/flexvolume/flexvolume.go
@@ -106,7 +106,7 @@ func (d *FlexVolumeDriver) isAttached(jsonOptions, nodeName string) (map[string]
 	return map[string]interface{}{"attached": true}, nil
 }
 
-//Invocation: <driver executable> mount <target mount dir> <mount device> <json options>
+//Invocation: <driver executable> mount <target mount dir> <json options>
 func (d *FlexVolumeDriver) mount(targetMountDir, jsonOptions string) (map[string]interface{}, error) {
 	var opts map[string]interface{}
 	if err := json.Unmarshal([]byte(jsonOptions), &opts); err != nil {

--- a/pkg/libvirttools/flexvolume_volumesource.go
+++ b/pkg/libvirttools/flexvolume_volumesource.go
@@ -69,7 +69,7 @@ func ScanFlexVolumes(config *VMConfig, owner volumeOwner) ([]VMVolume, error) {
 		}
 		var msi map[string]interface{}
 		if err = json.Unmarshal(content, &msi); err != nil {
-			return nil, fmt.Errorf("error reading flexvolume config %q: %v", dataFilePath, err)
+			return nil, fmt.Errorf("error unmarshal flexvolume config %q: %v", dataFilePath, err)
 		}
 		fvType, _ := msi["type"].(string)
 		if fvType == "" {


### PR DESCRIPTION
The error message of ReadFile is same with error message of Unmarshal.
```
func ScanFlexVolumes(config *VMConfig, owner volumeOwner) ([]VMVolume, error) {
 
	for _, fi := range volDirItems {
		if !fi.IsDir() {
			continue
		}
		dataFilePath := filepath.Join(dir, fi.Name(), flexvolumeDataFile)
		content, err := ioutil.ReadFile(dataFilePath)
		if err != nil {
			return nil, fmt.Errorf("error reading flexvolume config %q: %v", dataFilePath, err)
		}
		var msi map[string]interface{}
		if err = json.Unmarshal(content, &msi); err != nil {
			return nil, fmt.Errorf("error reading flexvolume config %q: %v", dataFilePath, err)
		}

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/640)
<!-- Reviewable:end -->
