### PR TITLE
[DNM] PoC for huge pages in libvirt domain definition

### DIFF
--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -164,6 +164,19 @@ func (ds *domainSettings) createDomain(config *types.VMConfig) *libvirtxml.Domai
 		},
 	}
 
+	if len(config.ParsedAnnotations.HugePagesSettings) > 0 {
+		domain.MemoryBacking = &libvirtxml.DomainMemoryBacking{
+			MemoryHugePages: &libvirtxml.DomainMemoryHugepages{},
+		}
+		for _, el := range config.ParsedAnnotations.HugePagesSettings {
+			domain.MemoryBacking.MemoryHugePages.Hugepages = append(domain.MemoryBacking.MemoryHugePages.Hugepages, libvirtxml.DomainMemoryHugepage{
+				Size:    el.Size,
+				Unit:    el.Unit,
+				Nodeset: el.NodeSet,
+			})
+		}
+	}
+
 	if ds.enableSriov {
 		domain.QEMUCommandline.Envs = append(domain.QEMUCommandline.Envs,
 			libvirtxml.DomainQEMUCommandlineEnv{Name: "VMWRAPPER_KEEP_PRIVS", Value: "1"})


### PR DESCRIPTION
There is no verification if host supports huge pages.
There is no verification of any kind of additional libvirt/qemu configuration if it's needed for huge pages.
There is no validation of nodeset value at the moment.

Simply if there is VirtletHugePages annotation its value is used to
construct data in memoryBacking section of libvirt domain xml
(according to https://libvirt.org/formatdomain.html#elementsMemoryBacking).

Whole value is split to sub entries using ";" as separator.
Each entry should have 3 values:
 * size - as a uint
 * unit - single character denoting unit size (K, M, or G)
 * nodeset - node ranges (e.g. 0-3), or/and particular node numbers of
 numa nodes, combined with comma sign (please refer to libvirt docs for
 details - this part is passed "as is" to domain definition).