### PR TITLE
Do not remove container if start container failed

### DIFF
--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -447,20 +447,7 @@ func (v *VirtualizationTool) startContainer(containerID string) error {
 // If there was an error it will be returned to caller after an domain removal
 // attempt.  If also it had an error - both of them will be combined.
 func (v *VirtualizationTool) StartContainer(containerID string) error {
-	if err := v.startContainer(containerID); err != nil {
-		// FIXME: we do this here because kubelet may attempt new `CreateContainer()`
-		// calls for this VM after failed `StartContainer()` without first removing it.
-		// Better solution is perhaps moving domain setup logic to `StartContainer()`
-		// and cleaning it all up upon failure, but for now we just remove the VM
-		// so the next `CreateContainer()` call succeeds.
-		if rmErr := v.RemoveContainer(containerID); rmErr != nil {
-			return fmt.Errorf("container start error: %v \n+ container removal error: %v", err, rmErr)
-		}
-
-		return err
-	}
-
-	return nil
+	return v.startContainer(containerID)
 }
 
 // StopContainer calls graceful shutdown of domain and if it was non successful


### PR DESCRIPTION
It is not a good option to remove container if start container failed. The comments:
```// FIXME: we do this here because kubelet may attempt new `CreateContainer()`
// calls for this VM after failed `StartContainer()` without first removing it.```

Even kubelet may attempt new `CreateContainer()`, the virtlet will do nothing as the container has already been in db: https://github.com/Mirantis/virtlet/blob/master/pkg/manager/runtime.go#L305

To remove container,  the domain and VM will be removed too, it will impact running VMs, all data of running VM may be lost. For example, if the disk is full, the VM will get into paused state, and you cannot start the domain, but we should not remove the VM to workaround the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/858)
<!-- Reviewable:end -->
