### PR TITLE
Fix bind-mounting of /var/lib/virtlet in demo.sh

### DIFF
--- a/deploy/demo.sh
+++ b/deploy/demo.sh
@@ -175,7 +175,7 @@ function demo::fix-mounts {
   docker exec "${virtlet_node}" mount --make-shared /sys/fs/cgroup
   demo::step "Bind-mounting /var/lib/virtlet from a docker volume"
   docker exec "${virtlet_node}" mkdir -p /dind/virtlet /var/lib/virtlet
-  docker exec "${virtlet_node}" mount --bind /var/lib/virtlet /dind/virtlet
+  docker exec "${virtlet_node}" mount --bind /dind/virtlet /var/lib/virtlet
 }
 
 function demo::inject-local-image {


### PR DESCRIPTION
This was likely "reviving" an old bug in qemu because it was
breaking write barriers on the downloaded QCOW2 files, sometimes
causing persistent rootfs on local pv test to fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/785)
<!-- Reviewable:end -->
