### PR TITLE
Don't mark any multi CNI tests as [Conformance]

### DIFF
--- a/tests/e2e/multi_cni_test.go
+++ b/tests/e2e/multi_cni_test.go
@@ -82,7 +82,8 @@ func describeMultiCNI(what string, addCNIAnnotation bool) {
 
 		itShouldHaveNetworkConnectivity(
 			func() *framework.PodInterface { return vms[0].vmPod },
-			func() framework.Executor { return vms[0].ssh })
+			func() framework.Executor { return vms[0].ssh },
+			false)
 	})
 }
 


### PR DESCRIPTION
- [x] remove `[Conformance]` tag from multi CNI tests
- [x] make sure the updated tests are still `[Conformance]` tag in basic tests
   and no such tag in multi CNI tests (inspect test results to be sure)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/710)
<!-- Reviewable:end -->
