### PR TITLE
Point k-d-c to kubernetes-sigs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ VIRTLET_ON_MASTER=1 ./demo.sh
 
 The demo script will check for KVM support on the host and will make Virtlet use KVM if it's available on Docker host. If KVM is not available, plain QEMU will be used.
 
-The demo is based on [kubeadm-dind-cluster](https://github.com/Mirantis/kubeadm-dind-cluster) project. **Docker btrfs storage driver is currently unsupported.** Please refer to `kubeadm-dind-cluster` documentation for more info.
+The demo is based on [kubeadm-dind-cluster](https://github.com/kubernetes-sigs/kubeadm-dind-cluster) project. **Docker btrfs storage driver is currently unsupported.** Please refer to `kubeadm-dind-cluster` documentation for more info.
 
 You can remove the test cluster with `./dind-cluster-v1.9.sh clean` when you no longer need it.
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -12,7 +12,7 @@ The steps described here are performed automatically by
 1. Start [kubeadm-dind-cluster](https://github.com/Mirants/kubeadm-dind-cluster)
    with Kubernetes version 1.9 (you're not required to download it to your home directory):
    ```
-   $ wget -O ~/dind-cluster-v1.9.sh https://cdn.rawgit.com/Mirantis/kubeadm-dind-cluster/master/fixed/dind-cluster-v1.9.sh
+   $ wget -O ~/dind-cluster-v1.9.sh https://cdn.rawgit.com/kubernetes-sigs/kubeadm-dind-cluster/master/fixed/dind-cluster-v1.9.sh
    $ chmod +x ~/dind-cluster-v1.9.sh
    $ ~/dind-cluster-v1.9.sh up
    $ export PATH="$HOME/.kubeadm-dind-cluster:$PATH"

--- a/deploy/demo.sh
+++ b/deploy/demo.sh
@@ -104,7 +104,7 @@ function demo::get-dind-cluster {
   if [[ ${download} = "true" ]]; then
     demo::step "Will download ${dind_script} into current directory"
     demo::ask-before-continuing
-    wget "https://raw.githubusercontent.com/Mirantis/kubeadm-dind-cluster/master/fixed/${dind_script}"
+    wget "https://raw.githubusercontent.com/kubernetes-sigs/kubeadm-dind-cluster/master/fixed/${dind_script}"
     chmod +x "${dind_script}"
   fi
 }
@@ -361,7 +361,7 @@ cluster networking.
 
 To clean up the cluster, use './dind-cluster-v1.9.sh clean'
 [1] https://github.com/Mirantis/virtlet
-[2] https://github.com/Mirantis/kubeadm-dind-cluster
+[2] https://github.com/kubernetes-sigs/kubeadm-dind-cluster
 EOF
   exit 0
 fi

--- a/docs/devel/running-local-environment.md
+++ b/docs/devel/running-local-environment.md
@@ -7,10 +7,10 @@ At this stage Virtlet have following requirements:
 * SELinux/AppArmor disabled on host (to disable them - follow documentation from your host Linux distribution),
 * if host have libvirt installed - it should be stopped when working with Virtlet,
 * [docker](https://www.docker.com) should be installed on host and user account on which Virtlet will be built and run - should be properly configured to use this docker installation (possibly adding user's account into group in which docker deamon is running should be enough, but please follow docker documentation for your host Linux distribution),
-* [kubeadm-dind-cluster](https://github.com/Mirantis/kubeadm-dind-cluster) for version 1.9 (`dind-cluster-v1.9.sh`).
+* [kubeadm-dind-cluster](https://github.com/kubernetes-sigs/kubeadm-dind-cluster) for version 1.9 (`dind-cluster-v1.9.sh`).
   You can get the cluster startup script like this:
 ```
-$ wget -O ~/dind-cluster-v1.9.sh https://cdn.rawgit.com/Mirantis/kubeadm-dind-cluster/master/fixed/dind-cluster-v1.9.sh
+$ wget -O ~/dind-cluster-v1.9.sh https://cdn.rawgit.com/kubernetes-sigs/kubeadm-dind-cluster/master/fixed/dind-cluster-v1.9.sh
 $ chmod +x ~/dind-cluster-v1.9.sh
 ```
 

--- a/docs/multiple-interfaces.md
+++ b/docs/multiple-interfaces.md
@@ -20,11 +20,11 @@ There are two ways to tell CNI Genie which CNI networks to use:
 ## Configuring networks
 CNI plugins should return result in at least 0.3.0 format. All config files should be updated.
 
-# Example deployment using [kdc](https://github.com/Mirantis/kubeadm-dind-cluster)
+# Example deployment using [kdc](https://github.com/kubernetes-sigs/kubeadm-dind-cluster)
 
 ## Start a Kubernetes 1.9 cluster with Flannel, Calico, and CNI-Genie
 ```
-wget https://cdn.rawgit.com/Mirantis/kubeadm-dind-cluster/master/fixed/dind-cluster-v1.9.sh
+wget https://cdn.rawgit.com/kubernetes-sigs/kubeadm-dind-cluster/master/fixed/dind-cluster-v1.9.sh
 chmod +x dind-cluster-v1.9.sh
 ```
 


### PR DESCRIPTION
It was moved from Mirantis/kubeadm-dind-cluster to kubernetes-sigs/kubeadm-dind-cluster

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/685)
<!-- Reviewable:end -->
