### PR TITLE
Check image digests

### DIFF
--- a/pkg/image/fake/store.go
+++ b/pkg/image/fake/store.go
@@ -65,13 +65,13 @@ func (s *FakeStore) ListImages(filter string) ([]*image.Image, error) {
 
 // ImageStatus implements ImageStatus method of Store interface.
 func (s *FakeStore) ImageStatus(name string) (*image.Image, error) {
-	name = image.StripTags(name)
+	name, _ = image.SplitImageName(name)
 	return s.images[name], nil
 }
 
 // PullImage implements PullImage method of Store interface.
 func (s *FakeStore) PullImage(ctx context.Context, name string, translator image.Translator) (string, error) {
-	name = image.StripTags(name)
+	name, _ = image.SplitImageName(name)
 	ep := translator(ctx, name)
 	d := digest.FromString(name)
 	named, err := reference.WithName(name)

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -476,3 +476,24 @@ func TestCancelPullImage(t *testing.T) {
 		t.Errorf("the downloader isn't marked as canelled")
 	}
 }
+
+func TestVerifyImageChecksum(t *testing.T) {
+	tst := newIfsTester(t)
+	defer tst.teardown()
+
+	// Use image ref instead of the name.
+	// The ref contains sha256 sum
+	tst.pullImage(tst.refs[0], tst.refs[0])
+	tst.verifyListImages("foobar")
+
+	_, err := tst.store.PullImage(
+		context.Background(),
+		tst.images[0].Name+"@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+		tst.translateImageName)
+	switch {
+	case err == nil:
+		tst.t.Errorf("PullImage() din't return any error for an image with mismatching digest")
+	case !strings.Contains(err.Error(), "image digest mismatch"):
+		t.Errorf("PullImage() is expected to return invalid checksum error but returned %q", err)
+	}
+}

--- a/tests/e2e/ceph_test.go
+++ b/tests/e2e/ceph_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Ceph volumes tests", func() {
 				})
 			}
 
-			Expect(vm.Create(VMOptions{}.ApplyDefaults(), time.Minute*5, podCustomization)).To(Succeed())
+			Expect(vm.CreateAndWait(VMOptions{}.ApplyDefaults(), time.Minute*5, podCustomization)).To(Succeed())
 			var err error
 			_, err = vm.Pod()
 			Expect(err).NotTo(HaveOccurred())
@@ -141,7 +141,7 @@ var _ = Describe("Ceph volumes tests", func() {
 				})
 			}
 
-			Expect(vm.Create(VMOptions{}.ApplyDefaults(), time.Minute*5, podCustomization)).To(Succeed())
+			Expect(vm.CreateAndWait(VMOptions{}.ApplyDefaults(), time.Minute*5, podCustomization)).To(Succeed())
 			_ = do(vm.Pod()).(*framework.PodInterface)
 		})
 

--- a/tests/e2e/cloudinit_test.go
+++ b/tests/e2e/cloudinit_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Cloud-init related tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			vm = controller.VM("ssh-from-cm-impl")
-			Expect(vm.Create(VMOptions{
+			Expect(vm.CreateAndWait(VMOptions{
 				SSHKeySource: "configmap/cm-ssh-key-impl",
 			}.ApplyDefaults(), time.Minute*5, nil)).To(Succeed())
 		})
@@ -75,7 +75,7 @@ var _ = Describe("Cloud-init related tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			vm = controller.VM("ssh-from-cm-expl")
-			Expect(vm.Create(VMOptions{
+			Expect(vm.CreateAndWait(VMOptions{
 				SSHKeySource: "configmap/cm-ssh-key-expl/myKey",
 			}.ApplyDefaults(), time.Minute*5, nil)).To(Succeed())
 		})
@@ -106,7 +106,7 @@ var _ = Describe("Cloud-init related tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			vm = controller.VM("ssh-from-secret-impl")
-			Expect(vm.Create(VMOptions{
+			Expect(vm.CreateAndWait(VMOptions{
 				SSHKeySource: "secret/secret-ssh-key-impl",
 			}.ApplyDefaults(), time.Minute*5, nil)).To(Succeed())
 		})
@@ -137,7 +137,7 @@ var _ = Describe("Cloud-init related tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			vm = controller.VM("ssh-from-secret-expl")
-			Expect(vm.Create(VMOptions{
+			Expect(vm.CreateAndWait(VMOptions{
 				SSHKeySource: "secret/secret-ssh-key-expl/myKey",
 			}.ApplyDefaults(), time.Minute*5, nil)).To(Succeed())
 		})
@@ -171,7 +171,7 @@ var _ = Describe("Cloud-init related tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			vm = controller.VM("userdata-cm")
-			Expect(vm.Create(VMOptions{
+			Expect(vm.CreateAndWait(VMOptions{
 				UserDataSource: "configmap/cm-userdata",
 			}.ApplyDefaults(), time.Minute*5, nil)).To(Succeed())
 		})
@@ -206,7 +206,7 @@ var _ = Describe("Cloud-init related tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			vm = controller.VM("userdata-secret")
-			Expect(vm.Create(VMOptions{
+			Expect(vm.CreateAndWait(VMOptions{
 				UserDataSource: "secret/secret-userdata",
 			}.ApplyDefaults(), time.Minute*5, nil)).To(Succeed())
 		})
@@ -242,7 +242,7 @@ var _ = Describe("Cloud-init related tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			vm = controller.VM("userdata-cm-merge")
-			Expect(vm.Create(VMOptions{
+			Expect(vm.CreateAndWait(VMOptions{
 				UserDataSource: "configmap/cm-userdata",
 				UserData:       userData,
 			}.ApplyDefaults(), time.Minute*5, nil)).To(Succeed())

--- a/tests/e2e/cni_test.go
+++ b/tests/e2e/cni_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Virtlet CNI", func() {
 		// if network namespace was deleted
 		It("Should delete network namespace when VM is deleted", func() {
 			vm = controller.VM("cirros-vm")
-			err := vm.Create(VMOptions{}.ApplyDefaults(), time.Minute*5, nil)
+			err := vm.CreateAndWait(VMOptions{}.ApplyDefaults(), time.Minute*5, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			virtletPod, err := vm.VirtletPod()

--- a/tests/e2e/constants.go
+++ b/tests/e2e/constants.go
@@ -17,7 +17,7 @@ limitations under the License.
 package e2e
 
 const (
-	defaultVMImageLocation = "download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img"
+	defaultVMImageLocation = "download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img@sha256:a8dd75ecffd4cdd96072d60c2237b448e0c8b2bc94d57f10fdbc8c481d9005b8"
 	DefaultSSHUser         = "cirros"
 
 	SshPublicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaJEcFDXEK2ZbX0ZLS1EIYFZRbDAcRfuVjpstSc0De8+sV1aiu+deP" +

--- a/tests/e2e/hung_vm_test.go
+++ b/tests/e2e/hung_vm_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Hung VM", func() {
 
 	BeforeAll(func() {
 		vm = controller.VM("hung-vm")
-		Expect(vm.Create(VMOptions{}.ApplyDefaults(), time.Minute*5, nil)).To(Succeed())
+		Expect(vm.CreateAndWait(VMOptions{}.ApplyDefaults(), time.Minute*5, nil)).To(Succeed())
 		var err error
 		_, err = vm.Pod()
 		Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/image_name_translation_test.go
+++ b/tests/e2e/image_name_translation_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Image URL", func() {
 
 	It("Can be specified in CRD [Conformance]", func() {
 		vm := controller.VM("cirros-vm-with-remapped-image")
-		Expect(vm.Create(VMOptions{}.ApplyDefaults(), time.Minute*5, nil)).To(Succeed())
+		Expect(vm.CreateAndWait(VMOptions{}.ApplyDefaults(), time.Minute*5, nil)).To(Succeed())
 		_, err := vm.Pod()
 		Expect(err).NotTo(HaveOccurred())
 		deleteVM(vm)

--- a/tests/e2e/multi_cni_test.go
+++ b/tests/e2e/multi_cni_test.go
@@ -100,7 +100,7 @@ func makeMultiCNIVM(name string, addCNIAnnotation bool) *multiCNIVM {
 	if addCNIAnnotation {
 		opts.MultiCNI = "calico,flannel"
 	}
-	Expect(vm.Create(opts.ApplyDefaults(), time.Minute*5, nil)).To(Succeed())
+	Expect(vm.CreateAndWait(opts.ApplyDefaults(), time.Minute*5, nil)).To(Succeed())
 	vmPod, err := vm.Pod()
 	Expect(err).NotTo(HaveOccurred())
 	return &multiCNIVM{

--- a/tests/e2e/resources_test.go
+++ b/tests/e2e/resources_test.go
@@ -36,7 +36,7 @@ var _ = Describe("VM resources", func() {
 
 	BeforeAll(func() {
 		vm = controller.VM("vm-resources")
-		Expect(vm.Create(VMOptions{
+		Expect(vm.CreateAndWait(VMOptions{
 			VCPUCount:      2,
 			RootVolumeSize: "4Gi",
 		}.ApplyDefaults(), time.Minute*5, nil)).To(Succeed())

--- a/tests/e2e/restart_virtlet_test.go
+++ b/tests/e2e/restart_virtlet_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Virtlet restart [Disruptive]", func() {
 
 	BeforeAll(func() {
 		vm = controller.VM("cirros-vm")
-		vm.Create(VMOptions{}.ApplyDefaults(), time.Minute*5, nil)
+		vm.CreateAndWait(VMOptions{}.ApplyDefaults(), time.Minute*5, nil)
 		var err error
 		vmPod, err = vm.Pod()
 		Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/stop_qemu_test.go
+++ b/tests/e2e/stop_qemu_test.go
@@ -37,7 +37,7 @@ var _ = Describe("QEMU Process", func() {
 
 	BeforeAll(func() {
 		vm = controller.VM("kill-qemu-vm")
-		Expect(vm.Create(VMOptions{}.ApplyDefaults(), time.Minute*5, nil)).To(Succeed())
+		Expect(vm.CreateAndWait(VMOptions{}.ApplyDefaults(), time.Minute*5, nil)).To(Succeed())
 		var err error
 		vmPod, err := vm.Pod()
 		Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/virtletctl_test.go
+++ b/tests/e2e/virtletctl_test.go
@@ -66,7 +66,7 @@ var _ = Describe("virtletctl", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			vm = controller.VM("virtletctl-cirros-vm")
-			Expect(vm.Create(VMOptions{
+			Expect(vm.CreateAndWait(VMOptions{
 				SSHKeySource: "configmap/sshkey",
 			}.ApplyDefaults(), time.Minute*5, nil)).To(Succeed())
 

--- a/tests/e2e/volume_mount_test.go
+++ b/tests/e2e/volume_mount_test.go
@@ -177,7 +177,7 @@ var _ = Describe("Container volume mounts", func() {
 				})
 			}
 
-			Expect(vm.Create(VMOptions{}.ApplyDefaults(), time.Minute*5, podCustomization)).To(Succeed())
+			Expect(vm.CreateAndWait(VMOptions{}.ApplyDefaults(), time.Minute*5, podCustomization)).To(Succeed())
 		})
 
 		AfterAll(func() {
@@ -236,7 +236,7 @@ var _ = Describe("Container volume mounts", func() {
 				})
 			}
 
-			Expect(vm.Create(VMOptions{}.ApplyDefaults(), time.Minute*5, podCustomization)).To(Succeed())
+			Expect(vm.CreateAndWait(VMOptions{}.ApplyDefaults(), time.Minute*5, podCustomization)).To(Succeed())
 		})
 
 		AfterAll(func() {
@@ -270,7 +270,7 @@ func addFlexvolMount(pod *framework.PodInterface, name string, mountPath string,
 
 func makeVolumeMountVM(nodeName string, podCustomization func(*framework.PodInterface)) *framework.VMInterface {
 	vm := controller.VM("mount-vm")
-	Expect(vm.Create(VMOptions{
+	Expect(vm.CreateAndWait(VMOptions{
 		NodeName: nodeName,
 		// TODO: should also have an option to test using
 		// ubuntu image with volumes mounted using cloud-init

--- a/tests/longevity/vmcontoller.go
+++ b/tests/longevity/vmcontoller.go
@@ -74,7 +74,7 @@ func (i *VMInstance) Create() error {
 	var err error
 
 	i.vm = i.controller.VM(i.name)
-	err = i.vm.Create(e2e.VMOptions{}.ApplyDefaults(), time.Minute*5, nil)
+	err = i.vm.CreateAndWait(e2e.VMOptions{}.ApplyDefaults(), time.Minute*5, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
You can now specify image digests for VM images, e.g.
```
image: virtlet.cloud/cirros@sha256:0615af1caf345e605e27d5419f8d4c6d087b3b41ff4b979aec094ce0399f04ab
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/761)
<!-- Reviewable:end -->

- [x] verify digests in PullImage
- [x] verify digests during ImageStatus
- [x] verify digests during ListImages (skip mismatching images)
- [x] e2e test