### PR TITLE
[WiP] Use eth0 instead of virtlet-eth0 as CNI interface name

### DIFF
--- a/pkg/cni/client.go
+++ b/pkg/cni/client.go
@@ -134,7 +134,9 @@ func (c *realClient) cniRuntimeConf(podID, podName, podNs string) *libcni.Runtim
 	r := &libcni.RuntimeConf{
 		ContainerID: podID,
 		NetNS:       PodNetNSPath(podID),
-		IfName:      "virtlet-eth0",
+		// Some older CNI Genie versions insist on using eth0
+		// interface name. We used to have virtlet-eth0 here.
+		IfName: "eth0",
 	}
 	if podName != "" && podNs != "" {
 		r.Args = [][2]string{


### PR DESCRIPTION
This fixes compatibility with some older CNI Genie versions, and makes
configuration of the newer CNI Genie versions simpler. It has "eth0"
as the 1st CNI interface name hardcoded / default, and when the name
differs, there can be some problems like Calico not freeing its
workload endpoints (WEPs).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/virtlet/907)
<!-- Reviewable:end -->
