### PR TITLE
Allow start of libvirt with sriov_enabled on node without sriov

### DIFF
--- a/images/image_skel/libvirt.sh
+++ b/images/image_skel/libvirt.sh
@@ -14,8 +14,13 @@ if [[ -f /dind/vmwrapper ]]; then
 fi
 
 function regenerate_qemu_conf() {
-  set $(ls -l /sys/class/net/*/device/iommu_group | sed 's@.*/\(.*\)@"/dev/vfio/\1",@')
-  sed -i "s|# @DEVS@|$*|" /etc/libvirt/qemu.conf
+  if ls /sys/class/net/*/device/iommu_group >/dev/null 2>&1 ; then
+    set $(ls -l /sys/class/net/*/device/iommu_group | sed 's@.*/\(.*\)@"/dev/vfio/\1",@')
+    sed -i "s|# @DEVS@|$*|" /etc/libvirt/qemu.conf
+  else
+    echo WARNING - Virtlet is configured to use SR-IOV but no such resources are available on this host
+    sed -i "/# @DEVS@/d" /etc/libvirt/qemu.conf
+  fi
 }
 
 VIRTLET_SRIOV_SUPPORT="${VIRTLET_SRIOV_SUPPORT:-}"


### PR DESCRIPTION
Virtlet configmap is common for all nodes, so if different nodes have different hardware we should allow to start Virtlet with set `sriov_enabled` to non empty value in this config map even if there is missing hardware supporting SR-IOV.

Without this patch - `regenerate_qemu_conf` will fail because of `ls` can't find such entry in sysfs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/661)
<!-- Reviewable:end -->
