### PR TITLE
Get VLAN id of VF from host namespace

### DIFF
--- a/pkg/nettools/nettools.go
+++ b/pkg/nettools/nettools.go
@@ -56,6 +56,7 @@ import (
 
 	"github.com/Mirantis/virtlet/pkg/cni"
 	"github.com/Mirantis/virtlet/pkg/network"
+	"github.com/Mirantis/virtlet/pkg/utils"
 )
 
 const (
@@ -733,7 +734,6 @@ func SetupContainerSideNetwork(info *cnicurrent.Result, nsPath string, allLinks 
 		pciAddress := ""
 		var ifaceType network.InterfaceType
 		var fo *os.File
-		var vlanID int
 
 		mtu := link.Attrs().MTU
 
@@ -758,10 +758,6 @@ func SetupContainerSideNetwork(info *cnicurrent.Result, nsPath string, allLinks 
 			// new file descriptor with /dev/null opened
 			fo, err = os.Open("/dev/null")
 			if err != nil {
-				return nil, err
-			}
-
-			if vlanID, err = getVfVlanID(pciAddress); err != nil {
 				return nil, err
 			}
 
@@ -837,7 +833,6 @@ func SetupContainerSideNetwork(info *cnicurrent.Result, nsPath string, allLinks 
 			HardwareAddr: hwAddr,
 			PCIAddress:   pciAddress,
 			MTU:          uint16(mtu),
-			VLanID:       vlanID,
 		})
 	}
 
@@ -1263,4 +1258,77 @@ func netmaskForCalico() net.IPMask {
 		}
 	}
 	return net.CIDRMask(n, 32)
+}
+
+type VfInfo struct {
+	PCIAddress string
+	Vlan       int
+}
+
+func GetVfInfos(nspath string) ([]*VfInfo, error) {
+	vmNS, err := ns.GetNS(nspath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open network namespace at %q: %v", nspath, err)
+	}
+
+	var vfInfos []*VfInfo
+	if err := vmNS.Do(func(ns.NetNS) error {
+		// enter container namespace
+		if err := utils.MountSysfs(); err != nil {
+			return err
+		}
+		defer func() {
+			if err := utils.UnmountSysfs(); err != nil {
+				glog.V(3).Infof("Warning, error during umount of /sys: %v", err)
+			}
+		}()
+
+		allLinks, err := netlink.LinkList()
+		if err != nil {
+			return err
+		}
+		for _, link := range allLinks {
+			// find all VFs
+			if isSriovVf(link) {
+				pciAddress, err := getPCIAddressOfVF(link.Attrs().Name)
+				if err != nil {
+					return err
+				}
+				vfInfos = append(vfInfos, &VfInfo{
+					PCIAddress: pciAddress,
+				})
+			}
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	// update vlan id for each vf looking on it's master device
+	// in host namespace
+	for _, vf := range vfInfos {
+		vlan, err := getVfVlanID(vf.PCIAddress)
+		if err != nil {
+			return nil, err
+		}
+		vf.Vlan = vlan
+	}
+
+	return vfInfos, err
+}
+
+func UpdateVfsInInterfaces(ifaces []*network.InterfaceDescription, vfInfos []*VfInfo) error {
+OUTER:
+	for _, iface := range ifaces {
+		if iface.Type == network.InterfaceTypeVF {
+			for _, info := range vfInfos {
+				if iface.PCIAddress == info.PCIAddress {
+					iface.VLanID = info.Vlan
+					continue OUTER
+				}
+			}
+			return fmt.Errorf("didn't found %s in vfinfos", iface.PCIAddress)
+		}
+	}
+	return nil
 }

--- a/pkg/utils/mountsysfs_linux.go
+++ b/pkg/utils/mountsysfs_linux.go
@@ -1,4 +1,4 @@
-// +build !linux
+// +build linux
 
 /*
 Copyright 2018 Mirantis
@@ -16,16 +16,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tapmanager
+package utils
 
 import (
-	"errors"
+	"syscall"
 )
 
-func mountSysfs() error {
-	return errors.New("not implemented")
+func MountSysfs() error {
+	return syscall.Mount("none", "/sys", "sysfs", 0, "")
 }
 
-func unmountSysfs() error {
-	return errors.New("not implemented")
+func UnmountSysfs() error {
+	return syscall.Unmount("/sys", syscall.MNT_DETACH)
 }

--- a/pkg/utils/mountsysfs_unsupported.go
+++ b/pkg/utils/mountsysfs_unsupported.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build !linux
 
 /*
 Copyright 2018 Mirantis
@@ -16,16 +16,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tapmanager
+package utils
 
 import (
-	"syscall"
+	"errors"
 )
 
-func mountSysfs() error {
-	return syscall.Mount("none", "/sys", "sysfs", 0, "")
+func MountSysfs() error {
+	return errors.New("not implemented")
 }
 
-func unmountSysfs() error {
-	return syscall.Unmount("/sys", syscall.MNT_DETACH)
+func UnmountSysfs() error {
+	return errors.New("not implemented")
 }


### PR DESCRIPTION
Because of madness of mixture of namespaces getting vlan id of vf was broken.
To do it correctly we need to extract list of vfs configured in container namespace then iterate over them using their pci addresses looking for master device of each (what can be done only in host namespace) and read from it VF vlan id, using vf index.

This PR provides required changes to support that.