### PR TITLE
Fix bad diag result on dotfiles in log dirs

### DIFF
--- a/pkg/diag/diag.go
+++ b/pkg/diag/diag.go
@@ -430,6 +430,9 @@ func (s *LogDirSource) DiagnosticInfo() (Result, error) {
 			continue
 		}
 		name := fi.Name()
+		if strings.HasPrefix(name, ".") {
+			continue
+		}
 		ext := filepath.Ext(name)
 		cur := Result{
 			Name: name,

--- a/pkg/diag/diag_test.go
+++ b/pkg/diag/diag_test.go
@@ -46,8 +46,10 @@ func setupLogDir(t *testing.T, baseDir string) string {
 		t.Fatalf("MkdirAll(): %v", err)
 	}
 	for name, contents := range map[string]string{
-		"log1.txt": "log1 contents",
-		"log2.txt": "log2 contents",
+		"log1.txt":      "log1 contents",
+		"log2.txt":      "log2 contents",
+		".placeholder":  "ignored file",
+		".place.holder": "another ignored file",
 	} {
 		if err := ioutil.WriteFile(filepath.Join(logDir, name), []byte(contents), 0777); err != nil {
 			t.Fatalf("WriteFile(): %v", err)


### PR DESCRIPTION
The diagnostics code was producing a diag.Result that can't be unpacked
when a log directory contained files named like `.placeholder`.

This PR makes virtlet diag ignore dotfiles in log directories (that is libvirt log dir for now)
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/749)
<!-- Reviewable:end -->
