### PR TITLE
Fix tap MTU setting

### DIFF
--- a/pkg/nettools/calico_test.go
+++ b/pkg/nettools/calico_test.go
@@ -124,7 +124,7 @@ func TestCalicoDetection(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			withFakeCNIVeth(t, func(hostNS, contNS ns.NetNS, origHostVeth, origContVeth netlink.Link) {
+			withFakeCNIVeth(t, defaultMTU, func(hostNS, contNS ns.NetNS, origHostVeth, origContVeth netlink.Link) {
 				for _, r := range tc.routes {
 					if r.Scope == SCOPE_LINK {
 						r.LinkIndex = origContVeth.Attrs().Index
@@ -148,7 +148,7 @@ func TestCalicoDetection(t *testing.T) {
 
 func TestFixCalicoNetworking(t *testing.T) {
 	withDummyNetworkNamespace(t, func(dummyNS ns.NetNS, dummyInfo *cnicurrent.Result) {
-		withFakeCNIVeth(t, func(hostNS, contNS ns.NetNS, origHostVeth, origContVeth netlink.Link) {
+		withFakeCNIVeth(t, defaultMTU, func(hostNS, contNS ns.NetNS, origHostVeth, origContVeth netlink.Link) {
 			addCalicoRoutes(t, origContVeth)
 			info, err := ExtractLinkInfo(origContVeth, contNS.Path())
 			if err != nil {

--- a/pkg/nettools/nettools.go
+++ b/pkg/nettools/nettools.go
@@ -55,6 +55,7 @@ import (
 )
 
 const (
+	defaultMTU                  = 1500
 	tapInterfaceNameTemplate    = "tap%d"
 	containerBridgeNameTemplate = "br%d"
 	loopbackInterfaceName       = "lo"

--- a/pkg/nettools/tap_linux.go
+++ b/pkg/nettools/tap_linux.go
@@ -83,5 +83,10 @@ func CreateTAP(devName string, mtu int) (netlink.Link, error) {
 		return nil, fmt.Errorf("failed to set %q up: %v", devName, err)
 	}
 
+	// NOTE: link mtu in LinkAttrs above is actually ignored
+	if err := netlink.LinkSetMTU(tap, mtu); err != nil {
+		return nil, fmt.Errorf("LinkSetMTU(): %v", err)
+	}
+
 	return tap, nil
 }


### PR DESCRIPTION
MTU for the tap interface was not being set properly, causing also
wrong MTU for the bridge. The problem was observed e.g. when using
Flannel on a cluster running on top of OpenStack.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/848)
<!-- Reviewable:end -->
