### PR TITLE
Force go-bindata to use particular file mode

### DIFF
--- a/build/cmd.sh
+++ b/build/cmd.sh
@@ -419,7 +419,7 @@ function get_ldflags {
 function build_internal {
     # we don't just always generate the bindata right there because we
     # want to keep the source buildable outside this build container.
-    go-bindata -o /tmp/bindata.go -modtime "${bindata_modtime}" -pkg "${bindata_pkg}" "${bindata_dir}"
+    go-bindata -mode 0644 -o /tmp/bindata.go -modtime "${bindata_modtime}" -pkg "${bindata_pkg}" "${bindata_dir}"
     if ! cmp /tmp/bindata.go "${bindata_out}"; then
         echo >&2 "${bindata_dir} changed, please re-run ${0} update-bindata"
         exit 1
@@ -485,7 +485,7 @@ function e2e {
 function update_bindata_internal {
     # set fixed modtime to avoid unwanted differences during the checks
     # that are done by build/cmd.sh build
-    go-bindata -modtime "${bindata_modtime}" -o "${bindata_out}" -pkg "${bindata_pkg}" "${bindata_dir}"
+    go-bindata -mode 0644 -modtime "${bindata_modtime}" -o "${bindata_out}" -pkg "${bindata_pkg}" "${bindata_dir}"
 }
 
 function update_docs_internal {


### PR DESCRIPTION
Without this change after using `build/cmd.sh update-bindata` I had constantly diffs like:
```diff
diff --git a/pkg/tools/bindata.go b/pkg/tools/bindata.go
index 8fa43ad..a476352 100644
--- a/pkg/tools/bindata.go
+++ b/pkg/tools/bindata.go
@@ -81,7 +81,7 @@ func deployDataVirtletDsYaml() (*asset, error) {
                return nil, err
        }

-       info := bindataFileInfo{name: "deploy/data/virtlet-ds.yaml", size: 10643, mode: os.FileMode(420), modTime: time.Unix(1522279343, 0)}
+       info := bindataFileInfo{name: "deploy/data/virtlet-ds.yaml", size: 10643, mode: os.FileMode(436), modTime: time.Unix(1522279343, 0)}
        a := &asset{bytes: bytes, info: info}
        return a, nil
 }
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/697)
<!-- Reviewable:end -->
