### PR TITLE
Use 'docs' branch instead of 'gh-pages'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -412,20 +412,20 @@ jobs:
     - restore_cache:
         <<: *restore_image_cache
     - run:
-        name: Update docs and push them to gh-pages branch
+        name: Update docs and push them to docs branch
         command: |
           build/portforward.sh 18730&
           git config --global user.email bot@virtlet.cloud
           git config --global user.name virtlet-bot
-          git fetch -f https://github.com/Mirantis/virtlet.git gh-pages:gh-pages
+          git fetch -f https://github.com/Mirantis/virtlet.git docs:docs
           build/cmd.sh build-docs
           if [[ ${CIRCLE_BRANCH:-} != ${DOCS_SOURCE_BRANCH} ]]; then
-            echo >&2 "Not updating gh-pages branch: current branch is ${CIRCLE_BRANCH:-} not ${DOCS_SOURCE_BRANCH}"
+            echo >&2 "Not updating docs branch: current branch is ${CIRCLE_BRANCH:-} not ${DOCS_SOURCE_BRANCH}"
           elif [[ ! ${GITHUB_TOKEN:-} ]]; then
-            echo >&2 "Not updating gh-pages branch: missing GITHUB_TOKEN env var"
+            echo >&2 "Not updating docs branch: missing GITHUB_TOKEN env var"
           else
             # if the docs didn't change, this push will do nothing
-            git push https://${GITHUB_TOKEN}@github.com/Mirantis/virtlet.git gh-pages:gh-pages
+            git push https://${GITHUB_TOKEN}@github.com/Mirantis/virtlet.git docs:docs
           fi
           tar -czf /tmp/docs.tar.gz _docs
     - store_artifacts:

--- a/build/cmd.sh
+++ b/build/cmd.sh
@@ -559,7 +559,7 @@ function build_docs_internal {
 function build_docs {
     cd "${project_dir}"
     rm -rf _docs
-    git clone -b gh-pages . _docs
+    git clone -b docs . _docs
     local docs_hash="$(git ls-tree HEAD -- docs | awk '{print $3}')"
     if [[ ! -e _docs/source_hash || ${docs_hash} != $(cat _docs/source_hash) ]]; then
         echo >&2 "docs/ directory changed since the last doc build, rebuilding docs"
@@ -578,7 +578,7 @@ function build_docs {
         git add .
         git commit -m "Update generated docs [ci skip]"
         # this pushes the changes into the local repo (not github!)
-        git push origin gh-pages
+        git push origin docs
     )
 }
 

--- a/docs/docs/dev/build-tool.md
+++ b/docs/docs/dev/build-tool.md
@@ -180,7 +180,7 @@ the current Virtlet working copy, you need to run `build/cmd.sh sync`.
 ### build-docs
 
 Builds the documentation using [MkDocs](https://www.mkdocs.org/) and
-puts the result into `gh-pages` branch. The copy of MkDocs output is
+puts the result into `docs` branch. The copy of MkDocs output is
 stored under `_docs/` subdirectory of the working copy. The build is
 done only if the docs changed since they were last build and stored
 under `gh-docs` branch or if the current working copy is dirty (i.e.


### PR DESCRIPTION
We're not using GitHub pages but with `gh-pages` branch present it's
being forced by GitHub.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/855)
<!-- Reviewable:end -->
