### PR TITLE
Fix tests on non-linux OSes after 9pfs changes

### DIFF
--- a/pkg/flexvolume/flexvolume.go
+++ b/pkg/flexvolume/flexvolume.go
@@ -46,18 +46,6 @@ func init() {
 	}
 }
 
-type nullMounter struct{}
-
-func (m *nullMounter) Mount(source string, target string, fstype string, flags uintptr) error {
-	return nil
-}
-
-func (m *nullMounter) Unmount(target string, flags int) error {
-	return nil
-}
-
-var NullMounter = &nullMounter{}
-
 type UuidGen func() string
 
 type FlexVolumeDriver struct {
@@ -128,7 +116,7 @@ func (d *FlexVolumeDriver) mount(targetMountDir, jsonOptions string) (map[string
 		return nil, err
 	}
 
-	if err := d.mounter.Mount("tmpfs", targetMountDir, "tmpfs", 0); err != nil {
+	if err := d.mounter.Mount("tmpfs", targetMountDir, "tmpfs", false); err != nil {
 		return nil, fmt.Errorf("error mounting tmpfs at %q: %v", targetMountDir, err)
 	}
 
@@ -136,7 +124,7 @@ func (d *FlexVolumeDriver) mount(targetMountDir, jsonOptions string) (map[string
 	defer func() {
 		// try to unmount upon error or panic
 		if !done {
-			d.mounter.Unmount(targetMountDir, 0)
+			d.mounter.Unmount(targetMountDir, true)
 		}
 	}()
 
@@ -150,7 +138,7 @@ func (d *FlexVolumeDriver) mount(targetMountDir, jsonOptions string) (map[string
 
 // Invocation: <driver executable> unmount <mount dir>
 func (d *FlexVolumeDriver) unmount(targetMountDir string) (map[string]interface{}, error) {
-	if err := d.mounter.Unmount(targetMountDir, 0); err != nil {
+	if err := d.mounter.Unmount(targetMountDir, true); err != nil {
 		return nil, fmt.Errorf("unmount %q: %v", targetMountDir, err.Error())
 	}
 

--- a/pkg/flexvolume/flexvolume_test.go
+++ b/pkg/flexvolume/flexvolume_test.go
@@ -53,9 +53,9 @@ func (mounter *fakeMounter) validatePath(target string) {
 	}
 }
 
-func (mounter *fakeMounter) Mount(source string, target string, fstype string, flags uintptr) error {
+func (mounter *fakeMounter) Mount(source string, target string, fstype string, bind bool) error {
 	mounter.validatePath(target)
-	mounter.journal = append(mounter.journal, fmt.Sprintf("mount: %s %s %s", source, target, fstype))
+	mounter.journal = append(mounter.journal, fmt.Sprintf("mount: %s %s %s %v", source, target, fstype, bind))
 
 	// We want to check directory contents both before & after mount,
 	// see comment in FlexVolumeDriver.mount() in flexvolume.go.
@@ -81,10 +81,10 @@ func (mounter *fakeMounter) Mount(source string, target string, fstype string, f
 	return nil
 }
 
-func (mounter *fakeMounter) Unmount(target string, flags int) error {
+func (mounter *fakeMounter) Unmount(target string, detach bool) error {
 	// we make sure that path is under our tmpdir before wiping it
 	mounter.validatePath(target)
-	mounter.journal = append(mounter.journal, fmt.Sprintf("unmount: %s", target))
+	mounter.journal = append(mounter.journal, fmt.Sprintf("unmount: %s %v", target, detach))
 
 	paths, err := filepath.Glob(filepath.Join(target, "*"))
 	if err != nil {
@@ -186,7 +186,7 @@ func TestFlexVolume(t *testing.T) {
 				},
 			},
 			mountJournal: []string{
-				fmt.Sprintf("mount: tmpfs %s tmpfs", cephDir),
+				fmt.Sprintf("mount: tmpfs %s tmpfs false", cephDir),
 			},
 		},
 		{
@@ -195,7 +195,7 @@ func TestFlexVolume(t *testing.T) {
 			status: "Success",
 			subdir: "ceph",
 			mountJournal: []string{
-				fmt.Sprintf("unmount: %s", cephDir),
+				fmt.Sprintf("unmount: %s true", cephDir),
 			},
 		},
 		{
@@ -210,7 +210,7 @@ func TestFlexVolume(t *testing.T) {
 				},
 			},
 			mountJournal: []string{
-				fmt.Sprintf("mount: tmpfs %s tmpfs", cephDir),
+				fmt.Sprintf("mount: tmpfs %s tmpfs false", cephDir),
 			},
 		},
 		{
@@ -219,7 +219,7 @@ func TestFlexVolume(t *testing.T) {
 			status: "Success",
 			subdir: "ceph",
 			mountJournal: []string{
-				fmt.Sprintf("unmount: %s", cephDir),
+				fmt.Sprintf("unmount: %s true", cephDir),
 			},
 		},
 		{

--- a/pkg/libvirttools/root_volumesource_test.go
+++ b/pkg/libvirttools/root_volumesource_test.go
@@ -22,6 +22,7 @@ import (
 	libvirtxml "github.com/libvirt/libvirt-go-xml"
 
 	"github.com/Mirantis/virtlet/pkg/metadata/types"
+	"github.com/Mirantis/virtlet/pkg/utils"
 	testutils "github.com/Mirantis/virtlet/pkg/utils/testing"
 	"github.com/Mirantis/virtlet/pkg/virt"
 	"github.com/Mirantis/virtlet/pkg/virt/fake"
@@ -220,3 +221,7 @@ func (vo fakeVolumeOwner) RawDevices() []string { return nil }
 func (vo fakeVolumeOwner) KubeletRootDir() string { return "" }
 
 func (vo fakeVolumeOwner) VolumePoolName() string { return "" }
+
+func (vo fakeVolumeOwner) Mounter() utils.Mounter { return utils.NullMounter }
+
+func (vo fakeVolumeOwner) SharedFilesystemPath() string { return "/var/lib/virtlet/fs" }

--- a/pkg/libvirttools/virtualization_test.go
+++ b/pkg/libvirttools/virtualization_test.go
@@ -91,7 +91,7 @@ func newContainerTester(t *testing.T, rec *testutils.TopLevelRecorder) *containe
 		KubeletRootDir:     ct.kubeletRootDir,
 		StreamerSocketPath: "/var/lib/libvirt/streamer.sock",
 	}
-	ct.virtTool = NewVirtualizationTool(ct.domainConn, ct.storageConn, imageManager, ct.metadataStore, GetDefaultVolumeSource(), virtConfig)
+	ct.virtTool = NewVirtualizationTool(ct.domainConn, ct.storageConn, imageManager, ct.metadataStore, GetDefaultVolumeSource(), virtConfig, utils.NullMounter)
 	ct.virtTool.SetClock(ct.clock)
 
 	return ct
@@ -320,7 +320,7 @@ func TestDomainDefinitions(t *testing.T) {
 	flexVolumeDriver := flexvolume.NewFlexVolumeDriver(func() string {
 		// note that this is only good for just one flexvolume
 		return fakeUUID
-	}, flexvolume.NullMounter)
+	}, utils.NullMounter)
 	for _, tc := range []struct {
 		name        string
 		annotations map[string]string

--- a/pkg/libvirttools/volumes.go
+++ b/pkg/libvirttools/volumes.go
@@ -20,6 +20,7 @@ import (
 	libvirtxml "github.com/libvirt/libvirt-go-xml"
 
 	"github.com/Mirantis/virtlet/pkg/metadata/types"
+	"github.com/Mirantis/virtlet/pkg/utils"
 	"github.com/Mirantis/virtlet/pkg/virt"
 )
 
@@ -35,6 +36,8 @@ type volumeOwner interface {
 	RawDevices() []string
 	KubeletRootDir() string
 	VolumePoolName() string
+	Mounter() utils.Mounter
+	SharedFilesystemPath() string
 }
 
 // VMVolumeSource is a function that provides `VMVolume`s for VMs

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -33,6 +33,7 @@ import (
 	"github.com/Mirantis/virtlet/pkg/metadata/types"
 	"github.com/Mirantis/virtlet/pkg/stream"
 	"github.com/Mirantis/virtlet/pkg/tapmanager"
+	"github.com/Mirantis/virtlet/pkg/utils"
 )
 
 const (
@@ -40,6 +41,7 @@ const (
 	tapManagerAttemptCount    = 50
 	streamerSocketPath        = "/var/lib/libvirt/streamer.sock"
 	volumePoolName            = "volumes"
+	virtletSharedFsDir        = "/var/lib/virtlet/fs"
 )
 
 // VirtletManager wraps the Virtlet's Runtime and Image CRI services,
@@ -105,10 +107,11 @@ func (v *VirtletManager) Run() error {
 	v.diagSet.RegisterDiagSource("libvirt-xml", libvirttools.NewLibvirtDiagSource(conn, conn))
 
 	virtConfig := libvirttools.VirtualizationConfig{
-		DisableKVM:     *v.config.DisableKVM,
-		EnableSriov:    *v.config.EnableSriov,
-		CPUModel:       *v.config.CPUModel,
-		VolumePoolName: volumePoolName,
+		DisableKVM:           *v.config.DisableKVM,
+		EnableSriov:          *v.config.EnableSriov,
+		CPUModel:             *v.config.CPUModel,
+		VolumePoolName:       volumePoolName,
+		SharedFilesystemPath: virtletSharedFsDir,
 	}
 	if *v.config.RawDevices != "" {
 		virtConfig.RawDevices = strings.Split(*v.config.RawDevices, ",")
@@ -131,7 +134,7 @@ func (v *VirtletManager) Run() error {
 	}
 
 	volSrc := libvirttools.GetDefaultVolumeSource()
-	v.virtTool = libvirttools.NewVirtualizationTool(conn, conn, v.imageStore, v.metadataStore, volSrc, virtConfig)
+	v.virtTool = libvirttools.NewVirtualizationTool(conn, conn, v.imageStore, v.metadataStore, volSrc, virtConfig, utils.NewMounter())
 
 	runtimeService := NewVirtletRuntimeService(v.virtTool, v.metadataStore, v.fdManager, streamServer, v.imageStore, nil)
 	imageService := NewVirtletImageService(v.imageStore, translator, nil)

--- a/pkg/manager/runtime_test.go
+++ b/pkg/manager/runtime_test.go
@@ -236,7 +236,7 @@ func makeVirtletCRITester(t *testing.T) *virtletCRITester {
 		KubeletRootDir:     kubeletRootDir,
 		StreamerSocketPath: streamerSocketPath,
 	}
-	virtTool := libvirttools.NewVirtualizationTool(domainConn, storageConn, imageStore, metadataStore, libvirttools.GetDefaultVolumeSource(), virtConfig)
+	virtTool := libvirttools.NewVirtualizationTool(domainConn, storageConn, imageStore, metadataStore, libvirttools.GetDefaultVolumeSource(), virtConfig, utils.NullMounter)
 	virtTool.SetClock(clock)
 	streamServer := newFakeStreamServer(rec.Child("streamServer"))
 	criHandler := &criHandler{
@@ -291,7 +291,7 @@ func (tst *virtletCRITester) invoke(name string, req interface{}, failOnError bo
 func (tst *virtletCRITester) getSampleFlexvolMounts(podSandboxID string) []*kubeapi.Mount {
 	flexVolumeDriver := flexvolume.NewFlexVolumeDriver(func() string {
 		return "abb67e3c-71b3-4ddd-5505-8c4215d5c4eb"
-	}, flexvolume.NullMounter)
+	}, utils.NullMounter)
 	flexVolDir := filepath.Join(tst.kubeletRootDir, podSandboxID, "volumes/virtlet~flexvolume_driver", "vol1")
 	flexVolDef := map[string]interface{}{
 		"type":     "qcow2",

--- a/pkg/utils/mounter.go
+++ b/pkg/utils/mounter.go
@@ -18,6 +18,25 @@ package utils
 
 // Mounter defines mount/unmount interface
 type Mounter interface {
-	Mount(source string, target string, fstype string, flags uintptr) error
-	Unmount(target string, flags int) error
+	// Mount mounts the specified source under the target path.
+	// For bind mounts, bind must be true.
+	Mount(source string, target string, fstype string, bind bool) error
+	// Unmount unmounts the specified target directory. If detach
+	// is true, MNT_DETACH option is used (disconnect the
+	// filesystem for the new accesses even if it's busy).
+	Unmount(target string, detach bool) error
 }
+
+type nullMounter struct{}
+
+func (m *nullMounter) Mount(source string, target string, fstype string, bind bool) error {
+	return nil
+}
+
+func (m *nullMounter) Unmount(target string, detach bool) error {
+	return nil
+}
+
+// NullMounter is a mounter that's used for testing and does nothing
+// instead of mounting/unmounting.
+var NullMounter Mounter = &nullMounter{}

--- a/pkg/utils/mounter_linux.go
+++ b/pkg/utils/mounter_linux.go
@@ -29,10 +29,18 @@ func NewMounter() Mounter {
 	return &mounter{}
 }
 
-func (mounter *mounter) Mount(source string, target string, fstype string, flags uintptr) error {
+func (mounter *mounter) Mount(source string, target string, fstype string, bind bool) error {
+	flags := uintptr(0)
+	if bind {
+		flags = syscall.MS_BIND | syscall.MS_REC
+	}
 	return syscall.Mount(source, target, fstype, flags, "")
 }
 
-func (mounter *mounter) Unmount(target string, flags int) error {
+func (mounter *mounter) Unmount(target string, detach bool) error {
+	flags := 0
+	if detach {
+		flags = syscall.MNT_DETACH
+	}
 	return syscall.Unmount(target, flags)
 }

--- a/pkg/utils/mounter_unsupported.go
+++ b/pkg/utils/mounter_unsupported.go
@@ -18,21 +18,8 @@ limitations under the License.
 
 package utils
 
-import "errors"
-
-type mounter struct{}
-
-var _ Mounter = &mounter{}
-
-// NewMounter creates unsupported mounter struct
+// NewMounter is a placeholder for an function that is not implemented
+// on non-Linux platforms.
 func NewMounter() Mounter {
-	return &mounter{}
-}
-
-func (mounter *mounter) Mount(source string, target string, fstype string, flags uintptr) error {
-	return errors.New("not implemented")
-}
-
-func (mounter *mounter) Unmount(target string, flags int) error {
-	return errors.New("not implemented")
+	panic("Not implemented")
 }


### PR DESCRIPTION
Some of the changes in #739 broke tests on non-Linux platforms, and possibly on Linux, too, if they're run outside the build container.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/758)
<!-- Reviewable:end -->
