### PR TITLE
log level: It should be a error log instead of info.

### DIFF
--- a/pkg/manager/grpc.go
+++ b/pkg/manager/grpc.go
@@ -112,7 +112,7 @@ func intercept(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo,
 	case err != nil && !bool(glog.V(criErrorLogLevel)):
 		// do nothing
 	case err != nil:
-		glog.Infof("FAIL: %s(): %v", info.FullMethod, err)
+		glog.Errorf("FAIL: %s(): %v", info.FullMethod, err)
 	case bool(glog.V(logLevel)):
 		glog.Infof("LEAVE: %s()\n%s", info.FullMethod, dump(resp))
 	}


### PR DESCRIPTION
What this PR does / why we need it:
the function of intercept in file pkg/manager/grpc.go has a condition when invoke handler(crx, req) has a error result, which lead to a log, but the log level is info. It's my suggestion that it should use error log instead of info log. what do you think about?

Which issue(s) this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #NONE issue

Special notes for your reviewer:
NONE
Release note:
NONE

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/737)
<!-- Reviewable:end -->
