### PR TITLE
Integrate repeated code and modify confused fdErr and err using defer.

### DIFF
--- a/pkg/manager/runtime.go
+++ b/pkg/manager/runtime.go
@@ -101,7 +101,7 @@ func (v *VirtletRuntimeService) Version(ctx context.Context, in *kubeapi.Version
 //
 
 // RunPodSandbox implements RunPodSandbox method of CRI.
-func (v *VirtletRuntimeService) RunPodSandbox(ctx context.Context, in *kubeapi.RunPodSandboxRequest) (*kubeapi.RunPodSandboxResponse, error) {
+func (v *VirtletRuntimeService) RunPodSandbox(ctx context.Context, in *kubeapi.RunPodSandboxRequest) (response *kubeapi.RunPodSandboxResponse, retErr error) {
 	config := in.GetConfig()
 	if config == nil {
 		return nil, errors.New("no pod sandbox config passed to RunPodSandbox")
@@ -146,14 +146,21 @@ func (v *VirtletRuntimeService) RunPodSandbox(ctx context.Context, in *kubeapi.R
 			Options:     config.DnsConfig.Options,
 		}
 	}
+
 	fdPayload := &tapmanager.GetFDPayload{Description: pnd}
 	csnBytes, err := v.fdManager.AddFDs(podID, fdPayload)
-	if err != nil {
-		// Try to clean up CNI netns (this may be necessary e.g. in case of multiple CNI plugins with CNI Genie)
-		if fdErr := v.fdManager.ReleaseFDs(podID); err != nil {
-			glog.Errorf("Error removing pod %s (%s) from CNI network: %v", podName, podID, fdErr)
+	// The reason for defer here is that it is also necessary to ReleaseFDs if AddFDs fail
+	// Try to clean up CNI netns (this may be necessary e.g. in case of multiple CNI plugins with CNI Genie)
+	defer func() {
+		if retErr != nil {
+			// Try to clean up CNI netns if we couldn't add the pod to the metadata store or if AddFDs call wasn't
+			// successful to avoid leaking resources
+			if fdErr := v.fdManager.ReleaseFDs(podID); fdErr != nil {
+				glog.Errorf("Error removing pod %s (%s) from CNI network: %v", podName, podID, fdErr)
+			}
 		}
-
+	}()
+	if err != nil {
 		return nil, fmt.Errorf("Error adding pod %s (%s) to CNI network: %v", podName, podID, err)
 	}
 
@@ -161,24 +168,16 @@ func (v *VirtletRuntimeService) RunPodSandbox(ctx context.Context, in *kubeapi.R
 		CRIPodSandboxConfigToPodSandboxConfig(config),
 		csnBytes, types.PodSandboxState(state), v.clock)
 	if err != nil {
-		// cleanup cni if we could not add pod to metadata store to prevent resource leaking
-		if fdErr := v.fdManager.ReleaseFDs(podID); err != nil {
-			glog.Errorf("Error removing pod %s (%s) from CNI network: %v", podName, podID, fdErr)
-		}
 		return nil, err
 	}
 
 	sandbox = v.metadataStore.PodSandbox(config.Metadata.Uid)
-	if storeErr := sandbox.Save(
+	if err := sandbox.Save(
 		func(c *types.PodSandboxInfo) (*types.PodSandboxInfo, error) {
 			return psi, nil
 		},
-	); storeErr != nil {
-		// cleanup cni if we could not add pod to metadata store to prevent resource leaking
-		if err := v.fdManager.ReleaseFDs(podID); err != nil {
-			glog.Errorf("Error removing pod %s (%s) from CNI network: %v", podName, podID, err)
-		}
-		return nil, storeErr
+	); err != nil {
+		return nil, err
 	}
 
 	return &kubeapi.RunPodSandboxResponse{


### PR DESCRIPTION
1. In consideration of the confusion of variable 'fdErr' and 'err' in "pkg/manager/runtime.go", I integrate the repeated code and modify the error in below by using keyword "defer ".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/762)
<!-- Reviewable:end -->
