### PR TITLE
Add per-node config e2e test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,11 +168,16 @@ e2e: &e2e
           BASE_LOCATION="$PWD" \
           deploy/demo.sh
   - run:
-      name: install kubectl
+      name: Install kubectl
       command: |
         curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl
         echo ${KUBECTL_SHA1} /usr/local/bin/kubectl |sha1sum -c
         chmod +x /usr/local/bin/kubectl
+
+  - run:
+      name: Prepare all of the nodes for Virtlet pod
+      command: |
+        build/cmd.sh prepare-all-nodes
 
   - run:
       name: Run e2e tests

--- a/docs/devel/build-tool.md
+++ b/docs/devel/build-tool.md
@@ -74,6 +74,14 @@ the DIND node that will run Virtlet if it doesn't exist there
 or if `FORCE_UPDATE_IMAGE` is set to a non-empty value.
 This command requires `kubectl`.
 
+### prepare-all-nodes
+
+Makes all the worker nodes in the `kubeadm-dind-cluster` ready for
+Virtlet pod, but doesn't start Virtlet pod on them (it doesn't apply
+`extraRuntime=virtlet` label). This is done automatically for the
+Virtlet node during `start-dind`, but it's necessary to do so for all
+the worker nodes for Virtlet e2e config test to pass.
+
 ### vsh
 
 Starts an interactive shell using build container. Useful for debugging.

--- a/tests/e2e/config_test.go
+++ b/tests/e2e/config_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2018 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	. "github.com/onsi/gomega"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	virtlet_v1 "github.com/Mirantis/virtlet/pkg/api/virtlet.k8s/v1"
+	"github.com/Mirantis/virtlet/tests/e2e/framework"
+	. "github.com/Mirantis/virtlet/tests/e2e/ginkgo-ext"
+)
+
+var _ = Describe("Per-node configuration", func() {
+	var extraVirtletNode string
+	var virtletPod *framework.PodInterface
+	var configMappingNames []string
+
+	installVirtletOnExtraNode := func() {
+		var err error
+		extraVirtletNode, err = controller.AvailableNodeName()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(controller.AddLabelsToNode(extraVirtletNode, map[string]string{
+			"extraRuntime": "virtlet",
+			"foobarConfig": "baz",
+		})).To(Succeed())
+		virtletPod, err = controller.WaitForVirtletPodOnTheNode(extraVirtletNode)
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	createConfigs := func() {
+		logLevel := 5
+		rawDevs := "foobar*"
+		cms := []virtlet_v1.VirtletConfigMapping{
+			{
+				ObjectMeta: meta_v1.ObjectMeta{
+					GenerateName: "virtlet-e2e-",
+				},
+				Spec: virtlet_v1.VirtletConfigMappingSpec{
+					NodeSelector: map[string]string{
+						"extraRuntime": "virtlet",
+					},
+					Config: &virtlet_v1.VirtletConfig{
+						LogLevel: &logLevel,
+					},
+				},
+			},
+			{
+				ObjectMeta: meta_v1.ObjectMeta{
+					GenerateName: "virtlet-e2e-",
+				},
+				Spec: virtlet_v1.VirtletConfigMappingSpec{
+					NodeSelector: map[string]string{
+						"foobarConfig": "baz",
+					},
+					Config: &virtlet_v1.VirtletConfig{
+						RawDevices: &rawDevs,
+					},
+				},
+			},
+		}
+		for _, cm := range cms {
+			cm, err := controller.CreateVirtletConfigMapping(cm)
+			Expect(err).NotTo(HaveOccurred())
+			if cm != nil {
+				configMappingNames = append(configMappingNames, cm.Name)
+			}
+		}
+	}
+
+	AfterAll(func() {
+		if extraVirtletNode != "" {
+			Expect(controller.RemoveLabelOffNode(extraVirtletNode, []string{
+				"extraRuntime",
+				"foobarConfig",
+			})).To(Succeed())
+			Expect(controller.WaitForVirtletPodToDisappearFromTheNode(extraVirtletNode)).To(Succeed())
+		}
+		for _, cmName := range configMappingNames {
+			Expect(controller.DeleteVirtletConfigMapping(cmName)).To(Succeed())
+		}
+	})
+
+	It("Should be obtained by combining the Virtlet config mappings that match the node", func() {
+		createConfigs()
+		installVirtletOnExtraNode()
+		virtletContainer, err := virtletPod.Container("virtlet")
+		Expect(err).NotTo(HaveOccurred())
+		out, err := framework.RunSimple(virtletContainer, "cat", "/var/lib/virtlet/config.sh")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(ContainSubstring("export VIRTLET_RAW_DEVICES=foobar\\*\n"))
+		Expect(out).To(ContainSubstring("export VIRTLET_LOGLEVEL=5"))
+	})
+})

--- a/tests/e2e/framework/controller.go
+++ b/tests/e2e/framework/controller.go
@@ -14,22 +14,47 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Some parts of this file are borrowed from Kubernetes source
+// (test/utils/density_utils.go). The original copyright notice
+// follows.
+
+/*
+Copyright 2016 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package framework
 
 import (
+	"errors"
 	"flag"
 	"fmt"
+	"strings"
 	"time"
 
 	"k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	typedv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
 	virtlet_v1 "github.com/Mirantis/virtlet/pkg/api/virtlet.k8s/v1"
 	virtletclientv1 "github.com/Mirantis/virtlet/pkg/client/clientset/versioned/typed/virtlet.k8s/v1"
+)
+
+const (
+	retries = 5
 )
 
 var ClusterURL = flag.String("cluster-url", "http://127.0.0.1:8080", "apiserver URL")
@@ -107,6 +132,14 @@ func (c *Controller) DeleteVirtletImageMapping(name string) error {
 	return c.virtletClient.VirtletImageMappings("kube-system").Delete(name, &metav1.DeleteOptions{})
 }
 
+func (c *Controller) CreateVirtletConfigMapping(configMapping virtlet_v1.VirtletConfigMapping) (*virtlet_v1.VirtletConfigMapping, error) {
+	return c.virtletClient.VirtletConfigMappings("kube-system").Create(&configMapping)
+}
+
+func (c *Controller) DeleteVirtletConfigMapping(name string) error {
+	return c.virtletClient.VirtletConfigMappings("kube-system").Delete(name, &metav1.DeleteOptions{})
+}
+
 // PersistentVolumesClient returns interface for PVs
 func (c *Controller) PersistentVolumesClient() typedv1.PersistentVolumeInterface {
 	return c.client.PersistentVolumes()
@@ -176,13 +209,138 @@ func (c *Controller) VirtletPod() (*PodInterface, error) {
 	return pod, nil
 }
 
-// VirtletNodeName returns the name of one of the nodes that run virtlet
+// VirtletNodeName returns the name of one of the nodes that run Virtlet
 func (c *Controller) VirtletNodeName() (string, error) {
 	virtletPod, err := c.VirtletPod()
 	if err != nil {
 		return "", err
 	}
 	return virtletPod.Pod.Spec.NodeName, nil
+}
+
+// AvailableNodeName returns the name of a node that doesn't run
+// Virtlet after the standard test setup is done but which can be
+// labelled to run Virtlet.
+func (c *Controller) AvailableNodeName() (string, error) {
+	virtletNodeName, err := c.VirtletNodeName()
+	if err != nil {
+		return "", err
+	}
+
+	nodeList, err := c.client.Nodes().List(metav1.ListOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	for _, node := range nodeList.Items {
+		if node.Name == virtletNodeName {
+			continue
+		}
+		if len(node.Spec.Taints) == 0 {
+			return node.Name, nil
+		}
+	}
+
+	return "", errors.New("couldn't find an available node")
+}
+
+// AddLabelsToNode adds the specified labels to the node.
+// Based on test/utils/density_utils.go in the Kubernetes source.
+func (c *Controller) AddLabelsToNode(nodeName string, labels map[string]string) error {
+	tokens := make([]string, 0, len(labels))
+	for k, v := range labels {
+		tokens = append(tokens, "\""+k+"\":\""+v+"\"")
+	}
+	labelString := "{" + strings.Join(tokens, ",") + "}"
+	patch := fmt.Sprintf(`{"metadata":{"labels":%v}}`, labelString)
+	var err error
+	for attempt := 0; attempt < retries; attempt++ {
+		_, err = c.client.Nodes().Patch(nodeName, types.MergePatchType, []byte(patch))
+		if err != nil {
+			if !apierrs.IsConflict(err) {
+				return err
+			}
+		} else {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return err
+}
+
+// RemoveLabelOffNode is for cleaning up labels temporarily added to node,
+// won't fail if target label doesn't exist or has been removed.
+// Based on test/utils/density_utils.go in the Kubernetes source.
+func (c *Controller) RemoveLabelOffNode(nodeName string, labelKeys []string) error {
+	var node *v1.Node
+	var err error
+	for attempt := 0; attempt < retries; attempt++ {
+		node, err = c.client.Nodes().Get(nodeName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if node.Labels == nil {
+			return nil
+		}
+		for _, labelKey := range labelKeys {
+			if node.Labels == nil || len(node.Labels[labelKey]) == 0 {
+				break
+			}
+			delete(node.Labels, labelKey)
+		}
+		_, err = c.client.Nodes().Update(node)
+		if err != nil {
+			if !apierrs.IsConflict(err) {
+				return err
+			}
+		} else {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return err
+}
+
+func (c *Controller) WaitForVirtletPodOnTheNode(name string) (*PodInterface, error) {
+	var virtletPod *PodInterface
+	if err := waitFor(func() error {
+		var err error
+		virtletPod, err = c.FindPod("kube-system", map[string]string{"runtime": "virtlet"}, func(podInterface *PodInterface) bool {
+			return podInterface.Pod.Spec.NodeName == name
+		})
+		switch {
+		case err != nil:
+			return err
+		case virtletPod != nil:
+			return nil
+		default:
+			return fmt.Errorf("no Virtlet pod on the node %q", name)
+		}
+	}, 5*time.Minute, 5*time.Second, false); err != nil {
+		return nil, err
+	}
+
+	if err := virtletPod.Wait(5 * time.Minute); err != nil {
+		return nil, err
+	}
+
+	return virtletPod, nil
+}
+
+func (c *Controller) WaitForVirtletPodToDisappearFromTheNode(name string) error {
+	return waitFor(func() error {
+		virtletPod, err := c.FindPod("kube-system", map[string]string{"runtime": "virtlet"}, func(podInterface *PodInterface) bool {
+			return podInterface.Pod.Spec.NodeName == name
+		})
+		switch {
+		case err != nil:
+			return err
+		case virtletPod == nil:
+			return nil
+		default:
+			return fmt.Errorf("Virtlet pod still present on the node %q", name)
+		}
+	}, 5*time.Minute, 5*time.Second, false)
 }
 
 // DinDNodeExecutor returns executor in DinD container for one of k8s nodes

--- a/tests/e2e/framework/pod_interface.go
+++ b/tests/e2e/framework/pod_interface.go
@@ -104,6 +104,9 @@ func (pi *PodInterface) Wait(timing ...time.Duration) error {
 			if cs.State.Running == nil {
 				return fmt.Errorf("container %s in pod %s is not running: %s", cs.Name, podUpdated.Name, spew.Sdump(cs.State))
 			}
+			if !cs.Ready {
+				return fmt.Errorf("container %s in pod %s in not ready", cs.Name, podUpdated.Name)
+			}
 		}
 		return nil
 	}, timeout, pollPeriond, consistencyPeriod)


### PR DESCRIPTION
This test creates some Virtlet config mappings, then starts Virtlet pod
of one of the available nodes in the cluster and verifies the effective
configuration used by Virtlet after that. Note that is does so just by
checking the contents of `/var/lib/virtlet/config.sh` as seen by Virtlet
container. Verifying the actual settings being applied to VMs in e2e is
too complex/fragile to be practical right now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/704)
<!-- Reviewable:end -->
