### PR TITLE
CRI metrics - runtime part

### DIFF
--- a/pkg/image/fake/store.go
+++ b/pkg/image/fake/store.go
@@ -25,6 +25,7 @@ import (
 	digest "github.com/opencontainers/go-digest"
 
 	"github.com/Mirantis/virtlet/pkg/image"
+	"github.com/Mirantis/virtlet/pkg/metadata/types"
 	testutils "github.com/Mirantis/virtlet/pkg/utils/testing"
 )
 
@@ -133,8 +134,8 @@ func (s *FakeStore) SetRefGetter(imageRefGetter image.RefGetter) {
 }
 
 // FilesystemStats implements FilesystemStats method from Store interface.
-func (s *FakeStore) FilesystemStats() (*image.FilesystemStats, error) {
-	return &image.FilesystemStats{
+func (s *FakeStore) FilesystemStats() (*types.FilesystemStats, error) {
+	return &types.FilesystemStats{
 		Mountpoint: fakeStoreMountpoint,
 		UsedBytes:  fakeUsedBytes,
 		UsedInodes: fakeUsedInodes,

--- a/pkg/image/fake/store.go
+++ b/pkg/image/fake/store.go
@@ -141,3 +141,8 @@ func (s *FakeStore) FilesystemStats() (*types.FilesystemStats, error) {
 		UsedInodes: fakeUsedInodes,
 	}, nil
 }
+
+// BytesUsedBy implements BytesUsedBy method from Store interface.
+func (s *FakeStore) BytesUsedBy(path string) (uint64, error) {
+	return fakeUsedBytes, nil
+}

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -92,6 +92,9 @@ type Store interface {
 
 	// FilesystemStats returns disk space and inode usage info for this store.
 	FilesystemStats() (*types.FilesystemStats, error)
+
+	// BytesUsedBy returns disk usage of the file in this store.
+	BytesUsedBy(path string) (uint64, error)
 }
 
 // VirtualSizeFunc specifies a function that returns the virtual
@@ -602,4 +605,13 @@ func (s *FileStore) FilesystemStats() (*types.FilesystemStats, error) {
 		UsedBytes:  occupiedBytes,
 		UsedInodes: occupiedInodes,
 	}, nil
+}
+
+// BytesUsedBy return disk usage of provided file as seen in store
+func (s *FileStore) BytesUsedBy(path string) (uint64, error) {
+	fstat, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+	return uint64(fstat.Size()), nil
 }

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -30,6 +30,7 @@ import (
 	"github.com/golang/glog"
 	digest "github.com/opencontainers/go-digest"
 
+	"github.com/Mirantis/virtlet/pkg/metadata/types"
 	"github.com/Mirantis/virtlet/pkg/utils"
 )
 
@@ -56,17 +57,6 @@ type Translator func(context.Context, string) Endpoint
 // RefGetter is a function that returns the list of images
 // that are currently in use.
 type RefGetter func() (map[string]bool, error)
-
-// FilesystemStats contains info about filesystem mountpoint and
-// space/inodes used by images on it
-type FilesystemStats struct {
-	// Mountpoint denotes the filesystem mount point
-	Mountpoint string
-	// UsedBytes is the number of bytes used by images
-	UsedBytes uint64
-	// UsedInodes is the number of inodes used by images
-	UsedInodes uint64
-}
 
 // Store is an interface for the image store.
 type Store interface {
@@ -101,7 +91,7 @@ type Store interface {
 	SetRefGetter(imageRefGetter RefGetter)
 
 	// FilesystemStats returns disk space and inode usage info for this store.
-	FilesystemStats() (*FilesystemStats, error)
+	FilesystemStats() (*types.FilesystemStats, error)
 }
 
 // VirtualSizeFunc specifies a function that returns the virtual
@@ -594,7 +584,7 @@ func GetHexDigest(imageSpec string) string {
 // TODO: instead of returning data from filesystem we should retrieve from
 // metadata store sizes of images and sum them, or even retrieve precalculated
 // sum. That's because same filesystem could be used by other things than images.
-func (s *FileStore) FilesystemStats() (*FilesystemStats, error) {
+func (s *FileStore) FilesystemStats() (*types.FilesystemStats, error) {
 	occupiedBytes, occupiedInodes, err := utils.GetFsStatsForPath(s.dir)
 	if err != nil {
 		return nil, err
@@ -607,7 +597,7 @@ func (s *FileStore) FilesystemStats() (*FilesystemStats, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &FilesystemStats{
+	return &types.FilesystemStats{
 		Mountpoint: mount.FSRoot,
 		UsedBytes:  occupiedBytes,
 		UsedInodes: occupiedInodes,

--- a/pkg/libvirttools/libvirt_domain.go
+++ b/pkg/libvirttools/libvirt_domain.go
@@ -235,10 +235,10 @@ func (domain *libvirtDomain) GetCPUTime() (uint64, error) {
 	if len(stats) != 1 {
 		return 0, fmt.Errorf("domain.GetCPUStats returned %d values while single one was expected", len(stats))
 	}
-	if !stats[0].VcpuTimeSet {
-		return 0, fmt.Errorf("domain.VcpuTime not found in memory stats")
+	if !stats[0].CpuTimeSet {
+		return 0, fmt.Errorf("domain.CpuTime not found in memory stats")
 	}
-	return stats[0].VcpuTime, nil
+	return stats[0].CpuTime, nil
 }
 
 type libvirtSecret struct {

--- a/pkg/libvirttools/root_volumesource_test.go
+++ b/pkg/libvirttools/root_volumesource_test.go
@@ -30,8 +30,10 @@ import (
 )
 
 const (
-	testUUID             = "77f29a0e-46af-4188-a6af-9ff8b8a65224"
-	fakeImageVirtualSize = 424242
+	testUUID                 = "77f29a0e-46af-4188-a6af-9ff8b8a65224"
+	fakeImageVirtualSize     = 424242
+	fakeImageStoreUsedBytes  = 424242
+	fakeImageStoreUsedInodes = 424242
 )
 
 type FakeImageManager struct {
@@ -49,6 +51,14 @@ func NewFakeImageManager(rec testutils.Recorder) *FakeImageManager {
 func (im *FakeImageManager) GetImagePathAndVirtualSize(imageName string) (string, uint64, error) {
 	im.rec.Rec("GetImagePathAndVirtualSize", imageName)
 	return "/fake/volume/path", fakeImageVirtualSize, nil
+}
+
+func (im *FakeImageManager) FilesystemStats() (*types.FilesystemStats, error) {
+	return &types.FilesystemStats{
+		Mountpoint: "/some/dir",
+		UsedBytes:  fakeImageStoreUsedBytes,
+		UsedInodes: fakeImageStoreUsedInodes,
+	}, nil
 }
 
 func TestRootVolumeNaming(t *testing.T) {

--- a/pkg/libvirttools/root_volumesource_test.go
+++ b/pkg/libvirttools/root_volumesource_test.go
@@ -61,6 +61,11 @@ func (im *FakeImageManager) FilesystemStats() (*types.FilesystemStats, error) {
 	}, nil
 }
 
+func (im *FakeImageManager) BytesUsedBy(path string) (uint64, error) {
+	im.rec.Rec("BytesUsedBy", path)
+	return fakeImageVirtualSize, nil
+}
+
 func TestRootVolumeNaming(t *testing.T) {
 	v := rootVolume{
 		volumeBase{

--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -809,6 +809,31 @@ func (v *VirtualizationTool) ContainerInfo(containerID string) (*types.Container
 	return containerInfo, nil
 }
 
+// VMStats returns current cpu/memory/disk usage for VM
+func (v *VirtualizationTool) VMStats(containerID string) (*types.VMStats, error) {
+	domain, err := v.domainConn.LookupDomainByUUIDString(containerID)
+	if err != nil {
+		return nil, err
+	}
+	vs := types.VMStats{
+		Timestamp: time.Now().UnixNano(),
+	}
+	if rss, err := domain.GetRSS(); err != nil {
+		return nil, err
+	} else {
+		vs.MemoryUsage = rss
+	}
+	if cpuTime, err := domain.GetCPUTime(); err != nil {
+		return nil, err
+	} else {
+		vs.CpuUsage = cpuTime
+	}
+	// TODO: find image created by rootfs provider, stat it and fill there
+	// used by it bytes/inodes. Additionally mountpoint of fs on which
+	// root volume is located should be found and filled there
+	return &vs, nil
+}
+
 // volumeOwner implementation follows
 
 // StoragePool returns StoragePool for volumes

--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -858,6 +858,8 @@ func (v *VirtualizationTool) VMStats(containerID string, name string) (*types.VM
 	}
 	vs.FsBytes = rootDiskSize
 
+	glog.V(4).Infof("VMStats - cpu: %d, mem: %d, disk: %d, timestamp: %d", vs.CpuUsage, vs.MemoryUsage, vs.FsBytes, vs.Timestamp)
+
 	return &vs, nil
 }
 

--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -841,6 +841,9 @@ func (v *VirtualizationTool) VMStats(containerID string, name string) (*types.VM
 
 	rootDiskLocation := ""
 	for _, disk := range domainxml.Devices.Disks {
+		if disk.Source == nil || disk.Source.File == nil {
+			continue
+		}
 		fname := disk.Source.File.File
 		// TODO: split file name and use HasPrefix on last part
 		// instead of Contains

--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -812,7 +812,7 @@ func (v *VirtualizationTool) ContainerInfo(containerID string) (*types.Container
 }
 
 // VMStats returns current cpu/memory/disk usage for VM
-func (v *VirtualizationTool) VMStats(containerID string) (*types.VMStats, error) {
+func (v *VirtualizationTool) VMStats(containerID string, name string) (*types.VMStats, error) {
 	domain, err := v.domainConn.LookupDomainByUUIDString(containerID)
 	if err != nil {
 		return nil, err
@@ -820,6 +820,7 @@ func (v *VirtualizationTool) VMStats(containerID string) (*types.VMStats, error)
 	vs := types.VMStats{
 		Timestamp:   time.Now().UnixNano(),
 		ContainerID: containerID,
+		Name:        name,
 	}
 
 	rss, err := domain.GetRSS()
@@ -885,7 +886,7 @@ func (v *VirtualizationTool) ListVMStats(filter *types.VMStatsFilter) ([]types.V
 
 	var statsList []types.VMStats
 	for _, info := range infos {
-		stats, err := v.VMStats(info.Id)
+		stats, err := v.VMStats(info.Id, info.Name)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -819,16 +819,19 @@ func (v *VirtualizationTool) VMStats(containerID string) (*types.VMStats, error)
 		Timestamp:   time.Now().UnixNano(),
 		ContainerID: containerID,
 	}
-	if rss, err := domain.GetRSS(); err != nil {
+
+	rss, err := domain.GetRSS()
+	if err != nil {
 		return nil, err
-	} else {
-		vs.MemoryUsage = rss
 	}
-	if cpuTime, err := domain.GetCPUTime(); err != nil {
+	vs.MemoryUsage = rss
+
+	cpuTime, err := domain.GetCPUTime()
+	if err != nil {
 		return nil, err
-	} else {
-		vs.CpuUsage = cpuTime
 	}
+	vs.CpuUsage = cpuTime
+
 	// TODO: find image created by rootfs provider, stat it and fill there
 	// used by it bytes/inodes. Additionally mountpoint of fs on which
 	// root volume is located should be found and filled there
@@ -859,11 +862,11 @@ func (v *VirtualizationTool) ListVMStats(filter *types.VMStatsFilter) ([]types.V
 
 	var statsList []types.VMStats
 	for _, info := range infos {
-		if stats, err := v.VMStats(info.Id); err != nil {
+		stats, err := v.VMStats(info.Id)
+		if err != nil {
 			return nil, err
-		} else {
-			statsList = append(statsList, *stats)
 		}
+		statsList = append(statsList, *stats)
 	}
 	return statsList, nil
 }

--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -18,7 +18,6 @@ package libvirttools
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -818,7 +817,7 @@ func (v *VirtualizationTool) VMStats(containerID string, name string) (*types.VM
 		return nil, err
 	}
 	vs := types.VMStats{
-		Timestamp:   time.Now().UnixNano(),
+		Timestamp:   v.clock.Now().UnixNano(),
 		ContainerID: containerID,
 		Name:        name,
 	}
@@ -853,11 +852,11 @@ func (v *VirtualizationTool) VMStats(containerID string, name string) (*types.VM
 		return nil, fmt.Errorf("cannot locate root disk in domain definition")
 	}
 
-	fstat, err := os.Stat(rootDiskLocation)
+	rootDiskSize, err := v.ImageManager().BytesUsedBy(rootDiskLocation)
 	if err != nil {
 		return nil, err
 	}
-	vs.FsBytes = uint64(fstat.Size())
+	vs.FsBytes = rootDiskSize
 
 	return &vs, nil
 }

--- a/pkg/libvirttools/volumes.go
+++ b/pkg/libvirttools/volumes.go
@@ -28,6 +28,7 @@ import (
 type ImageManager interface {
 	GetImagePathAndVirtualSize(ref string) (string, uint64, error)
 	FilesystemStats() (*types.FilesystemStats, error)
+	BytesUsedBy(path string) (uint64, error)
 }
 
 type volumeOwner interface {

--- a/pkg/libvirttools/volumes.go
+++ b/pkg/libvirttools/volumes.go
@@ -27,6 +27,7 @@ import (
 // ImageManager describes a images info provider.
 type ImageManager interface {
 	GetImagePathAndVirtualSize(ref string) (string, uint64, error)
+	FilesystemStats() (*types.FilesystemStats, error)
 }
 
 type volumeOwner interface {

--- a/pkg/manager/TestCRIPods.out.yaml
+++ b/pkg/manager/TestCRIPods.out.yaml
@@ -301,6 +301,56 @@
         name: container-for-testName_0
       started_at: 1524648266720331175
       state: 1
+- name: 'enter: ContainerStats'
+  value:
+    container_id: 231700d5-c9a6-5a49-738d-99a954c51550
+- name: 'leave: ContainerStats'
+  value:
+    stats:
+      attributes:
+        id: 231700d5-c9a6-5a49-738d-99a954c51550
+        metadata:
+          name: 231700d5-c9a6-5a49-738d-99a954c51550
+      cpu:
+        timestamp: 1524648266720331175
+        usage_core_nano_seconds: {}
+      memory:
+        timestamp: 1524648266720331175
+        working_set_bytes: {}
+      writable_layer:
+        fs_id:
+          mountpoint: /var/lib/virtlet
+        inodes_used:
+          value: 1
+        timestamp: 1524648266720331175
+        used_bytes:
+          value: 1073741824
+- name: 'enter: ListContainerStats'
+  value: {}
+- name: 'domain conn: ListDomains'
+  value:
+  - virtlet-231700d5-c9a6-container-for-testName_0
+- name: 'leave: ListContainerStats'
+  value:
+    stats:
+    - attributes:
+        id: 231700d5-c9a6-5a49-738d-99a954c51550
+        metadata:
+          name: 231700d5-c9a6-5a49-738d-99a954c51550
+      cpu:
+        timestamp: 1524648266720331175
+        usage_core_nano_seconds: {}
+      memory:
+        timestamp: 1524648266720331175
+        working_set_bytes: {}
+      writable_layer:
+        fs_id:
+          mountpoint: /var/lib/virtlet
+        inodes_used:
+          value: 1
+        timestamp: 1524648266720331175
+        used_bytes:
+          value: 1073741824
 - name: 'enter: PullImage'
   value:
     image:

--- a/pkg/manager/TestContainerListStats.out.yaml
+++ b/pkg/manager/TestContainerListStats.out.yaml
@@ -1,0 +1,117 @@
+- name: 'enter: ListContainerStats'
+  value: {}
+- name: 'leave: ListContainerStats'
+  value:
+    stats:
+    - attributes:
+        id: 231700d5-c9a6-5a49-738d-99a954c51550
+        metadata:
+          name: 231700d5-c9a6-5a49-738d-99a954c51550
+      cpu:
+        timestamp: 1524648266720331175
+        usage_core_nano_seconds: {}
+      memory:
+        timestamp: 1524648266720331175
+        working_set_bytes: {}
+      writable_layer:
+        fs_id:
+          mountpoint: /var/lib/virtlet
+        inodes_used:
+          value: 1
+        timestamp: 1524648266720331175
+        used_bytes:
+          value: 1073741824
+    - attributes:
+        id: 6b94d9a7-e22a-5d08-65ee-16b9b1e07ab0
+        metadata:
+          name: 6b94d9a7-e22a-5d08-65ee-16b9b1e07ab0
+      cpu:
+        timestamp: 1524648266720331175
+        usage_core_nano_seconds: {}
+      memory:
+        timestamp: 1524648266720331175
+        working_set_bytes: {}
+      writable_layer:
+        fs_id:
+          mountpoint: /var/lib/virtlet
+        inodes_used:
+          value: 1
+        timestamp: 1524648266720331175
+        used_bytes:
+          value: 1073741824
+- name: 'enter: ListContainerStats'
+  value:
+    filter:
+      id: 231700d5-c9a6-5a49-738d-99a954c51550
+- name: 'leave: ListContainerStats'
+  value:
+    stats:
+    - attributes:
+        id: 231700d5-c9a6-5a49-738d-99a954c51550
+        metadata:
+          name: 231700d5-c9a6-5a49-738d-99a954c51550
+      cpu:
+        timestamp: 1524648266720331175
+        usage_core_nano_seconds: {}
+      memory:
+        timestamp: 1524648266720331175
+        working_set_bytes: {}
+      writable_layer:
+        fs_id:
+          mountpoint: /var/lib/virtlet
+        inodes_used:
+          value: 1
+        timestamp: 1524648266720331175
+        used_bytes:
+          value: 1073741824
+- name: 'enter: ListContainerStats'
+  value:
+    filter:
+      label_selector:
+        io.kubernetes.pod.name: testName_1
+- name: 'leave: ListContainerStats'
+  value:
+    stats:
+    - attributes:
+        id: 6b94d9a7-e22a-5d08-65ee-16b9b1e07ab0
+        metadata:
+          name: 6b94d9a7-e22a-5d08-65ee-16b9b1e07ab0
+      cpu:
+        timestamp: 1524648266720331175
+        usage_core_nano_seconds: {}
+      memory:
+        timestamp: 1524648266720331175
+        working_set_bytes: {}
+      writable_layer:
+        fs_id:
+          mountpoint: /var/lib/virtlet
+        inodes_used:
+          value: 1
+        timestamp: 1524648266720331175
+        used_bytes:
+          value: 1073741824
+- name: 'enter: ListContainerStats'
+  value:
+    filter:
+      pod_sandbox_id: 69eec606-0493-5825-73a4-c5e0c0236155
+- name: 'leave: ListContainerStats'
+  value:
+    stats:
+    - attributes:
+        id: 231700d5-c9a6-5a49-738d-99a954c51550
+        metadata:
+          name: 231700d5-c9a6-5a49-738d-99a954c51550
+      cpu:
+        timestamp: 1524648266720331175
+        usage_core_nano_seconds: {}
+      memory:
+        timestamp: 1524648266720331175
+        working_set_bytes: {}
+      writable_layer:
+        fs_id:
+          mountpoint: /var/lib/virtlet
+        inodes_used:
+          value: 1
+        timestamp: 1524648266720331175
+        used_bytes:
+          value: 1073741824

--- a/pkg/manager/cri.go
+++ b/pkg/manager/cri.go
@@ -198,7 +198,7 @@ func CRIContainerStatsFilterToVMStatsFilter(in *kubeapi.ContainerStatsFilter) *t
 		return nil
 	}
 	return &types.VMStatsFilter{
-		Id:            in.ID,
+		Id:            in.Id,
 		PodSandboxID:  in.PodSandboxId,
 		LabelSelector: in.LabelSelector,
 	}

--- a/pkg/manager/cri.go
+++ b/pkg/manager/cri.go
@@ -192,6 +192,18 @@ func CRIContainerFilterToContainerFilter(in *kubeapi.ContainerFilter) *types.Con
 	}
 }
 
+// CRIContainerStatsFilterToVMStatsFilter converts CRI ContainerStatsFilter to VMStatsFilter.
+func CRIContainerStatsFilterToVMStatsFilter(in *kubeapi.ContainerStatsFilter) *types.VMStatsFilter {
+	if in == nil {
+		return nil
+	}
+	return &types.VMStatsFilter{
+		Id:            in.ID,
+		PodSandboxID:  in.PodSandboxId,
+		LabelSelector: in.LabelSelector,
+	}
+}
+
 func containerMetadata(in *types.ContainerInfo) *kubeapi.ContainerMetadata {
 	return &kubeapi.ContainerMetadata{
 		Name:    in.Name,

--- a/pkg/manager/runtime.go
+++ b/pkg/manager/runtime.go
@@ -463,27 +463,7 @@ func (v *VirtletRuntimeService) ContainerStats(ctx context.Context, in *kubeapi.
 		return nil, err
 	}
 	return &kubeapi.ContainerStatsResponse{
-		Stats: &kubeapi.ContainerStats{
-			Attributes: &kubeapi.ContainerAttributes{
-				Id: in.ContainerId,
-			},
-			Cpu: &kubeapi.CpuUsage{
-				Timestamp:            vs.Timestamp,
-				UsageCoreNanoSeconds: &kubeapi.UInt64Value{Value: vs.CpuUsage},
-			},
-			Memory: &kubeapi.MemoryUsage{
-				Timestamp:       vs.Timestamp,
-				WorkingSetBytes: &kubeapi.UInt64Value{Value: vs.MemoryUsage},
-			},
-			WritableLayer: &kubeapi.FilesystemUsage{
-				Timestamp: vs.Timestamp,
-				FsId: &kubeapi.FilesystemIdentifier{
-					Mountpoint: vs.Mountpoint,
-				},
-				UsedBytes:  &kubeapi.UInt64Value{Value: vs.FsBytes},
-				InodesUsed: &kubeapi.UInt64Value{Value: vs.FsInodes},
-			},
-		},
+		Stats: VMStatsToCRIContainerStats(vs),
 	}, nil
 }
 
@@ -497,32 +477,38 @@ func (v *VirtletRuntimeService) ListContainerStats(ctx context.Context, in *kube
 	}
 	var stats []*kubeapi.ContainerStats
 	for _, vs := range vmstatsList {
-		stats = append(stats, &kubeapi.ContainerStats{
-			Attributes: &kubeapi.ContainerAttributes{
-				Id: vs.ContainerID,
-			},
-			Cpu: &kubeapi.CpuUsage{
-				Timestamp:            vs.Timestamp,
-				UsageCoreNanoSeconds: &kubeapi.UInt64Value{Value: vs.CpuUsage},
-			},
-			Memory: &kubeapi.MemoryUsage{
-				Timestamp:       vs.Timestamp,
-				WorkingSetBytes: &kubeapi.UInt64Value{Value: vs.MemoryUsage},
-			},
-			WritableLayer: &kubeapi.FilesystemUsage{
-				Timestamp: vs.Timestamp,
-				FsId: &kubeapi.FilesystemIdentifier{
-					Mountpoint: vs.Mountpoint,
-				},
-				UsedBytes:  &kubeapi.UInt64Value{Value: vs.FsBytes},
-				InodesUsed: &kubeapi.UInt64Value{Value: vs.FsInodes},
-			},
-		})
+		stats = append(stats, VMStatsToCRIContainerStats(vs))
 	}
 
 	return &kubeapi.ListContainerStatsResponse{
 		Stats: stats,
 	}, nil
+}
+
+// VMStatsToCRIContainerStats converts internal representation of vm/container stats
+// to corresponding kubeapi type object
+func VMStatsToCRIContainerStats(vs types.VMStats) *kubeapi.ContainerStats {
+	return &kubeapi.ContainerStats{
+		Attributes: &kubeapi.ContainerAttributes{
+			Id: vs.ContainerID,
+		},
+		Cpu: &kubeapi.CpuUsage{
+			Timestamp:            vs.Timestamp,
+			UsageCoreNanoSeconds: &kubeapi.UInt64Value{Value: vs.CpuUsage},
+		},
+		Memory: &kubeapi.MemoryUsage{
+			Timestamp:       vs.Timestamp,
+			WorkingSetBytes: &kubeapi.UInt64Value{Value: vs.MemoryUsage},
+		},
+		WritableLayer: &kubeapi.FilesystemUsage{
+			Timestamp: vs.Timestamp,
+			FsId: &kubeapi.FilesystemIdentifier{
+				Mountpoint: vs.Mountpoint,
+			},
+			UsedBytes:  &kubeapi.UInt64Value{Value: vs.FsBytes},
+			InodesUsed: &kubeapi.UInt64Value{Value: vs.FsInodes},
+		},
+	}
 }
 
 // ReopenContainerLog is a placeholder for an unimplemented CRI method.

--- a/pkg/manager/runtime.go
+++ b/pkg/manager/runtime.go
@@ -520,9 +520,9 @@ func (v *VirtletRuntimeService) ListContainerStats(ctx context.Context, in *kube
 		})
 	}
 
-	return nil, &kubeapi.ListContainerStatsResponse{
+	return &kubeapi.ListContainerStatsResponse{
 		Stats: stats,
-	}
+	}, nil
 }
 
 // ReopenContainerLog is a placeholder for an unimplemented CRI method.

--- a/pkg/manager/runtime.go
+++ b/pkg/manager/runtime.go
@@ -458,7 +458,11 @@ func (v *VirtletRuntimeService) Status(context.Context, *kubeapi.StatusRequest) 
 
 // ContainerStats returns cpu/memory/disk usage for particular container id
 func (v *VirtletRuntimeService) ContainerStats(ctx context.Context, in *kubeapi.ContainerStatsRequest) (*kubeapi.ContainerStatsResponse, error) {
-	vs, err := v.virtTool.VMStats(in.ContainerId)
+	info, err := v.virtTool.ContainerInfo(in.ContainerId)
+	if err != nil {
+		return nil, err
+	}
+	vs, err := v.virtTool.VMStats(info.Id, info.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -499,6 +503,9 @@ func VMStatsToCRIContainerStats(vs types.VMStats, mountpoint string) *kubeapi.Co
 	return &kubeapi.ContainerStats{
 		Attributes: &kubeapi.ContainerAttributes{
 			Id: vs.ContainerID,
+			Metadata: &kubeapi.ContainerMetadata{
+				Name: vs.ContainerID,
+			},
 		},
 		Cpu: &kubeapi.CpuUsage{
 			Timestamp:            vs.Timestamp,

--- a/pkg/manager/runtime.go
+++ b/pkg/manager/runtime.go
@@ -456,9 +456,35 @@ func (v *VirtletRuntimeService) Status(context.Context, *kubeapi.StatusRequest) 
 	}, nil
 }
 
-// ContainerStats is a placeholder for an unimplemented CRI method.
+// ContainerStats returns cpu/memory/disk usage for particular container id
 func (v *VirtletRuntimeService) ContainerStats(ctx context.Context, in *kubeapi.ContainerStatsRequest) (*kubeapi.ContainerStatsResponse, error) {
-	return nil, errors.New("ContainerStats() not implemented")
+	vs, err := v.virtTool.VMStats(in.ContainerId)
+	if err != nil {
+		return nil, err
+	}
+	return &kubeapi.ContainerStatsResponse{
+		Stats: &kubeapi.ContainerStats{
+			Attributes: &kubeapi.ContainerAttributes{
+				Id: in.ContainerId,
+			},
+			Cpu: &kubeapi.CpuUsage{
+				Timestamp:            vs.Timestamp,
+				UsageCoreNanoSeconds: &kubeapi.UInt64Value{Value: vs.CpuUsage},
+			},
+			Memory: &kubeapi.MemoryUsage{
+				Timestamp:       vs.Timestamp,
+				WorkingSetBytes: &kubeapi.UInt64Value{Value: vs.MemoryUsage},
+			},
+			WritableLayer: &kubeapi.FilesystemUsage{
+				Timestamp: vs.Timestamp,
+				FsId: &kubeapi.FilesystemIdentifier{
+					Mountpoint: vs.Mountpoint,
+				},
+				UsedBytes:  &kubeapi.UInt64Value{Value: vs.FsBytes},
+				InodesUsed: &kubeapi.UInt64Value{Value: vs.FsInodes},
+			},
+		},
+	}, nil
 }
 
 // ListContainerStats is a placeholder for an unimplemented CRI method.

--- a/pkg/metadata/types/types.go
+++ b/pkg/metadata/types/types.go
@@ -103,13 +103,8 @@ type VMStats struct {
 	// MemoryUsage is expected to contain the amount of working set memory
 	// in bytes what in our case will be returned using RSS value
 	MemoryUsage uint64
-	// Mountpoint on host for filesystem containing the directory in which
-	// rootfs of VM is stored
-	Mountpoint string
 	// FsBytes represents current size of rootfs in bytes
 	FsBytes uint64
-	// FsInodes contains number of inodes used by rootfs image
-	FsInodes uint64
 }
 
 // NamespaceOption provides options for Linux namespaces.
@@ -310,4 +305,15 @@ type VMStatsFilter struct {
 	// LabelSelector to select matches. Requirementes should be ANDed.
 	// Match Expressions is not supported.
 	LabelSelector map[string]string
+}
+
+// FilesystemStats contains info about filesystem mountpoint and
+// space/inodes used by images on it
+type FilesystemStats struct {
+	// Mountpoint denotes the filesystem mount point
+	Mountpoint string
+	// UsedBytes is the number of bytes used by images
+	UsedBytes uint64
+	// UsedInodes is the number of inodes used by images
+	UsedInodes uint64
 }

--- a/pkg/metadata/types/types.go
+++ b/pkg/metadata/types/types.go
@@ -90,6 +90,25 @@ type ContainerInfo struct {
 	Config VMConfig
 }
 
+// VMStats contains cpu/memory/disk usage for VM.
+type VMStats struct {
+	// Timestatmp holds an unix timestamp (including nanoseconds)
+	// for stats collection
+	Timestamp int64
+	// CpuUsage in nano seconds per cpu
+	CpuUsage uint64
+	// MemoryUsage is expected to contain the amount of working set memory
+	// in bytes what in our case will be returned using RSS value
+	MemoryUsage uint64
+	// Mountpoint on host for filesystem containing the directory in which
+	// rootfs of VM is stored
+	Mountpoint string
+	// FsBytes represents current size of rootfs in bytes
+	FsBytes uint64
+	// FsInodes contains number of inodes used by rootfs image
+	FsInodes uint64
+}
+
 // NamespaceOption provides options for Linux namespaces.
 type NamespaceOption struct {
 	// If set, use the host's network namespace.

--- a/pkg/metadata/types/types.go
+++ b/pkg/metadata/types/types.go
@@ -92,6 +92,9 @@ type ContainerInfo struct {
 
 // VMStats contains cpu/memory/disk usage for VM.
 type VMStats struct {
+	// ContainerID holds identifier of container for which these statistics
+	// were collected
+	ContainerID string
 	// Timestatmp holds an unix timestamp (including nanoseconds)
 	// for stats collection
 	Timestamp int64
@@ -294,5 +297,17 @@ type ContainerFilter struct {
 	// LabelSelector to select matches.
 	// Only api.MatchLabels is supported for now and the requirements
 	// are ANDed. MatchExpressions is not supported yet.
+	LabelSelector map[string]string
+}
+
+// VMStatsFilter is used to filter set of container stats
+// All those fields are combined with 'AND'
+type VMStatsFilter struct {
+	// ID holds of the container.
+	Id string
+	// PodSandboxID holds id of podsandbox.
+	PodSandboxID string
+	// LabelSelector to select matches. Requirementes should be ANDed.
+	// Match Expressions is not supported.
 	LabelSelector map[string]string
 }

--- a/pkg/metadata/types/types.go
+++ b/pkg/metadata/types/types.go
@@ -95,6 +95,8 @@ type VMStats struct {
 	// ContainerID holds identifier of container for which these statistics
 	// were collected
 	ContainerID string
+	// Name holds name of the container
+	Name string
 	// Timestatmp holds an unix timestamp (including nanoseconds)
 	// for stats collection
 	Timestamp int64

--- a/pkg/virt/domain_interface.go
+++ b/pkg/virt/domain_interface.go
@@ -105,4 +105,8 @@ type Domain interface {
 	Name() (string, error)
 	// XML retrieves xml definition of the domain
 	XML() (*libvirtxml.Domain, error)
+	// GetRSS returns RSS used by VM in bytes
+	GetRSS() (uint64, error)
+	// GetCPUTime returns cpu time used by VM in nanoseconds per core
+	GetCPUTime() (uint64, error)
 }

--- a/pkg/virt/fake/fake_domain.go
+++ b/pkg/virt/fake/fake_domain.go
@@ -312,6 +312,16 @@ func (d *FakeDomain) XML() (*libvirtxml.Domain, error) {
 	return d.def, nil
 }
 
+// GetCPUTime implements GetCPUTime of Domain interface.
+func (d *FakeDomain) GetCPUTime() (uint64, error) {
+	return 0, nil
+}
+
+// GetRSS implements GetRSS of Domain interface.
+func (d *FakeDomain) GetRSS() (uint64, error) {
+	return 0, nil
+}
+
 // FakeSecret is a fake implementation of Secret interace.
 type FakeSecret struct {
 	rec       testutils.Recorder


### PR DESCRIPTION
TODO:
 - [x] add stats for rootfs filesystem usage of VM
 - [x] add checking for mountpoint of fs on which volumes store is located (that should be included in rootfs stats for each container, but also can be done once per whole filter).

That's final version with additional coverage in `pkg/manager/runtime_test.go`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/743)
<!-- Reviewable:end -->
