### PR TITLE
Remove vlan support for SR-IOV

### DIFF
--- a/pkg/nettools/nettools.go
+++ b/pkg/nettools/nettools.go
@@ -675,9 +675,9 @@ func getMasterLinkOfVf(pciAddress string) (netlink.Link, error) {
 	return masterLink, nil
 }
 
-// SetMacAndVlanOnVf uses VF pci address to locate its parent device and uses
-// it to set mac address and vlan id on VF.  It needs to be called from host netns.
-func SetMacAndVlanOnVf(pciAddress string, vlanID int, mac net.HardwareAddr) error {
+// SetMacOnVf uses VF pci address to locate its parent device and uses
+// it to set mac address on VF.  It needs to be called from host netns.
+func SetMacOnVf(pciAddress string, mac net.HardwareAddr) error {
 	virtFNNo, err := getVirtFNNo(pciAddress)
 	if err != nil {
 		return err
@@ -686,27 +686,7 @@ func SetMacAndVlanOnVf(pciAddress string, vlanID int, mac net.HardwareAddr) erro
 	if err != nil {
 		return err
 	}
-	if err := netlink.LinkSetVfHardwareAddr(masterLink, virtFNNo, mac); err != nil {
-		return err
-	}
-	return netlink.LinkSetVfVlan(masterLink, virtFNNo, vlanID)
-}
-
-func getVfVlanID(pciAddress string) (int, error) {
-	virtFNNo, err := getVirtFNNo(pciAddress)
-	if err != nil {
-		return 0, err
-	}
-	masterLink, err := getMasterLinkOfVf(pciAddress)
-	if err != nil {
-		return 0, err
-	}
-	for _, vfInfo := range masterLink.Attrs().Vfs {
-		if vfInfo.ID == virtFNNo {
-			return int(vfInfo.Vlan), nil
-		}
-	}
-	return 0, fmt.Errorf("vlan info for %d vf on %s not found", virtFNNo, masterLink.Attrs().Name)
+	return netlink.LinkSetVfHardwareAddr(masterLink, virtFNNo, mac)
 }
 
 // SetupContainerSideNetwork sets up networking in container
@@ -733,7 +713,6 @@ func SetupContainerSideNetwork(info *cnicurrent.Result, nsPath string, allLinks 
 		pciAddress := ""
 		var ifaceType network.InterfaceType
 		var fo *os.File
-		var vlanID int
 
 		mtu := link.Attrs().MTU
 
@@ -758,10 +737,6 @@ func SetupContainerSideNetwork(info *cnicurrent.Result, nsPath string, allLinks 
 			// new file descriptor with /dev/null opened
 			fo, err = os.Open("/dev/null")
 			if err != nil {
-				return nil, err
-			}
-
-			if vlanID, err = getVfVlanID(pciAddress); err != nil {
 				return nil, err
 			}
 
@@ -837,7 +812,6 @@ func SetupContainerSideNetwork(info *cnicurrent.Result, nsPath string, allLinks 
 			HardwareAddr: hwAddr,
 			PCIAddress:   pciAddress,
 			MTU:          uint16(mtu),
-			VLanID:       vlanID,
 		})
 	}
 
@@ -1053,7 +1027,7 @@ func ReconstructVFs(csn *network.ContainerSideNetwork, netns ns.NetNS, ignoreUnb
 		if err != nil {
 			return err
 		}
-		if err := SetMacAndVlanOnVf(iface.PCIAddress, iface.VLanID, iface.HardwareAddr); err != nil {
+		if err := SetMacOnVf(iface.PCIAddress, iface.HardwareAddr); err != nil {
 			return err
 		}
 		link, err := netlink.LinkByName(devName)

--- a/pkg/network/csn.go
+++ b/pkg/network/csn.go
@@ -52,8 +52,6 @@ type InterfaceDescription struct {
 	PCIAddress string
 	// MTU contains max transfer unit value for interface.
 	MTU uint16
-	// VlanID contains vlan identifier for sr-iov vf interface.
-	VLanID int
 }
 
 // ContainerSideNetwork struct describes the container (VM) network

--- a/pkg/tapmanager/tapfdsource.go
+++ b/pkg/tapmanager/tapfdsource.go
@@ -198,7 +198,7 @@ func (s *TapFDSource) GetFDs(key string, data []byte) ([]int, []byte, error) {
 
 	for _, iface := range csn.Interfaces {
 		if iface.Type == network.InterfaceTypeVF {
-			if err := nettools.SetMacAndVlanOnVf(iface.PCIAddress, iface.VLanID, iface.HardwareAddr); err != nil {
+			if err := nettools.SetMacOnVf(iface.PCIAddress, iface.HardwareAddr); err != nil {
 				gotError = true
 				return nil, nil, err
 			}


### PR DESCRIPTION
In current state it tries to read vlan id from master device while code
is executed in container namespace, but master device is available only
in host namespace.

New approach will be prepared in separate PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/694)
<!-- Reviewable:end -->
