### PR TITLE
Populate FDs during recover

### DIFF
--- a/pkg/nettools/nettools.go
+++ b/pkg/nettools/nettools.go
@@ -671,7 +671,7 @@ func RecoverContainerSideNetwork(csn *network.ContainerSideNetwork, nsPath strin
 		oldDescs[desc.Name] = desc
 	}
 
-	for _, link := range contLinks {
+	for ifaceNo, link := range contLinks {
 		// Skip missing link which is already used by running VM
 		if link == nil {
 			continue
@@ -704,6 +704,14 @@ func RecoverContainerSideNetwork(csn *network.ContainerSideNetwork, nsPath strin
 			bindDeviceToVFIO(devIdentifier)
 		} else {
 			ifaceType = network.InterfaceTypeTap
+
+			tapInterfaceName := fmt.Sprintf(tapInterfaceNameTemplate, ifaceNo)
+			fo, err := OpenTAP(tapInterfaceName)
+			if err != nil {
+				glog.Errorf("(RecoverContainerSideNetwork) Failed to open %s: %v", ifaceName, err)
+				return err
+			}
+			desc.Fo = fo
 		}
 		if desc.Type != ifaceType {
 			return fmt.Errorf("bad interface type for %q", desc.Name)


### PR DESCRIPTION
There is such case: virtlet gets exited for some reasons, and during the restart, recover is executed without the TAP fds, everything is fine now. But later the qemu process may quit, kubelet will try to start a new one, but vmwrapper will fail to read the fds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/832)
<!-- Reviewable:end -->
