### PR TITLE
Use fixed image tag for nginx

### DIFF
--- a/tests/e2e/basic_test.go
+++ b/tests/e2e/basic_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Virtlet [Basic cirros tests]", func() {
 		localExecutor := framework.LocalExecutor(ctx)
 
 		By(fmt.Sprintf("Starting nginx pod"))
-		nginxPod, err := controller.RunPod(podName, "nginx", nil, time.Minute*4, 80)
+		nginxPod, err := controller.RunPod(podName, framework.NginxImage, nil, time.Minute*4, 80)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(nginxPod).NotTo(BeNil())
 
@@ -209,7 +209,7 @@ func itShouldHaveNetworkConnectivity(podIface func() *framework.PodInterface, ss
 		var nginxPod *framework.PodInterface
 
 		BeforeAll(func() {
-			p, err := controller.RunPod("nginx", "nginx", nil, time.Minute*4, 80)
+			p, err := controller.RunPod("nginx", framework.NginxImage, nil, time.Minute*4, 80)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(p).NotTo(BeNil())
 			nginxPod = p

--- a/tests/e2e/framework/common.go
+++ b/tests/e2e/framework/common.go
@@ -24,6 +24,10 @@ import (
 	"time"
 )
 
+const (
+	NginxImage = "nginx:1.14"
+)
+
 // ErrTimeout is the timeout error returned from functions wrapped by WithTimeout
 var ErrTimeout = fmt.Errorf("timeout")
 

--- a/tests/longevity/checks.go
+++ b/tests/longevity/checks.go
@@ -93,7 +93,7 @@ func checkInterPodConnectivity(instance *VMInstance) error {
 
 func startNginxPod(controller *framework.Controller) (*framework.PodInterface, error) {
 	// Create a Pod to test in-cluster network connectivity
-	p, err := controller.RunPod("nginx", "nginx", nil, time.Minute*4, 80)
+	p, err := controller.RunPod("nginx", framework.NginxImage, nil, time.Minute*4, 80)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
1.15 caused breakage in our CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/756)
<!-- Reviewable:end -->
