### PR TITLE
 Partial fix for VF reconstruction

### DIFF
--- a/pkg/nettools/nettools.go
+++ b/pkg/nettools/nettools.go
@@ -565,10 +565,6 @@ func isSriovVf(link netlink.Link) bool {
 	return err == nil
 }
 
-func openVfConfigFile(devName string) (*os.File, error) {
-	return os.OpenFile(filepath.Join("/sys/bus/pci/devices", devName, "config"), os.O_RDWR, 0644)
-}
-
 func getPCIAddressOfVF(devName string) (string, error) {
 	linkDestination, err := os.Readlink(filepath.Join("/sys/class/net", devName, "device"))
 	if err != nil {
@@ -765,7 +761,10 @@ func SetupContainerSideNetwork(info *cnicurrent.Result, nsPath string, allLinks 
 				return nil, err
 			}
 
-			fo, err = openVfConfigFile(pciAddress)
+			// tapmanager protocol needs a file descriptor in Fo field
+			// but SR-IOV part is not using it at all, so set it to
+			// new file descriptor with /dev/null opened
+			fo, err = os.Open("/dev/null")
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
SR-IOV support was not ready for any kind of Virtlet restarts, and this PR fixes 2 scenarios - reboot of whole machine and restart of Virtlet while VMs are also restarted.

There is also last scenario - restart of Virtlet while VMs are running (so pci devices are attached to VMs and should not be recovered into container namespace), so similar situation to restart VM without restart of Virtlet. That's for the moment not supported and needs further work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/686)
<!-- Reviewable:end -->
