### PR TITLE
Dump cluster/virtlet state at the end of e2e

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ extract_binaries_from_the_image: &extract_binaries_from_the_image
     image="mirantis/virtlet:${tag}"
     echo "Extracting binaries from ${image}"
     mkdir -p _output/
-    docker run "${image}" tar -C / -c vmwrapper virtlet-e2e-tests | tar -C _output/ -xv
+    docker run "${image}" tar -C / -c vmwrapper virtlet-e2e-tests virtletctl | tar -C _output/ -xv
 
 push_images: &push_images
   <<: *defaults
@@ -204,6 +204,18 @@ e2e: &e2e
 
   - store_test_results:
       path: ~/junit
+
+  - run:
+      name: Dump the cluster state
+      when: always
+      command: |
+        build/portforward.sh 8080&
+        mkdir -p /tmp/cluster_state
+        bash -x ./dind-cluster*.sh dump | gzip >/tmp/cluster_state/kdc-dump.gz
+        _output/virtletctl diag dump --json | gzip >/tmp/cluster_state/virtlet-dump.json.gz
+
+  - store_artifacts:
+      path: /tmp/cluster_state
 
 version: 2
 jobs:


### PR DESCRIPTION
Dump the cluster state and virtlet diag at the end of e2e run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/760)
<!-- Reviewable:end -->
