### PR TITLE
Fix startup data corruption on persistent rootfs

### DIFF
--- a/deploy/demo.sh
+++ b/deploy/demo.sh
@@ -172,6 +172,9 @@ function demo::fix-mounts {
     docker exec "${virtlet_node}" mount --make-shared /boot
   fi
   docker exec "${virtlet_node}" mount --make-shared /sys/fs/cgroup
+  demo::step "Bind-mounting /var/lib/virtlet from a docker volume"
+  docker exec "${virtlet_node}" mkdir -p /dind/virtlet /var/lib/virtlet
+  docker exec "${virtlet_node}" mount --bind /var/lib/virtlet /dind/virtlet
 }
 
 function demo::inject-local-image {

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -19,6 +19,7 @@ package e2e
 import (
 	"flag"
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -34,7 +35,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const cephContainerName = "ceph_cluster"
+const (
+	cephContainerName = "ceph_cluster"
+	loopDeviceTestDir = "/virtlet-e2e-tests"
+)
 
 var (
 	vmImageLocation       = flag.String("image", defaultVMImageLocation, "VM image URL (*without http(s)://*")
@@ -180,35 +184,47 @@ func includeUnsafe() {
 	}
 }
 
-func withLoopbackBlockDevice(virtletNodeName, devPath *string) {
+func withLoopbackBlockDevice(virtletNodeName, devPath *string, mkfs bool) {
 	var nodeExecutor framework.Executor
-	BeforeAll(func() {
+	var filename string
+	BeforeEach(func() {
 		var err error
 		*virtletNodeName, err = controller.VirtletNodeName()
 		Expect(err).NotTo(HaveOccurred())
 		nodeExecutor, err = controller.DinDNodeExecutor(*virtletNodeName)
 		Expect(err).NotTo(HaveOccurred())
 
-		_, err = framework.RunSimple(nodeExecutor, "dd", "if=/dev/zero", "of=/rawdevtest", "bs=1M", "count=1000")
+		_, err = framework.RunSimple(nodeExecutor, "mkdir", "-p", loopDeviceTestDir)
 		Expect(err).NotTo(HaveOccurred())
-		// We use mkfs.ext3 here because mkfs.ext4 on
-		// the node may be too new for CirrOS, causing
-		// errors like this in VM's dmesg:
-		// [    1.316395] EXT3-fs (vdb): error: couldn't mount because of unsupported optional features (2c0)
-		// [    1.320222] EXT4-fs (vdb): couldn't mount RDWR because of unsupported optional features (400)
-		// [    1.339594] EXT3-fs (vdc1): error: couldn't mount because of unsupported optional features (240)
-		// [    1.342850] EXT4-fs (vdc1): mounted filesystem with ordered data mode. Opts: (null)
-		_, err = framework.RunSimple(nodeExecutor, "mkfs.ext3", "/rawdevtest")
+
+		filename, err = framework.RunSimple(nodeExecutor, "tempfile", "-d", loopDeviceTestDir, "--prefix", "ve2e-")
 		Expect(err).NotTo(HaveOccurred())
-		*devPath, err = framework.RunSimple(nodeExecutor, "losetup", "-f", "/rawdevtest", "--show")
+
+		_, err = framework.RunSimple(nodeExecutor, "dd", "if=/dev/zero", "of="+filename, "bs=1M", "count=1000")
+		Expect(err).NotTo(HaveOccurred())
+		if mkfs {
+			// We use mkfs.ext3 here because mkfs.ext4 on
+			// the node may be too new for CirrOS, causing
+			// errors like this in VM's dmesg:
+			// [    1.316395] EXT3-fs (vdb): error: couldn't mount because of unsupported optional features (2c0)
+			// [    1.320222] EXT4-fs (vdb): couldn't mount RDWR because of unsupported optional features (400)
+			// [    1.339594] EXT3-fs (vdc1): error: couldn't mount because of unsupported optional features (240)
+			// [    1.342850] EXT4-fs (vdc1): mounted filesystem with ordered data mode. Opts: (null)
+			_, err = framework.RunSimple(nodeExecutor, "mkfs.ext3", filename)
+			Expect(err).NotTo(HaveOccurred())
+		}
+		_, err = framework.RunSimple(nodeExecutor, "sync")
+		Expect(err).NotTo(HaveOccurred())
+		*devPath, err = framework.RunSimple(nodeExecutor, "losetup", "-f", filename, "--show")
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	AfterAll(func() {
+	AfterEach(func() {
 		// The loopback device is detached by itself upon
 		// success (TODO: check why it happens), so we
 		// ignore errors here
 		framework.RunSimple(nodeExecutor, "losetup", "-d", *devPath)
+		Expect(os.RemoveAll(loopDeviceTestDir)).To(Succeed())
 	})
 }
 

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -37,7 +37,8 @@ import (
 
 const (
 	cephContainerName = "ceph_cluster"
-	loopDeviceTestDir = "/virtlet-e2e-tests"
+	// avoid having the loop device on top of overlay2/aufs when using k-d-c
+	loopDeviceTestDir = "/dind/virtlet-e2e-tests"
 )
 
 var (

--- a/tests/e2e/volume_mount_test.go
+++ b/tests/e2e/volume_mount_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Container volume mounts", func() {
 			ssh             framework.Executor
 		)
 
-		withLoopbackBlockDevice(&virtletNodeName, &devPath)
+		withLoopbackBlockDevice(&virtletNodeName, &devPath, true)
 
 		AfterEach(func() {
 			if ssh != nil {


### PR DESCRIPTION
There was another problem with caching when setting up the device mapper for the persistent rootfs.

- [x] fix e2e tests that were reusing same file for a loopback block device
- [x] try fixing cache issue using a "brute-force" write barrier (sync + drop kernel caches)
- [x] do multiple runs to confirm that "brute-force" approach works
- [x] implement less broad sync to fix the issue
- [ ] do multiple test runs to confirm that the "less broad sync" approach works

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/776)
<!-- Reviewable:end -->
