### PR TITLE
Add network interface ordering test

### DIFF
--- a/tests/network/fake_cni_test.go
+++ b/tests/network/fake_cni_test.go
@@ -202,12 +202,11 @@ func (c *FakeCNIClient) AddSandboxToNetwork(podId, podName, podNS string) (*cnic
 	}
 
 	replaceSandboxPlaceholders(entry.info, podId)
-	for n, iface := range entry.info.Interfaces {
-		if iface.Sandbox == "" {
+	for _, ip := range entry.info.IPs {
+		if entry.info.Interfaces[ip.Interface].Sandbox == "" {
 			continue
 		}
-
-		if err := entry.addSandboxToNetwork(n); err != nil {
+		if err := entry.addSandboxToNetwork(ip.Interface); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Make sure the interfaces are ordered according IPs in the CNI result.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/663)
<!-- Reviewable:end -->
