### PR TITLE
Facilitate e2e diagnostics on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,6 +176,7 @@ e2e: &e2e
           INJECT_LOCAL_IMAGE=1 \
           VIRTLET_DEMO_BRANCH=master \
           ENABLE_CEPH=1 \
+          DEMO_LOG_LEVEL=6 \
           FEATURE_GATES="BlockVolume=true" \
           KUBELET_FEATURE_GATES="BlockVolume=true" \
           BASE_LOCATION="$PWD" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,8 @@ defaults: &defaults
     DOCKER_VERSION: "17.03.0-ce"
     KUBECTL_VERSION: "v1.9.3"
     KUBECTL_SHA1: "a27d808eb011dbeea876fe5326349ed167a7ed28"
+    # Uncomment the following to use ginkgo.focus for e2e
+    # E2E_FOCUS: "Specify a regexp.*here"
 
 prereqs: &prereqs
   name: Install prerequisites
@@ -198,12 +200,15 @@ e2e: &e2e
       command: |
         build/portforward.sh 8080&
         mkdir -p ~/junit
-        skip="-ginkgo.skip=\[Heavy\]|\[MultiCNI\]|\[Disruptive\]"
+        skip_focus=("-ginkgo.skip=\[Heavy\]|\[MultiCNI\]|\[Disruptive\]")
         if [[ ${CIRCLE_JOB} = e2e_multi_cni ]]; then
           # per-node config test requires an additional worker node
-          skip="-ginkgo.skip=\[Heavy\]|\[Disruptive\]|Per-node configuration"
+          skip_focus="-ginkgo.skip=\[Heavy\]|\[Disruptive\]|Per-node configuration"
         fi
-        _output/virtlet-e2e-tests -test.v "${skip}" -junitOutput ~/junit/junit.xml -include-unsafe-tests=true
+        if [[ ${E2E_FOCUS:-} ]]; then
+          skip_focus+=("-ginkgo.focus=${E2E_FOCUS}")
+        fi
+        _output/virtlet-e2e-tests -test.v "${skip_focus[@]}" -junitOutput ~/junit/junit.xml -include-unsafe-tests=true
 
   - store_test_results:
       path: ~/junit

--- a/deploy/demo.sh
+++ b/deploy/demo.sh
@@ -20,6 +20,7 @@ VIRTLET_ON_MASTER="${VIRTLET_ON_MASTER:-}"
 VIRTLET_MULTI_NODE="${VIRTLET_MULTI_NODE:-}"
 IMAGE_REGEXP_TRANSLATION="${IMAGE_REGEXP_TRANSLATION:-1}"
 MULTI_CNI="${MULTI_CNI:-}"
+DEMO_LOG_LEVEL="${DEMO_LOG_LEVEL:-}"
 # Convenience setting for local testing:
 # BASE_LOCATION="${HOME}/work/kubernetes/src/github.com/Mirantis/virtlet"
 cirros_key="demo-cirros-private-key"
@@ -362,6 +363,22 @@ function demo::start-virtlet {
     fi
   fi
 
+  if [[ ${DEMO_LOG_LEVEL} ]]; then
+      demo::step "Deploying Virtlet CRDs"
+      docker run --rm "mirantis/virtlet:${virtlet_docker_tag}" virtletctl gen --crd |
+          "${kubectl}" apply -f -
+      "${kubectl}" apply -f - <<EOF
+---
+apiVersion: "virtlet.k8s/v1"
+kind: VirtletConfigMapping
+metadata:
+  name: demo-log-level
+  namespace: kube-system
+spec:
+  config:
+    logLevel: ${DEMO_LOG_LEVEL}
+EOF
+  fi
   demo::step "Deploying Virtlet DaemonSet with docker tag ${virtlet_docker_tag}"
   docker run --rm "mirantis/virtlet:${virtlet_docker_tag}" virtletctl gen --tag "${virtlet_docker_tag}" |
       "${kubectl}" apply -f -


### PR DESCRIPTION
Add `DEMO_LOG_LEVEL` option for `deploy/demo.sh` and set it to 6 for CircleCI.
Add `E2E_FOCUS` option to CircleCI config (unused by default, to be patched during debugging).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/777)
<!-- Reviewable:end -->
