### PR TITLE
Fix run after stop of pod sandbox

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -187,8 +187,6 @@ func (v *VirtletManager) RunPodSandbox(ctx context.Context, in *kubeapi.RunPodSa
 				PodSandboxId: podID,
 			}, err
 		}
-		glog.Errorf("sandbox exists but it's not ready. Sandbox status: %v", status)
-		return nil, err
 	}
 
 	glog.V(3).Infof("RunPodSandbox: %s", spew.Sdump(in))


### PR DESCRIPTION
Run just after Stop was working fine before this change, now we have there segfault because nil as err effects with trying to serialize nil as kubeapi.RunPodSandboxResponse which expects something other than nil (that can be an error in api, will look on that later).

This PR restores the previous behavior which we had in this place for other states of pod than READY.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/646)
<!-- Reviewable:end -->
