### PR TITLE
Fix getting device through its pci address

### DIFF
--- a/pkg/nettools/nettools.go
+++ b/pkg/nettools/nettools.go
@@ -588,10 +588,15 @@ func getDevNameByPCIAddress(address string) (string, error) {
 		return "", err
 	}
 	for _, fi := range devices {
-		linkDestination, err := os.Readlink(filepath.Join("/sys/class/net", fi.Name(), "device"))
-		if os.IsNotExist(err) {
+		// skip entries in /sys/class/net which are not directories
+		// with "device" entry (example: bonding_masters)
+		devPath := filepath.Join("/sys/class/net", fi.Name(), "device")
+		if _, err := os.Stat(devPath); err != nil {
 			continue
-		} else if err != nil {
+		}
+
+		linkDestination, err := os.Readlink(devPath)
+		if err != nil {
 			return "", err
 		}
 		if linkDestination == desiredLinkLocation {


### PR DESCRIPTION
Looks like in `/sys/class/net` there can be entries other than directories in which case Virtlet was failing to find master device for particular VF with "not a directory" error (during `os.Readlink`). That can be visible when there is defined at least one bond interface.

This PR fixes that situation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/688)
<!-- Reviewable:end -->
