### PR TITLE
Pass server url to virtletctl in e2e tests

### DIFF
--- a/tests/e2e/framework/controller.go
+++ b/tests/e2e/framework/controller.go
@@ -34,7 +34,7 @@ import (
 	"github.com/Mirantis/virtlet/pkg/imagetranslation"
 )
 
-var url = flag.String("cluster-url", "http://127.0.0.1:8080", "apiserver URL")
+var ClusterURL = flag.String("cluster-url", "http://127.0.0.1:8080", "apiserver URL")
 
 // Controller is the entry point for various operations on k8s+virtlet entities
 type Controller struct {
@@ -48,7 +48,7 @@ type Controller struct {
 // NewController creates instance of controller for specified k8s namespace.
 // If namespace is empty string then namespace with random name is going to be created
 func NewController(namespace string) (*Controller, error) {
-	config, err := clientcmd.BuildConfigFromFlags(*url, "")
+	config, err := clientcmd.BuildConfigFromFlags(*ClusterURL, "")
 	if err != nil {
 		return nil, err
 	}

--- a/tests/e2e/virtletctl_test.go
+++ b/tests/e2e/virtletctl_test.go
@@ -44,8 +44,7 @@ var _ = Describe("virtletctl", func() {
 		localExecutor := framework.LocalExecutor(ctx)
 
 		By("Calling virtletctl help")
-		_, err := framework.RunSimple(localExecutor, "_output/virtletctl", "help")
-		Expect(err).NotTo(HaveOccurred())
+		callVirtletctl(localExecutor, "help")
 	}, 10)
 
 	Context("Tests depending on spawning VM", func() {
@@ -98,8 +97,7 @@ var _ = Describe("virtletctl", func() {
 			defer closeFunc()
 			localExecutor := framework.LocalExecutor(ctx)
 
-			output, err := framework.RunSimple(localExecutor, "_output/virtletctl", "ssh", "--namespace", controller.Namespace(), "cirros@virtletctl-cirros-vm", "--", "-i", tempfileName, "hostname")
-			Expect(err).NotTo(HaveOccurred())
+			output := callVirtletctl(localExecutor, "ssh", "--namespace", controller.Namespace(), "cirros@virtletctl-cirros-vm", "--", "-i", tempfileName, "hostname")
 			Expect(output).To(Equal("virtletctl-cirros-vm"))
 		}, 60)
 
@@ -111,8 +109,7 @@ var _ = Describe("virtletctl", func() {
 			localExecutor := framework.LocalExecutor(ctx)
 
 			By("Calling virtletctl dump-metadata")
-			output, err := framework.RunSimple(localExecutor, "_output/virtletctl", "dump-metadata")
-			Expect(err).NotTo(HaveOccurred())
+			output := callVirtletctl(localExecutor, "dump-metadata")
 			Expect(output).To(ContainSubstring("virtletctl-cirros-vm"))
 		}, 60)
 
@@ -126,8 +123,7 @@ var _ = Describe("virtletctl", func() {
 		localExecutor := framework.LocalExecutor(ctx)
 
 		By("Calling virtletctl virsh version")
-		output, err := framework.RunSimple(localExecutor, "_output/virtletctl", "virsh", "version")
-		Expect(err).NotTo(HaveOccurred())
+		output := callVirtletctl(localExecutor, "virsh", "version")
 		Expect(output).To(ContainSubstring("Compiled against library:"))
 		Expect(output).To(ContainSubstring("Using library:"))
 	}, 60)
@@ -139,11 +135,17 @@ var _ = Describe("virtletctl", func() {
 		localExecutor := framework.LocalExecutor(ctx)
 
 		By("Calling virtletctl install")
-		_, err := framework.RunSimple(localExecutor, "_output/virtletctl", "install")
-		Expect(err).NotTo(HaveOccurred())
+		callVirtletctl(localExecutor, "install")
 
 		By("Calling kubectl plugin virt help")
-		_, err = framework.RunSimple(localExecutor, "kubectl", "plugin", "virt", "help")
+		_, err := framework.RunSimple(localExecutor, "kubectl", "plugin", "virt", "help")
 		Expect(err).NotTo(HaveOccurred())
 	}, 60)
 })
+
+func callVirtletctl(executor framework.Executor, args ...string) string {
+	args = append([]string{"_output/virtletctl", "-s", *framework.ClusterURL}, args...)
+	output, err := framework.RunSimple(executor, args...)
+	Expect(err).NotTo(HaveOccurred())
+	return output
+}


### PR DESCRIPTION
That allows for running e2e virtletctl tests against other than accessible by localhost:8080 cluster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/644)
<!-- Reviewable:end -->
