### PR TITLE
Make examples runnable in parallel

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -247,7 +247,7 @@ After the VM boots, we can log into it and create a file on the root
 filesystem:
 
 ```console
-$ virtletctl ssh cirros@cirros-vm-p -- -i examples/vmkey
+$ virtletctl ssh cirros@cirros-vm-pl -- -i examples/vmkey
 ...
 $ echo foo >bar.txt
 ```
@@ -261,7 +261,7 @@ kubectl apply -f examples/cirros-vm-persistent-rootfs-local.yaml
 After logging into the new VM pod, we see that the file is still
 there:
 ```console
-$ virtletctl ssh cirros@cirros-vm-p -- -i examples/vmkey
+$ virtletctl ssh cirros@cirros-vm-pl -- -i examples/vmkey
 ...
 $ cat bar.txt
 foo
@@ -280,4 +280,5 @@ kubectl apply -f examples/cirros-vm-persistent-rootfs-rbd.yaml
 ```
 
 After that, you can verify that the persistent rootfs indeed works
-using the same approach as with local PVs.
+using the same approach as with local PVs, but using name `cirros-vm-pr`
+in place of `cirros-vm-pl`.

--- a/examples/cirros-vm-persistent-rootfs-local.yaml
+++ b/examples/cirros-vm-persistent-rootfs-local.yaml
@@ -43,7 +43,7 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: cirros-vm-p
+  name: cirros-vm-pl
   annotations:
     kubernetes.io/target-runtime: virtlet.cloud
     # CirrOS doesn't load nocloud data from SCSI CD-ROM for some reason

--- a/examples/cirros-vm-persistent-rootfs-rbd.yaml
+++ b/examples/cirros-vm-persistent-rootfs-rbd.yaml
@@ -36,7 +36,7 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: cirros-vm-p
+  name: cirros-vm-pr
   annotations:
     kubernetes.io/target-runtime: virtlet.cloud
     # CirrOS doesn't load nocloud data from SCSI CD-ROM for some reason

--- a/examples/cirros-vm-raw-device.yaml
+++ b/examples/cirros-vm-raw-device.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: cirros-vm
+  name: cirros-vm-raw-device
   annotations:
     kubernetes.io/target-runtime: virtlet.cloud
 spec:

--- a/examples/ubuntu-multi-cni.yaml
+++ b/examples/ubuntu-multi-cni.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: ubuntu-vm
+  name: ubuntu-multi-cni
   annotations:
     multi-ip-preferences: |
       {

--- a/examples/ubuntu-vm-local-block-pv.yaml
+++ b/examples/ubuntu-vm-local-block-pv.yaml
@@ -49,7 +49,7 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: ubuntu-vm
+  name: ubuntu-vm-local-block-pv
   annotations:
     kubernetes.io/target-runtime: virtlet.cloud
     VirtletSSHKeys: |

--- a/examples/ubuntu-vm-rbd-block-pv.yaml
+++ b/examples/ubuntu-vm-rbd-block-pv.yaml
@@ -36,7 +36,7 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: ubuntu-vm
+  name: ubuntu-vm-rdb-block-pv
   annotations:
     kubernetes.io/target-runtime: virtlet.cloud
     VirtletSSHKeys: |


### PR DESCRIPTION
Each examples (excluding k8s.yaml) have now own pod name, so they can be started in the same time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/774)
<!-- Reviewable:end -->
