### PR TITLE
Fix small typo

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -140,7 +140,7 @@ func (v *VirtletManager) Run() error {
 		glog.Warning(err)
 	}
 
-	glog.V(1).Infof("Starting server on socket %s", v.config.CRISocketPath)
+	glog.V(1).Infof("Starting server on socket %s", *v.config.CRISocketPath)
 	if err = v.server.Serve(*v.config.CRISocketPath); err != nil {
 		return fmt.Errorf("serving failed: %v", err)
 	}


### PR DESCRIPTION
Fixes:
```
manager.go:143] Starting server on socket %!s(*string=0xc4202178b0)
```
message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/709)
<!-- Reviewable:end -->
