### PR TITLE
Use containerd for public CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,8 @@ defaults: &defaults
     DOCKER_VERSION: "17.03.0-ce"
     KUBECTL_VERSION: "v1.9.3"
     KUBECTL_SHA1: "a27d808eb011dbeea876fe5326349ed167a7ed28"
+    # remove DIND_CRI to use dockershim
+    DIND_CRI: containerd
     # Uncomment the following to use ginkgo.focus for e2e
     # E2E_FOCUS: "Specify a regexp.*here"
 

--- a/build/cmd.sh
+++ b/build/cmd.sh
@@ -282,6 +282,9 @@ function prepare_node {
     fi
     ensure_build_container
     echo >&2 "Installing CRI proxy package in the node container (${node})..."
+    if [[ ${DIND_CRI:-} = containerd ]]; then
+        docker exec "${node}" /bin/bash -c 'echo criproxy-nodeps criproxy/primary_cri select containerd | debconf-set-selections'
+    fi
     docker exec "${node}" /bin/bash -c "curl -sSL '${CRIPROXY_DEB_URL}' >/criproxy.deb && dpkg -i /criproxy.deb && rm /criproxy.deb"
 
     docker exec "${node}" mount --make-shared /dind


### PR DESCRIPTION
- [x] update demo script to use containerd
- [x] update CI config to use containerd
- [x] rebase on top of #813 
- [x] use released CRI proxy version (need to make a release of CRI proxy)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/811)
<!-- Reviewable:end -->
