### PR TITLE
Support Kubernetes 1.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,6 +162,10 @@ e2e: &e2e
         elif [[ ${CIRCLE_JOB} = e2e_multi_cni ]]; then
           export MULTI_CNI=1
           echo >&2 "*** Using multiple CNIs (flannel + calico)"
+        elif [[ ${CIRCLE_JOB} = e2e_1_9 ]]; then
+          export KUBE_VERSION=1.9
+        elif [[ ${CIRCLE_JOB} = e2e_1_10 ]]; then
+          export KUBE_VERSION=1.10
         fi
         SKIP_SNAPSHOT=1 \
           NONINTERACTIVE=1 \
@@ -359,6 +363,12 @@ jobs:
   e2e_multi_cni:
     <<: *e2e
 
+  e2e_1_9:
+    <<: *e2e
+
+  e2e_1_10:
+    <<: *e2e
+
   push_branch:
     <<: *push_images
 
@@ -459,6 +469,20 @@ workflows:
           tags:
             only:
               - /^v[0-9].*/
+    - e2e_1_9:
+        requires:
+        - build
+        filters:
+          tags:
+            only:
+              - /^v[0-9].*/
+    - e2e_1_10:
+        requires:
+        - build
+        filters:
+          tags:
+            only:
+              - /^v[0-9].*/
     - push_branch:
         requires:
         - build
@@ -474,6 +498,8 @@ workflows:
         - e2e_flannel
         - e2e_weave
         - e2e_multi_cni
+        - e2e_1_9
+        - e2e_1_10
         - integration
         filters:
           branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,8 +363,8 @@ jobs:
   e2e_multi_cni:
     <<: *e2e
 
-  e2e_1_9:
-    <<: *e2e
+  # e2e_1_9:
+  #   <<: *e2e
 
   e2e_1_10:
     <<: *e2e
@@ -469,13 +469,13 @@ workflows:
           tags:
             only:
               - /^v[0-9].*/
-    - e2e_1_9:
-        requires:
-        - build
-        filters:
-          tags:
-            only:
-              - /^v[0-9].*/
+    # - e2e_1_9:
+    #     requires:
+    #     - build
+    #     filters:
+    #       tags:
+    #         only:
+    #           - /^v[0-9].*/
     - e2e_1_10:
         requires:
         - build
@@ -498,7 +498,7 @@ workflows:
         - e2e_flannel
         - e2e_weave
         - e2e_multi_cni
-        - e2e_1_9
+        # - e2e_1_9
         - e2e_1_10
         - integration
         filters:

--- a/build/cmd.sh
+++ b/build/cmd.sh
@@ -4,7 +4,7 @@ set -o nounset
 set -o pipefail
 set -o errtrace
 
-CRIPROXY_DEB_URL="${CRIPROXY_DEB_URL:-https://github.com/Mirantis/criproxy/releases/download/v0.11.1/criproxy-nodeps_0.11.1_amd64.deb}"
+CRIPROXY_DEB_URL="${CRIPROXY_DEB_URL:-https://github.com/Mirantis/criproxy/releases/download/v0.12.0/criproxy-nodeps_0.12.0_amd64.deb}"
 VIRTLET_IMAGE="${VIRTLET_IMAGE:-mirantis/virtlet}"
 VIRTLET_SKIP_RSYNC="${VIRTLET_SKIP_RSYNC:-}"
 VIRTLET_RSYNC_PORT="${VIRTLET_RSYNC_PORT:-18730}"

--- a/deploy/demo.sh
+++ b/deploy/demo.sh
@@ -5,11 +5,11 @@ set -o nounset
 set -o pipefail
 set -o errtrace
 
-CRIPROXY_DEB_URL="${CRIPROXY_DEB_URL:-https://github.com/Mirantis/criproxy/releases/download/v0.11.1/criproxy-nodeps_0.11.1_amd64.deb}"
+CRIPROXY_DEB_URL="${CRIPROXY_DEB_URL:-https://github.com/Mirantis/criproxy/releases/download/v0.12.0/criproxy-nodeps_0.12.0_amd64.deb}"
 NONINTERACTIVE="${NONINTERACTIVE:-}"
 NO_VM_CONSOLE="${NO_VM_CONSOLE:-}"
 INJECT_LOCAL_IMAGE="${INJECT_LOCAL_IMAGE:-}"
-dind_script="dind-cluster-v1.10.sh"
+dind_script="dind-cluster-v1.11.sh"
 kubectl="${HOME}/.kubeadm-dind-cluster/kubectl"
 BASE_LOCATION="${BASE_LOCATION:-https://raw.githubusercontent.com/Mirantis/virtlet/master/}"
 RELEASE_LOCATION="${RELEASE_LOCATION:-https://github.com/Mirantis/virtlet/releases/download/}"
@@ -130,7 +130,7 @@ function demo::start-dind-cluster {
   if [[ ! ${NONINTERACTIVE} ]]; then
     echo "Cirros ssh connection will be open after Virtlet setup is complete, press Ctrl-D to disconnect." >&2
   fi
-  echo "To clean up the cluster, use './dind-cluster-v1.9.sh clean'" >&2
+  echo "To clean up the cluster, use './dind-cluster-v1.11.sh clean'" >&2
   demo::ask-before-continuing
   "./${dind_script}" clean
   "./${dind_script}" up
@@ -390,7 +390,7 @@ can be used to disconnect from it.
 Use 'curl http://nginx.default.svc.cluster.local' from VM console to test
 cluster networking.
 
-To clean up the cluster, use './dind-cluster-v1.9.sh clean'
+To clean up the cluster, use './dind-cluster-v1.11.sh clean'
 [1] https://github.com/Mirantis/virtlet
 [2] https://github.com/kubernetes-sigs/kubeadm-dind-cluster
 EOF

--- a/deploy/demo.sh
+++ b/deploy/demo.sh
@@ -5,11 +5,12 @@ set -o nounset
 set -o pipefail
 set -o errtrace
 
+KUBE_VERSION="${KUBE_VERSION:-1.11}"
 CRIPROXY_DEB_URL="${CRIPROXY_DEB_URL:-https://github.com/Mirantis/criproxy/releases/download/v0.12.0/criproxy-nodeps_0.12.0_amd64.deb}"
 NONINTERACTIVE="${NONINTERACTIVE:-}"
 NO_VM_CONSOLE="${NO_VM_CONSOLE:-}"
 INJECT_LOCAL_IMAGE="${INJECT_LOCAL_IMAGE:-}"
-dind_script="dind-cluster-v1.11.sh"
+dind_script="dind-cluster-v${KUBE_VERSION}.sh"
 kubectl="${HOME}/.kubeadm-dind-cluster/kubectl"
 BASE_LOCATION="${BASE_LOCATION:-https://raw.githubusercontent.com/Mirantis/virtlet/master/}"
 RELEASE_LOCATION="${RELEASE_LOCATION:-https://github.com/Mirantis/virtlet/releases/download/}"
@@ -130,7 +131,7 @@ function demo::start-dind-cluster {
   if [[ ! ${NONINTERACTIVE} ]]; then
     echo "Cirros ssh connection will be open after Virtlet setup is complete, press Ctrl-D to disconnect." >&2
   fi
-  echo "To clean up the cluster, use './dind-cluster-v1.11.sh clean'" >&2
+  echo "To clean up the cluster, use './dind-cluster-v${KUBE_VERSION}.sh clean'" >&2
   demo::ask-before-continuing
   "./${dind_script}" clean
   "./${dind_script}" up
@@ -390,7 +391,7 @@ can be used to disconnect from it.
 Use 'curl http://nginx.default.svc.cluster.local' from VM console to test
 cluster networking.
 
-To clean up the cluster, use './dind-cluster-v1.11.sh clean'
+To clean up the cluster, use './dind-cluster-v${KUBE_VERSION}.sh clean'
 [1] https://github.com/Mirantis/virtlet
 [2] https://github.com/kubernetes-sigs/kubeadm-dind-cluster
 EOF

--- a/pkg/manager/TestCRIMounts.out.yaml
+++ b/pkg/manager/TestCRIMounts.out.yaml
@@ -220,7 +220,7 @@
         io.kubernetes.pod.name: testName_0
         io.kubernetes.pod.namespace: default
         io.kubernetes.pod.uid: 69eec606-0493-5825-73a4-c5e0c0236155
-      log_path: container-for-testName_0_0.log
+      log_path: /var/log/test_log_directory/container-for-testName_0_0.log
       metadata:
         name: container-for-testName_0
       mounts:

--- a/pkg/manager/TestCRIPods.out.yaml
+++ b/pkg/manager/TestCRIPods.out.yaml
@@ -250,7 +250,7 @@
         io.kubernetes.pod.name: testName_0
         io.kubernetes.pod.namespace: default
         io.kubernetes.pod.uid: 69eec606-0493-5825-73a4-c5e0c0236155
-      log_path: container-for-testName_0_0.log
+      log_path: /var/log/test_log_directory/container-for-testName_0_0.log
       metadata:
         name: container-for-testName_0
 - name: 'enter: StartContainer'
@@ -296,7 +296,7 @@
         io.kubernetes.pod.name: testName_0
         io.kubernetes.pod.namespace: default
         io.kubernetes.pod.uid: 69eec606-0493-5825-73a4-c5e0c0236155
-      log_path: container-for-testName_0_0.log
+      log_path: /var/log/test_log_directory/container-for-testName_0_0.log
       metadata:
         name: container-for-testName_0
       started_at: 1524648266720331175
@@ -541,7 +541,7 @@
         io.kubernetes.pod.name: testName_1
         io.kubernetes.pod.namespace: default
         io.kubernetes.pod.uid: d25ded14-d35d-510b-5749-f83cc165794e
-      log_path: container-for-testName_1_0.log
+      log_path: /var/log/test_log_directory/container-for-testName_1_0.log
       metadata:
         name: container-for-testName_1
 - name: 'enter: StartContainer'
@@ -587,7 +587,7 @@
         io.kubernetes.pod.name: testName_1
         io.kubernetes.pod.namespace: default
         io.kubernetes.pod.uid: d25ded14-d35d-510b-5749-f83cc165794e
-      log_path: container-for-testName_1_0.log
+      log_path: /var/log/test_log_directory/container-for-testName_1_0.log
       metadata:
         name: container-for-testName_1
       started_at: 1524648266720331175
@@ -675,7 +675,7 @@
         io.kubernetes.pod.name: testName_0
         io.kubernetes.pod.namespace: default
         io.kubernetes.pod.uid: 69eec606-0493-5825-73a4-c5e0c0236155
-      log_path: container-for-testName_0_0.log
+      log_path: /var/log/test_log_directory/container-for-testName_0_0.log
       metadata:
         name: container-for-testName_0
       started_at: 1524648266720331175

--- a/pkg/manager/cri.go
+++ b/pkg/manager/cri.go
@@ -19,6 +19,7 @@ package manager
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 
 	kubeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
@@ -227,7 +228,7 @@ func ContainerInfoToCRIContainerStatus(in *types.ContainerInfo) *kubeapi.Contain
 		Labels:      in.Config.ContainerLabels,
 		Annotations: in.Config.ContainerAnnotations,
 		Mounts:      mounts,
-		LogPath:     in.Config.LogPath,
+		LogPath:     filepath.Join(in.Config.LogDirectory, in.Config.LogPath),
 		// TODO: FinishedAt, Reason, Message
 	}
 }

--- a/pkg/tools/TestDiagSonobuoy.out.yaml
+++ b/pkg/tools/TestDiagSonobuoy.out.yaml
@@ -16,8 +16,6 @@ spec:
   selector:
     run: sonobuoy-master
   type: ClusterIP
-status:
-  loadBalancer: {}
 
 ---
 apiVersion: v1

--- a/pkg/tools/TestGenCommand__compat.out.yaml
+++ b/pkg/tools/TestGenCommand__compat.out.yaml
@@ -262,11 +262,6 @@ spec:
           name: virtlet-image-translations
         name: image-name-translations
   updateStrategy: {}
-status:
-  currentNumberScheduled: 0
-  desiredNumberScheduled: 0
-  numberMisscheduled: 0
-  numberReady: 0
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -424,11 +419,6 @@ spec:
     singular: virtletimagemapping
   scope: Namespaced
   version: v1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -502,9 +492,4 @@ spec:
             priority:
               type: integer
   version: v1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
 

--- a/pkg/tools/TestGenCommand__compat_dev.out.yaml
+++ b/pkg/tools/TestGenCommand__compat_dev.out.yaml
@@ -273,11 +273,6 @@ spec:
           path: /dind
         name: dind
   updateStrategy: {}
-status:
-  currentNumberScheduled: 0
-  desiredNumberScheduled: 0
-  numberMisscheduled: 0
-  numberReady: 0
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -435,11 +430,6 @@ spec:
     singular: virtletimagemapping
   scope: Namespaced
   version: v1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -513,9 +503,4 @@ spec:
             priority:
               type: integer
   version: v1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
 

--- a/pkg/tools/TestGenCommand__crd.out.yaml
+++ b/pkg/tools/TestGenCommand__crd.out.yaml
@@ -16,11 +16,6 @@ spec:
     singular: virtletimagemapping
   scope: Namespaced
   version: v1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -94,9 +89,4 @@ spec:
             priority:
               type: integer
   version: v1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
 

--- a/pkg/tools/TestGenCommand__dev.out.yaml
+++ b/pkg/tools/TestGenCommand__dev.out.yaml
@@ -277,11 +277,6 @@ spec:
           path: /dind
         name: dind
   updateStrategy: {}
-status:
-  currentNumberScheduled: 0
-  desiredNumberScheduled: 0
-  numberMisscheduled: 0
-  numberReady: 0
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -439,11 +434,6 @@ spec:
     singular: virtletimagemapping
   scope: Namespaced
   version: v1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -517,9 +507,4 @@ spec:
             priority:
               type: integer
   version: v1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
 

--- a/pkg/tools/TestGenCommand__plain.out.yaml
+++ b/pkg/tools/TestGenCommand__plain.out.yaml
@@ -266,11 +266,6 @@ spec:
           name: virtlet-image-translations
         name: image-name-translations
   updateStrategy: {}
-status:
-  currentNumberScheduled: 0
-  desiredNumberScheduled: 0
-  numberMisscheduled: 0
-  numberReady: 0
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -428,11 +423,6 @@ spec:
     singular: virtletimagemapping
   scope: Namespaced
   version: v1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -506,9 +496,4 @@ spec:
             priority:
               type: integer
   version: v1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
 

--- a/pkg/tools/TestGenCommand__tag.out.yaml
+++ b/pkg/tools/TestGenCommand__tag.out.yaml
@@ -266,11 +266,6 @@ spec:
           name: virtlet-image-translations
         name: image-name-translations
   updateStrategy: {}
-status:
-  currentNumberScheduled: 0
-  desiredNumberScheduled: 0
-  numberMisscheduled: 0
-  numberReady: 0
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -428,11 +423,6 @@ spec:
     singular: virtletimagemapping
   scope: Namespaced
   version: v1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -506,9 +496,4 @@ spec:
             priority:
               type: integer
   version: v1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
 

--- a/pkg/tools/TestLoadStoreYaml.out.yaml
+++ b/pkg/tools/TestLoadStoreYaml.out.yaml
@@ -17,5 +17,4 @@ spec:
   - image: docker.io/busybox
     name: tst
     resources: {}
-status: {}
 


### PR DESCRIPTION
- [x] fix log directory handling
- [x] bump CRI Proxy to a version that supports k8s 1.8 .. 1.11
- [x] update tests to use k8s 1.11
- [x] fix missing CRD fields and reenable validation in `demo.sh` and `cmd.sh`
- [x] add CircleCI jobs for 1.9 and 1.10

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/724)
<!-- Reviewable:end -->
