### PR TITLE
reclaim storageVolume when CreateStorageVol fail

### DIFF
--- a/pkg/libvirttools/libvirt_storage.go
+++ b/pkg/libvirttools/libvirt_storage.go
@@ -111,6 +111,7 @@ func (pool *libvirtStoragePool) CreateStorageVol(def *libvirtxml.StorageVolume) 
 	// Here we work around this problem by refreshing the pool
 	// which invokes acquiring volume info.
 	if err := pool.p.Refresh(0); err != nil {
+		v.Delete(0)
 		return nil, fmt.Errorf("failed to refresh the storage pool: %v", err)
 	}
 	return &libvirtStorageVolume{Mutex: pool.Mutex, name: def.Name, v: v}, nil


### PR DESCRIPTION
Signed-off-by: yanxuean <yan.xuean@zte.com.cn>

I hit a problem.
```
{"log":"E0508 07:24:43.603558   10024 manager.go:422] Error creating container cc-yy-7: virError(Code=90, Domain=18, Message='storage volume 'virtlet_root_a8941e21-b35f-54d0-7525-ae4d54f5b9e2' exists already')\n","stream":"stderr","time":"2018-05-08T07:24:43.604341563Z"}
```

We should reclaim storageVolume when CreateStorageVol is fail for Refresh.
The diskList setup don't reclaim it. 
```
func (dl *diskList) setup() ([]libvirtxml.DomainDisk, error) {
	var domainDisks []libvirtxml.DomainDisk
	for n, item := range dl.items {
		diskDef, err := item.setup(dl.config)
		if err != nil {
			// try to tear down volumes that were already set up
			for _, item := range dl.items[:n] {               <-- only reclaim those volumes that is successful created.
				if err := item.volume.Teardown(); err != nil {
					glog.Warningf("Failed to tear down a volume on error: %v", err)
				}
			}
			return nil, err
		}
		domainDisks = append(domainDisks, *diskDef)
	}
	return domainDisks, nil
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/718)
<!-- Reviewable:end -->
