### PR TITLE
delete useless constant "wantTapManagerEnv  = "WANT_TAP_MANAGER"" in virtlet.go

### DIFF
--- a/cmd/virtlet/virtlet.go
+++ b/cmd/virtlet/virtlet.go
@@ -40,7 +40,6 @@ import (
 )
 
 const (
-	wantTapManagerEnv  = "WANT_TAP_MANAGER"
 	nodeNameEnv        = "KUBE_NODE_NAME"
 	diagSocket         = "/run/virtlet-diag.sock"
 	netnsDiagCommand   = `if [ -d /var/run/netns ]; then cd /var/run/netns; for ns in *; do echo "*** ${ns} ***"; ip netns exec "${ns}" ip a; ip netns exec "${ns}" ip r; echo; done; fi`


### PR DESCRIPTION
What this PR does / why we need it:

It looks like it is no use for the constant "wantTapManagerEnv  = "WANT_TAP_MANAGER"" in file "cmd/virtlet/virtlet.go". I suggested it should be deleted. What do you mean?

Which issue(s) this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #NONE issue

Special notes for your reviewer:
NONE
Release note:
NONE

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/754)
<!-- Reviewable:end -->
