### PR TITLE
Fix demo.sh for MULTI_CNI

### DIFF
--- a/deploy/demo.sh
+++ b/deploy/demo.sh
@@ -437,9 +437,6 @@ if [[ ${MULTI_CNI} ]]; then
   export CNI_PLUGIN=flannel
 fi
 demo::start-dind-cluster
-if [[ ${MULTI_CNI} ]]; then
-  demo::install-cni-genie
-fi
 for virtlet_node in "${virtlet_nodes[@]}"; do
   demo::fix-mounts "${virtlet_node}"
   demo::install-cri-proxy "${virtlet_node}"
@@ -448,6 +445,9 @@ for virtlet_node in "${virtlet_nodes[@]}"; do
   fi
   demo::label-and-untaint-node "${virtlet_node}"
 done
+if [[ ${MULTI_CNI} ]]; then
+  demo::install-cni-genie
+fi
 demo::start-virtlet
 demo::start-nginx
 demo::start-vm


### PR DESCRIPTION
As demo::install-cri-proxy() causes a restart of the pods, it should
be done before demo::install-cni-genie(). Otherwise the modifications
done by demo::jq-patch() to /etc/cni/net.d get overwritten.

Signed-off-by: Gregory Vander Schueren <gregory.vanderschueren@tessares.net>

Also, I noticed the MULTI_CNI demo runs with a single host. Is there any reason not to run it with 2 hosts like the regular demo? I would be interested in modifying it to have 2 hosts. Will I run into troubles if I do so? Thanks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/889)
<!-- Reviewable:end -->
