### PR TITLE
Make prepare-node.sh more user friendly

### DIFF
--- a/images/image_skel/prepare-node.sh
+++ b/images/image_skel/prepare-node.sh
@@ -36,20 +36,21 @@ mkdir -p /host-var-lib/virtlet/images /hostlog/virtlet/vms /host-var-lib/virtlet
 if [[ ! ${VIRTLET_DISABLE_KVM:-} ]]; then
   if ! kvm-ok &>/dev/null; then
     # try to fix the environment by loading appropriate modules
-    modprobe kvm || (echo "Missing kvm module on the host" >&2 && exit 1)
+    modprobe kvm || (echo "Missing kvm module on the host" >&2 && sleep infinity)
     if grep vmx /proc/cpuinfo &>/dev/null; then
-      modprobe kvm_intel || (echo "Missing kvm_intel module on the host" >&2 && exit 1)
+      modprobe kvm_intel || (echo "Missing kvm_intel module on the host" >&2 && sleep infinity)
     elif grep svm /proc/cpuinfo &>/dev/null; then
-      modprobe kvm_amd || (echo "Missing kvm_amd module on the host" >&2 && exit 1)
+      modprobe kvm_amd || (echo "Missing kvm_amd module on the host" >&2 && sleep infinity)
     fi
   fi
   if [[ ! -e /dev/kvm ]] && ! mknod /dev/kvm c 10 $(grep '\<kvm\>' /proc/misc | cut -d" " -f1); then
     echo "Can't create /dev/kvm" >&2
   fi
-  if ! kvm-ok; then
+  while ! kvm-ok; do
     echo "*** VIRTLET_DISABLE_KVM is not set but KVM extensions are not available ***" >&2
     echo "*** Virtlet startup failed ***" >&2
-    exit 1
-  fi
+    echo "Rechecking in 5 sec." >&2
+    sleep 5
+  done
   chown libvirt-qemu.kvm /dev/kvm
 fi

--- a/images/image_skel/prepare-node.sh
+++ b/images/image_skel/prepare-node.sh
@@ -33,6 +33,13 @@ fi
 mkdir -p /host-var-lib/virtlet/images /hostlog/virtlet/vms /host-var-lib/virtlet/volumes
 
 # set up KVM
+# NOTE: sleep infinity is used there to prevent pod removal/recreation from daemonset
+# in non recoverable situation, allowing user to look on logs for the reason of failure.
+# Also contstant recreations of pod by DS in these situations can lead to saturation
+# of mountpoints doing the node unusable (probably due to bug on kubelet
+# or dockershim - this needs further research).
+# Other option would be to change restart policy in DS definition, but that will
+# block possibility to restart Virtlet by killing its pod.
 if [[ ! ${VIRTLET_DISABLE_KVM:-} ]]; then
   if ! kvm-ok &>/dev/null; then
     # try to fix the environment by loading appropriate modules


### PR DESCRIPTION
At the moment if there is an issue with prepare node, which is an init container - whole pod will be restarted and in effect reaching the logs with description of failure is quite hard.

This change should simplify the way of gaining information about cause of failure while also will allow to continue starting procedure if a system administrator would fix the issue manually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/827)
<!-- Reviewable:end -->
