### PR TITLE
Fix file injection with multiple partitions and unblock CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,8 @@ e2e: &e2e
   - run:
       name: Prepare all of the nodes for Virtlet pod
       command: |
-        build/cmd.sh prepare-all-nodes
+        build/portforward.sh 8080&
+        VIRTLET_SKIP_RSYNC=1 build/cmd.sh prepare-all-nodes
 
   - run:
       name: Run e2e tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,13 +216,14 @@ e2e: &e2e
       path: ~/junit
 
   - run:
-      name: Dump the cluster state
+      name: Dump the cluster state and display Virtlet version
       when: always
       command: |
         build/portforward.sh 8080&
         mkdir -p /tmp/cluster_state
         bash -x ./dind-cluster*.sh dump | gzip >/tmp/cluster_state/kdc-dump.gz
         _output/virtletctl diag dump --json | gzip >/tmp/cluster_state/virtlet-dump.json.gz
+        _output/virtletctl version
 
   - store_artifacts:
       path: /tmp/cluster_state

--- a/build/cmd.sh
+++ b/build/cmd.sh
@@ -167,7 +167,6 @@ function ensure_build_container {
                -v /lib/modules:/lib/modules:ro \
                -v /boot:/boot:ro \
                -v "${DOCKER_SOCKET_PATH}:/var/run/docker.sock" \
-               -e DOCKER_HOST="${DOCKER_HOST:-}" \
                -e DOCKER_MACHINE_NAME="${DOCKER_MACHINE_NAME:-}" \
                -e DOCKER_TLS_VERIFY="${DOCKER_TLS_VERIFY:-}" \
                -e TRAVIS="${TRAVIS:-}" \

--- a/build/cmd.sh
+++ b/build/cmd.sh
@@ -15,6 +15,7 @@ DOCKER_SOCKET_PATH="${DOCKER_SOCKET_PATH:-/var/run/docker.sock}"
 FORCE_UPDATE_IMAGE="${FORCE_UPDATE_IMAGE:-}"
 IMAGE_REGEXP_TRANSLATION="${IMAGE_REGEXP_TRANSLATION:-1}"
 GH_RELEASE_TEST_USER="ivan4th"
+DIND_CRI="${DIND_CRI:-containerd}"
 
 # Note that project_dir must not end with slash
 project_dir="$(cd "$(dirname "${BASH_SOURCE}")/.." && pwd)"
@@ -297,9 +298,13 @@ function prepare_node {
             kubectl taint nodes kube-master node-role.kubernetes.io/master-
         fi
     fi
-    if [[ ${FORCE_UPDATE_IMAGE} ]] || ! docker exec "${node}" docker history -q mirantis/virtlet:latest >&/dev/null; then
+    if [[ ${FORCE_UPDATE_IMAGE} ]] || ! docker exec "${node}" docker history -q "${virtlet_image}:latest" >&/dev/null; then
         echo >&2 "Propagating Virtlet image to the node container..."
-        vcmd "docker save '${virtlet_image}' | docker exec -i '${node}' docker load"
+        if [[ ${DIND_CRI} = containerd ]]; then
+          vcmd "docker save '${virtlet_image}:latest' | docker exec -i '${node}' ctr -n k8s.io images import -"
+        else
+          vcmd "docker save '${virtlet_image}:latest' | docker exec -i '${node}' docker load"
+        fi
     fi
 }
 

--- a/pkg/diskimage/diskimage_test.go
+++ b/pkg/diskimage/diskimage_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 Mirantis
+Copyright 2019 Mirantis
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/diskimage/diskimage_unsupported.go
+++ b/pkg/diskimage/diskimage_unsupported.go
@@ -1,7 +1,7 @@
 // +build !linux
 
 /*
-Copyright 2016 Mirantis
+Copyright 2019 Mirantis
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Also, fix error messages in diskimage code and copyright headers.

This PR also includes the fix for containerd image injection that was
blocking Virtlet CI, as well as related fixes for `build/cmd.sh`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/842)
<!-- Reviewable:end -->
