### PR TITLE
support add fd parallelly

### DIFF
--- a/cmd/vmwrapper/vmwrapper.go
+++ b/cmd/vmwrapper/vmwrapper.go
@@ -84,10 +84,6 @@ func main() {
 
 		if netFdKey != "" {
 			c := tapmanager.NewFDClient(fdSocketPath)
-			if err := c.Connect(); err != nil {
-				glog.Errorf("Can't connect to fd server: %v", err)
-				os.Exit(1)
-			}
 			fds, marshaledData, err := c.GetFDs(netFdKey)
 			if err != nil {
 				glog.Errorf("Failed to obtain tap fds for key %q: %v", netFdKey, err)

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -70,10 +70,10 @@ func (v *VirtletManager) Run() error {
 	if v.fdManager == nil {
 		client := tapmanager.NewFDClient(*v.config.FDServerSocketPath)
 		for i := 0; i < tapManagerAttemptCount; i++ {
-			time.Sleep(tapManagerConnectInterval)
-			if err = client.Connect(); err == nil {
+			if err = client.IsRunning(); err == nil {
 				break
 			}
+			time.Sleep(tapManagerConnectInterval)
 		}
 		if err != nil {
 			return fmt.Errorf("failed to connect to tapmanager: %v", err)

--- a/pkg/tapmanager/fdserver_test.go
+++ b/pkg/tapmanager/fdserver_test.go
@@ -192,14 +192,6 @@ func withFDClient(t *testing.T, toCall func(*FDClient, *sampleFDSource)) {
 		}
 	}()
 	c := NewFDClient(socketPath)
-	if err := c.Connect(); err != nil {
-		t.Fatalf("Connect(): %v", err)
-	}
-	defer func() {
-		if err := c.Close(); err != nil {
-			t.Errorf("Close(): %v", err)
-		}
-	}()
 
 	toCall(c, src)
 }

--- a/tests/network/vm_network_test.go
+++ b/tests/network/vm_network_test.go
@@ -311,9 +311,6 @@ func newTapFDSourceTester(t *testing.T, podId string, info *cnicurrent.Result, h
 
 func (tst *tapFDSourceTester) stop() {
 	if tst.c != nil {
-		if err := tst.c.Close(); err != nil {
-			tst.t.Errorf("FDClient.Close(): %v", err)
-		}
 		tst.c = nil
 	}
 	if tst.s != nil {
@@ -349,9 +346,6 @@ func (tst *tapFDSourceTester) setupServerAndConnectToFDServer() *tapmanager.FDCl
 	}
 
 	tst.c = tapmanager.NewFDClient(tst.socketPath)
-	if err := tst.c.Connect(); err != nil {
-		tst.t.Fatalf("Connect(): %v", err)
-	}
 
 	return tst.c
 }


### PR DESCRIPTION
create new connect for every fd request

Signed-off-by: yanxuean <yan.xuean@zte.com.cn>

virtletv1.0
hit a problem.
The request and response of AddFd will be mismatch when we create plenty of pod(e.g. 10).
```
{"log":"E0508 07:24:05.205665   10024 manager.go:220] Error when adding pod yy-8 (d6f96ee4-5290-11e8-8d7b-fa163e15c857) to CNI network: fd key mismatch in the server response\n","stream":"stderr","time":"2018-05-08T07:24:05.205934204Z"}
{"log":"nsfix reexec: pid 28438: entering the namespaces of target pid 1\n","stream":"stderr","time":"2018-05-08T07:24:05.244085618Z"}

{"log":"I0508 07:24:05.869500   10033 nettools.go:716] Opening tap interface \"tap0\" for link \"virtlet-eth0\"\n","stream":"stderr","time":"2018-05-08T07:24:05.87005565Z"}
{"log":"I0508 07:24:05.869571   10033 nettools.go:721] Adding interface \"virtlet-eth0\" as \"tap0\"\n","stream":"stderr","time":"2018-05-08T07:24:05.870131321Z"}
{"log":"2018/05/08 07:24:06 transport: http2Server.HandleStreams failed to receive the preface from client: EOF\n","stream":"stderr","time":"2018-05-08T07:24:06.092375098Z"}
{"log":"E0508 07:24:06.371938   10024 manager.go:220] Error when adding pod yy-7 (d601d1c1-5290-11e8-8d7b-fa163e15c857) to CNI network: fd key mismatch in the server response\n","stream":"stderr","time":"2018-05-08T07:24:06.372188913Z"}
{"log":"nsfix reexec: pid 28549: entering the namespaces of target pid 1\n","stream":"stderr","time":"2018-05-08T07:24:06.415327404Z"}

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/719)
<!-- Reviewable:end -->
