### PR TITLE
K8S_ANNOT not recognized by multus cni plugin

### DIFF
--- a/pkg/cni/client.go
+++ b/pkg/cni/client.go
@@ -143,6 +143,10 @@ func (c *realClient) cniRuntimeConf(podID, podName, podNs string) *libcni.Runtim
 			{"K8S_POD_NAME", podName},
 			{"K8S_POD_INFRA_CONTAINER_ID", podID},
 		}
+	} else {
+		r.Args = [][2]string{
+			{"IgnoreUnknown", "1"},
+		}
 	}
 	return r
 }


### PR DESCRIPTION
K8S_ANNOT option is only supported by CNI Genie but not by
other CNI plugins like Multus. IgnoreUnknown option is not added
to CNI call when pod id, name is missing because of which multus
raise an unknwon option error.

This patch adds IgnoreUnknown option even when pod id and name
are missing.

Fixes defect #890

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/891)
<!-- Reviewable:end -->
