### PR TITLE
Fix route handling and pv/pvc deletion in ceph e2e

### DIFF
--- a/tests/e2e/ceph_test.go
+++ b/tests/e2e/ceph_test.go
@@ -146,9 +146,9 @@ var _ = Describe("Ceph volumes tests", func() {
 		})
 
 		AfterAll(func() {
+			deleteVM(vm)
 			controller.PersistentVolumeClaimsClient().Delete("rbd-claim", nil)
 			controller.PersistentVolumesClient().Delete("rbd-pv-virtlet", nil)
-			deleteVM(vm)
 		})
 
 		It("Must be attached to libvirt domain", func() {
@@ -178,10 +178,10 @@ func setupCeph() (string, string) {
 	nodeExecutor, err := controller.DinDNodeExecutor("kube-master")
 	Expect(err).NotTo(HaveOccurred())
 
-	route, err := framework.RunSimple(nodeExecutor, "route")
+	route, err := framework.RunSimple(nodeExecutor, "route", "-n")
 	Expect(err).NotTo(HaveOccurred())
 
-	match := regexp.MustCompile(`default\s+([\d.]+)`).FindStringSubmatch(route)
+	match := regexp.MustCompile(`(?:default|0\.0\.0\.0)\s+([\d.]+)`).FindStringSubmatch(route)
 	Expect(match).To(HaveLen(2))
 
 	monIP := match[1]


### PR DESCRIPTION
"route" command did provide output that e2e code couldn't
parse depending on /etc/hosts contents.
Also, we should delete PVs/PVCs after deleting the VM, not before it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/679)
<!-- Reviewable:end -->
