### PR TITLE
Disable cloud-init netconfig for persistent rootfs

### DIFF
--- a/pkg/libvirttools/TestCloudInitGenerator__pod_with_persistent_rootfs.out.yaml
+++ b/pkg/libvirttools/TestCloudInitGenerator__pod_with_persistent_rootfs.out.yaml
@@ -1,0 +1,5 @@
+meta-data:
+  instance-id: foo.default
+  local-hostname: foo
+network-config: null
+user-data: null

--- a/pkg/libvirttools/TestDomainDefinitions__persistent_rootfs.out.yaml
+++ b/pkg/libvirttools/TestDomainDefinitions__persistent_rootfs.out.yaml
@@ -76,8 +76,6 @@
 - name: 'domain conn: virtlet-231700d5-c9a6-container1: iso image'
   value:
     meta-data: '{"instance-id":"testName_0.default","local-hostname":"testName_0"}'
-    network-config: |
-      version: 1
     user-data: |
       #cloud-config
 - name: 'domain conn: virtlet-231700d5-c9a6-container1: Destroy'

--- a/pkg/libvirttools/block_volumesource.go
+++ b/pkg/libvirttools/block_volumesource.go
@@ -59,7 +59,7 @@ func (v *blockVolume) Teardown() error {
 func GetBlockVolumes(config *types.VMConfig, owner volumeOwner) ([]VMVolume, error) {
 	var vols []VMVolume
 	for _, dev := range config.VolumeDevices {
-		if dev.DevicePath == "/" {
+		if dev.IsRoot() {
 			continue
 		}
 		vols = append(vols, &blockVolume{

--- a/pkg/libvirttools/root_volumesource.go
+++ b/pkg/libvirttools/root_volumesource.go
@@ -35,16 +35,13 @@ var _ VMVolume = &rootVolume{}
 // GetRootVolume returns volume source for root volume clone.
 func GetRootVolume(config *types.VMConfig, owner volumeOwner) ([]VMVolume, error) {
 	var vol VMVolume
-	for _, dev := range config.VolumeDevices {
-		if dev.DevicePath == "/" {
-			vol = &persistentRootVolume{
-				volumeBase: volumeBase{config, owner},
-				dev:        dev,
-			}
-			break
+	rootDev := config.RootVolumeDevice()
+	if rootDev != nil {
+		vol = &persistentRootVolume{
+			volumeBase: volumeBase{config, owner},
+			dev:        *rootDev,
 		}
-	}
-	if vol == nil {
+	} else {
 		vol = &rootVolume{
 			volumeBase{config, owner},
 		}

--- a/pkg/metadata/types/types.go
+++ b/pkg/metadata/types/types.go
@@ -213,6 +213,12 @@ type VMVolumeDevice struct {
 	HostPath string
 }
 
+// IsRoot returns true if this volume device should be used for a
+// persistent root filesystem, that is, its DevicePath is "/"
+func (d VMVolumeDevice) IsRoot() bool {
+	return d.DevicePath == "/"
+}
+
 // UUID returns an uuid that uniquely identifies the block device on
 // the host.
 func (dev VMVolumeDevice) UUID() string {
@@ -269,6 +275,18 @@ type VMConfig struct {
 	// Path relative to LogDirectory for container to store the
 	// log (STDOUT and STDERR) on the host.
 	LogPath string
+}
+
+// RootVolumeDevice returns the volume device that should be used for
+// a persistent root filesystem, that is, its DevicePath is "/"
+func (c *VMConfig) RootVolumeDevice() *VMVolumeDevice {
+	for n, _ := range c.VolumeDevices {
+		dev := &c.VolumeDevices[n]
+		if dev.IsRoot() {
+			return dev
+		}
+	}
+	return nil
 }
 
 // LoadAnnotations parses pod annotations in the VM config an


### PR DESCRIPTION
E.g. Ubuntu's cloud-init only sets up the networking on the first boot,
so we have to use dhcp for now. This will be documented in a separate
PR that adds docs and examples for persistent rootfs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/769)
<!-- Reviewable:end -->
