### PR TITLE
Fix MountPointChecker

### DIFF
--- a/images/image_skel/prepare-node.sh
+++ b/images/image_skel/prepare-node.sh
@@ -34,7 +34,7 @@ mkdir -p /host-var-lib/virtlet/images /hostlog/virtlet/vms /host-var-lib/virtlet
 
 # set up KVM
 if [[ ! ${VIRTLET_DISABLE_KVM:-} ]]; then
-  if ! kvm-ok >&/dev/null; then
+  if ! kvm-ok &>/dev/null; then
     # try to fix the environment by loading appropriate modules
     modprobe kvm || (echo "Missing kvm module on the host" >&2 && exit 1)
     if grep vmx /proc/cpuinfo &>/dev/null; then

--- a/pkg/utils/mountinfo.go
+++ b/pkg/utils/mountinfo.go
@@ -65,19 +65,19 @@ LineReader:
 		case io.EOF:
 			break LineReader
 		case nil:
+			// strip eol
+			line = strings.Trim(line, "\n")
+
+			// split and parse entries acording to section 3.5 in
+			// https://www.kernel.org/doc/Documentation/filesystems/proc.txt
+			// TODO: whitespaces and control chars in names are encoded as
+			// octal values (e.g. for "x x": "x\040x") what should be expanded
+			// in both mount point source and target
+			parts := strings.Split(line, " ")
+			mi[parts[4]] = mountEntry{Source: parts[9], Fs: parts[8]}
+		default:
 			return mountPointChecker{}, err
 		}
-
-		// strip eol
-		line = strings.Trim(line, "\n")
-
-		// split and parse entries acording to section 3.5 in
-		// https://www.kernel.org/doc/Documentation/filesystems/proc.txt
-		// TODO: whitespaces and control chars in names are encoded as
-		// octal values (e.g. for "x x": "x\040x") what should be expanded
-		// in both mount point source and target
-		parts := strings.Split(line, " ")
-		mi[parts[4]] = mountEntry{Source: parts[9], Fs: parts[8]}
 	}
 	return mountPointChecker{mountInfo: mi}, nil
 }
@@ -107,7 +107,7 @@ func (mpc mountPointChecker) IsPathAnNs(path string) bool {
 	if !isMountPoint {
 		return false
 	}
-	return entry.Fs == "nsfs"
+	return entry.Fs == "nsfs" || entry.Fs == "proc"
 }
 
 type fakeMountPointChecker struct{}


### PR DESCRIPTION
- Fixed the MountPointChecker issue, the mount point didn't save into map `mi` at all.
- For IsPathAnNs, the FS can either be nsfs in unbuntu and proc for centos

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/820)
<!-- Reviewable:end -->
